### PR TITLE
add section to array vignette on reshaping

### DIFF
--- a/vignettes/arrays.Rmd
+++ b/vignettes/arrays.Rmd
@@ -508,6 +508,50 @@ o$sub(np$arange(1, 25)$reshape(4L, 3L, 2L), np$array(y))
 The above NumPy arrays are the same, their element-wise difference is zero.
 
 
+### Reshaping arrays
+
+In R you would typically reshape an array using the `dim<-()` function. For example:
+
+```{r, eval=FALSE}
+dim(x) <- c(1000, 28, 28)
+```
+
+In R, this operation simply changes the "dim" attribute of the array, effectively 
+re-interpreting the array indices as specified using column-major semantics.
+
+However, the NumPy `reshape` method uses row-major semantics, so if you are mixing
+R and Python code that reshapes arrays you will find that the reshaping will be
+inconsistent if you use the R `dim<-()` function. 
+
+To overcome this inconsistency, there is an `array_reshape()` function which will
+reshape an R array using row-major semantics (i.e. will fill the new dimensions
+in row-major rather than col-major order). The example above would be re-written as:
+
+```{r, eval=FALSE}
+x <- array_reshape(x, c(1000, 28, 28))
+```
+
+Here's a further example to illustrate the difference:
+
+```{r}
+# let's construct a 2x2 array from a vector of 4 elements
+x <- 1:4
+
+# rearrange will fill the array row-wise
+array_reshape(x, c(2, 2))
+#      [,1] [,2]
+# [1,]    1    2
+# [2,]    3    4
+
+# setting the dimensions 'fills' the array col-wise
+dim(x) <- c(2, 2)
+x
+#      [,1] [,2]
+# [1,]    1    3
+# [2,]    2    4
+```
+
+
 ## Other differences warranting caution
 
 It's worth noting that analogs of R's `apply()` function in Python behave

--- a/vignettes/arrays.Rmd
+++ b/vignettes/arrays.Rmd
@@ -519,7 +519,7 @@ dim(x) <- c(1000, 28, 28)
 In R, this operation simply changes the "dim" attribute of the array, effectively 
 re-interpreting the array indices as specified using column-major semantics.
 
-However, the NumPy `reshape` method uses row-major semantics, so if you are mixing
+However, the NumPy `reshape` method uses row-major semantics by default, so if you are mixing
 R and Python code that reshapes arrays you will find that the reshaping will be
 inconsistent if you use the R `dim<-()` function. 
 


### PR DESCRIPTION
@kevinushey Could you take a look at this and let me know if it sounds correct?

@bwlewis We found that if you mixed NumPy reshaping and R reshaping in the same script (e.g. a tensorflow script that calls tf$reshape or np$reshape for training data, then R dim for prediction data) then the alternate ways of filling the reshaped array would cause problems. The `array_reshape()` function is intended to reshape R arrays in a manner consistent with NumPy.

A less hypothetical example would be a tensorflow model that was trained in Python (with reshaping of the raw input data) and then used in R (with dim based reshaping). 
