### PR TITLE
Fixed: class description consumed when extract preamble

### DIFF
--- a/R/help.R
+++ b/R/help.R
@@ -63,7 +63,7 @@ help_completion_handler.python.builtin.object <- function(topic, source) {
   if (arguments_matches[[1]] != -1)
     description <- substring(doc, 1, arguments_matches[[1]])
   else
-    description <- ""
+    description <- doc
   
   # extract description and details
   matches <- regexpr(pattern ='\n', description, fixed=TRUE)


### PR DESCRIPTION
Previously: 

`reticulate::py_function_wrapper("tf$python$training$basic_session_run_hooks$StopAtStepHook")` gives:

```
#' 
#' 
#' @param num_steps num_steps
#' @param last_step last_step
#' 
#' @export
StopAtStepHook <- function(num_steps = NULL, last_step = NULL) {
  tf$python$training$basic_session_run_hooks$StopAtStepHook(
    num_steps = num_steps,
    last_step = last_step
  )
}
```
where description has been reassigned to empty string when extracting the preamble. 

After the fix:

```
#' Monitor to request stop at a specified step.
#' 
#' 
#' 
#' @param num_steps num_steps
#' @param last_step last_step
#' 
#' @export
StopAtStepHook <- function(num_steps = NULL, last_step = NULL) {
  tf$python$training$basic_session_run_hooks$StopAtStepHook(
    num_steps = num_steps,
    last_step = last_step
  )
}
```