### PR TITLE
Provide sys.stdout and sys.stderr when they are None

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
 
 - Poll for interrupts every 500ms rather than 100ms
 
+- Provide sys.stdout and sys.stderr when they are None (e.g. in R GUI)
+
 
 # reticulate 0.8
 

--- a/R/output.R
+++ b/R/output.R
@@ -1,0 +1,14 @@
+
+
+write_stdout <- function(text) {
+  write(text, stdout())
+}
+
+write_stderr <- function(text) {
+  write(text, stderr())
+}
+
+remap_output_streams <- function() {
+  output <- import("rpytools.output")
+  output$remap_output_streams(write_stdout, write_stderr)
+}

--- a/R/package.R
+++ b/R/package.R
@@ -42,6 +42,10 @@ ensure_python_initialized <- function(required_module = NULL) {
         .globals$delay_load_module <- NULL # one shot
      }
     .globals$py_config <- initialize_python(required_module)
+    
+    # remap output streams to R output handlers
+    remap_output_streams()
+    
   }
 }
 

--- a/inst/python/rpytools/output.py
+++ b/inst/python/rpytools/output.py
@@ -27,4 +27,33 @@ def end_stderr_capture(restore):
   sys.stderr = restore
   return output
 
+
+class OutputRemap(object):
+  
+  def __init__(self, target, handler):
+    self.target = target
+    self.handler = handler
+  
+  def write(self, message):
+    self.handler(message)
+    
+  def __getattr__(self, attr): 
+    return getattr(self.target, attr)
+
+  def close(self):
+    return None
+  
+  def flush(self):
+    return None
+
+
+def remap_output_streams(r_stdout, r_stderr):
+  sys.stdout = OutputRemap(sys.stdout, r_stdout)
+  sys.stderr = OutputRemap(sys.stderr, r_stderr)
+
+
+
+
+
+
   

--- a/inst/python/rpytools/output.py
+++ b/inst/python/rpytools/output.py
@@ -38,7 +38,10 @@ class OutputRemap(object):
     self.handler(message)
     
   def __getattr__(self, attr): 
-    return getattr(self.target, attr)
+    if (self.target): 
+      return getattr(self.target, attr)
+    else:
+      return 0
 
   def close(self):
     return None
@@ -48,8 +51,10 @@ class OutputRemap(object):
 
 
 def remap_output_streams(r_stdout, r_stderr):
-  sys.stdout = OutputRemap(sys.stdout, r_stdout)
-  sys.stderr = OutputRemap(sys.stderr, r_stderr)
+  if (sys.stdout is None):
+    sys.stdout = OutputRemap(sys.stdout, r_stdout)
+  if (sys.stderr is None):
+    sys.stderr = OutputRemap(sys.stderr, r_stderr)
 
 
 


### PR DESCRIPTION
In R GUI the Python `sys.stdout` and `sys.stderr` are None (this may be an artifact of how stdout/stderr is handled/redirected for R GUI). This PR provides an R implementation of `sys.stdout` and `sys.stderr` when none exists.