### PR TITLE
Added test for function signature

### DIFF
--- a/inst/python/rpytools/help.py
+++ b/inst/python/rpytools/help.py
@@ -1,4 +1,3 @@
-
 import sys
 import types
 import inspect
@@ -105,4 +104,3 @@ def generate_signature_for_function(func):
     if argspec.keywords:
       args_list.append("...")
     return "(" + ", ".join(args_list) + ")"
-

--- a/tests/testthat/test-python-closures.R
+++ b/tests/testthat/test-python-closures.R
@@ -16,3 +16,11 @@ test_that("R functions can accept named arguments from Python", {
   expect_equal(func(x = 15, y = 10), test$callFunc(pyfunc, y = 10, x = 15))
 })
 
+test_that("Python function signatures are converted correctly", {
+  skip_if_no_python()
+  help <- import("rpytools.help")
+  func <- function(features, labels) features - labels
+  pyfunc <- test$reflect(func)
+  expect_equal(help$generate_signature_for_function(func), "(features, labels)")
+})
+


### PR DESCRIPTION
@jjallaire This does not seem to pass. Am I missing anything? 

```
Failed -----------------------------------------------------------------------------------------------
1. Failure: Python function signatures are converted correctly (@test-python-closures.R#24) ----------
help$generate_signature_for_function(func) not equal to "(features, labels)".
1/1 mismatches
x[1]: "(..., ...)"
y[1]: "(features, labels)"
```

Some context of this: I am trying to get the new Estimator API in core work. However, it seems like it failed when validating my custom model function's signature [here](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/estimator/estimator.py#L687) even though my function contains those required arguments. 
