### PR TITLE
Map numpy long integer types to REALSXP

### DIFF
--- a/src/python.cpp
+++ b/src/python.cpp
@@ -394,6 +394,7 @@ int narrow_array_typenum(int typenum) {
     // double
   case NPY_UINT:
   case NPY_ULONG:
+  case NPY_ULONGLONG:
   case NPY_LONG:
   case NPY_LONGLONG:
   case NPY_FLOAT:

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -388,14 +388,14 @@ int narrow_array_typenum(int typenum) {
   case NPY_UBYTE:
   case NPY_SHORT:
   case NPY_USHORT:
-  case NPY_UINT:
-  case NPY_ULONG:
   case NPY_INT:
-  case NPY_LONG:
-  case NPY_LONGLONG:
     typenum = NPY_LONG;
     break;
     // double
+  case NPY_UINT:
+  case NPY_ULONG:
+  case NPY_LONG:
+  case NPY_LONGLONG:
   case NPY_FLOAT:
   case NPY_DOUBLE:
     typenum = NPY_DOUBLE;

--- a/tests/testthat/test-python-numpy.R
+++ b/tests/testthat/test-python-numpy.R
@@ -30,3 +30,14 @@ test_that("Character arrays are handled correctly", {
   a1 <- array(as.character(c(1:8)), dim = c(2,2,2))
   expect_equal(a1, py_to_r(r_to_py(a1)))
 })
+
+test_that("Long integer types are converted to R numeric", {
+  skip_if_no_numpy()
+  np <- import("numpy", convert = FALSE)
+  dtypes <- c(np$int64, np$uint32, np$uint64, np$long, np$longlong)
+  lapply(dtypes, function(dtype) {
+    a1 <- np$array(c(1L:30L), dtype = dtype)
+    expect_equal(class(as.vector(py_to_r(a1))), "numeric")
+  })
+})
+


### PR DESCRIPTION
I had previously erred on the side of preserving integer vs. float representation but I think this might lead to overflow in some cases. This change maps all of the NumPy integer types that *could* be > 32 bits into REALSXP rather than INTSXP within R.

@bwlewis Let me know if you think this makes sense.