### PR TITLE
Converting Numpy Scalars to R causes an error

### DIFF
--- a/src/python.cpp
+++ b/src/python.cpp
@@ -563,9 +563,20 @@ SEXP py_to_r(PyObject* x) {
     npy_intp len = PyArray_SIZE(array);
     int nd = PyArray_NDIM(array);
     npy_intp *dims = PyArray_DIMS(array);
+
+    // treat np scalar as dim 1
+    if(nd == 0) nd = 1;
     IntegerVector dimsVector(nd);
-    for (int i = 0; i<nd; i++)
-      dimsVector[i] = dims[i];
+    
+    // can only access dims if we don't have a scalar
+    // if we do have a scalar set dimsVector to 1
+    if(PyArray_NDIM(array) > 0) {
+      for (int i = 0; i<nd; i++)
+        dimsVector[i] = dims[i];
+    }
+    else {
+      dimsVector[0] = 1;
+    }
 
     // determine the target type of the array
     int typenum = narrow_array_typenum(array);


### PR DESCRIPTION
The following code will yield an error because the array has shape ().

```r
np <- import("numpy")
a <- np$array(c(1.1))
```

I fixed this by just treating it as an array of shape (1). It's a quick and dirty fix, but I couldn't figure how the code that interacts with the numpy API was working.