### PR TITLE
make reticulate work in an embedded python environment

### DIFF
--- a/src/libpython.cpp
+++ b/src/libpython.cpp
@@ -154,6 +154,7 @@ bool LibPython::loadSymbols(bool python3, std::string* pError)
   bool is64bit = sizeof(size_t) >= 8;
 
   LOAD_PYTHON_SYMBOL(Py_Initialize)
+  LOAD_PYTHON_SYMBOL(Py_IsInitialized)
   LOAD_PYTHON_SYMBOL(Py_AddPendingCall)
   LOAD_PYTHON_SYMBOL(PyErr_SetInterrupt)
   LOAD_PYTHON_SYMBOL(PyExc_KeyboardInterrupt)

--- a/src/libpython.h
+++ b/src/libpython.h
@@ -139,6 +139,7 @@ void initialize_type_objects(bool python3);
 #define PyComplex_Check(o) (Py_TYPE(o) == Py_TYPE(Py_Complex))
 
 LIBPYTHON_EXTERN void (*Py_Initialize)();
+LIBPYTHON_EXTERN int (*Py_IsInitialized)();
 
 LIBPYTHON_EXTERN int (*Py_AddPendingCall)(int (*func)(void *), void *arg);
 LIBPYTHON_EXTERN void (*PyErr_SetInterrupt)();


### PR DESCRIPTION
close #98

When a python environment is detected., we load `rpycall` module rather than to insert it into the initialization table.
