### PR TITLE
Fix tyop

### DIFF
--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -213,7 +213,7 @@ The following articles cover additional aspects of using **reticulate**:
 
 - [Python Version Configuration](versions.html)
 
-- [Using reticulate in an R Package](pacakge.html)
+- [Using reticulate in an R Package](package.html)
 
 - [Arrays in R and Python](arrays.html)
 


### PR DESCRIPTION
Fixes a typo that was breaking a link in the vignette introduction.