### PR TITLE
Add support to trace call stacks for python threads

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: reticulate
 Type: Package
 Title: Interface to 'Python'
-Version: 1.3.1.9001
+Version: 1.3.1.9002
 Authors@R: c(
   person("JJ", "Allaire", role = c("aut", "cre"), email = "jj@rstudio.com"),
   person("Kevin", "Ushey", role = c("ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,10 @@ Install the development version with: `install_github("rstudio/reticulate")`
 
 ## reticulate 1.3
 
+- Support for `RETICULATE_TRACE` environment variable which can be set to
+  the number of milliseconds in which to output into stderr the call stacks
+  from all running threads.
+
 - Use existing instance of Python when reticulate is loaded within an 
   embedded Python environment (e.g. rpy2, rice, etc.)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 
 Install the development version with: `install_github("rstudio/reticulate")`
 
-- Support for `RETICULATE_TRACE` environment variable which can be set to
+- Support for `RETICULATE_DUMP_STACK_TRACE` environment variable which can be set to
   the number of milliseconds in which to output into stderr the call stacks
   from all running threads.
   

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,14 @@
+## reticulate 1.4 (development)
 
+<<<<<<< HEAD
 ## reticulate 1.4 (development)
 
 Install the development version with: `install_github("rstudio/reticulate")`
 
+- Support for `RETICULATE_TRACE` environment variable which can be set to
+  the number of milliseconds in which to output into stderr the call stacks
+  from all running threads.
+  
 - Provide hook to change target module when delay loading
 
 
@@ -13,10 +19,10 @@ Install the development version with: `install_github("rstudio/reticulate")`
 
 
 ## reticulate 1.3
-
-- Support for `RETICULATE_TRACE` environment variable which can be set to
-  the number of milliseconds in which to output into stderr the call stacks
-  from all running threads.
+=======
+Install the development version with: `install_github("rstudio/reticulate")`
+  
+## reticulate 1.3 (CRAN)
 
 - Use existing instance of Python when reticulate is loaded within an 
   embedded Python environment (e.g. rpy2, rice, etc.)

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -42,8 +42,8 @@ py_activate_virtualenv <- function(script) {
     invisible(.Call(`_reticulate_py_activate_virtualenv`, script))
 }
 
-py_initialize <- function(python, libpython, pythonhome, virtualenv_activate, python3, interactive, numpy_load_error) {
-    invisible(.Call(`_reticulate_py_initialize`, python, libpython, pythonhome, virtualenv_activate, python3, interactive, numpy_load_error))
+py_initialize <- function(python, libpython, pythonhome, virtualenv_activate, python3, interactive, numpy_load_error, tracems) {
+    invisible(.Call(`_reticulate_py_initialize`, python, libpython, pythonhome, virtualenv_activate, python3, interactive, numpy_load_error, tracems))
 }
 
 py_finalize <- function() {

--- a/R/package.R
+++ b/R/package.R
@@ -87,7 +87,7 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
                           Sys.getenv("PATH"),
                           sep = .Platform$path.sep))  
   
-  trace_ms <- Sys.getenv("RETICULATE_TRACE", 0)
+  trace_ms <- Sys.getenv("RETICULATE_DUMP_STACK_TRACE", 0)
   
   # initialize python
   py_initialize(config$python,
@@ -97,7 +97,7 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
                 config$version >= "3.0",
                 interactive(),
                 numpy_load_error,
-                as.numeric(trace_ms))
+                as.integer(trace_ms))
   
   # if we have a virtualenv then set the VIRTUAL_ENV environment variable
   if (nzchar(config$virtualenv_activate))

--- a/R/package.R
+++ b/R/package.R
@@ -87,6 +87,7 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
                           Sys.getenv("PATH"),
                           sep = .Platform$path.sep))  
   
+  trace_ms <- Sys.getenv("RETICULATE_TRACE", 0)
   
   # initialize python
   py_initialize(config$python,
@@ -95,7 +96,8 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
                 config$virtualenv_activate,
                 config$version >= "3.0",
                 interactive(),
-                numpy_load_error)
+                numpy_load_error,
+                as.numeric(trace_ms))
   
   # if we have a virtualenv then set the VIRTUAL_ENV environment variable
   if (nzchar(config$virtualenv_activate))

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -91,8 +91,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // py_initialize
-void py_initialize(const std::string& python, const std::string& libpython, const std::string& pythonhome, const std::string& virtualenv_activate, bool python3, bool interactive, const std::string& numpy_load_error);
-RcppExport SEXP _reticulate_py_initialize(SEXP pythonSEXP, SEXP libpythonSEXP, SEXP pythonhomeSEXP, SEXP virtualenv_activateSEXP, SEXP python3SEXP, SEXP interactiveSEXP, SEXP numpy_load_errorSEXP) {
+void py_initialize(const std::string& python, const std::string& libpython, const std::string& pythonhome, const std::string& virtualenv_activate, bool python3, bool interactive, const std::string& numpy_load_error, int tracems);
+RcppExport SEXP _reticulate_py_initialize(SEXP pythonSEXP, SEXP libpythonSEXP, SEXP pythonhomeSEXP, SEXP virtualenv_activateSEXP, SEXP python3SEXP, SEXP interactiveSEXP, SEXP numpy_load_errorSEXP, SEXP tracemsSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const std::string& >::type python(pythonSEXP);
@@ -102,7 +102,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< bool >::type python3(python3SEXP);
     Rcpp::traits::input_parameter< bool >::type interactive(interactiveSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type numpy_load_error(numpy_load_errorSEXP);
-    py_initialize(python, libpython, pythonhome, virtualenv_activate, python3, interactive, numpy_load_error);
+    Rcpp::traits::input_parameter< int >::type tracems(tracemsSEXP);
+    py_initialize(python, libpython, pythonhome, virtualenv_activate, python3, interactive, numpy_load_error, tracems);
     return R_NilValue;
 END_RCPP
 }
@@ -485,7 +486,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_reticulate_py_is_callable", (DL_FUNC) &_reticulate_py_is_callable, 1},
     {"_reticulate_r_to_py_impl", (DL_FUNC) &_reticulate_r_to_py_impl, 2},
     {"_reticulate_py_activate_virtualenv", (DL_FUNC) &_reticulate_py_activate_virtualenv, 1},
-    {"_reticulate_py_initialize", (DL_FUNC) &_reticulate_py_initialize, 7},
+    {"_reticulate_py_initialize", (DL_FUNC) &_reticulate_py_initialize, 8},
     {"_reticulate_py_finalize", (DL_FUNC) &_reticulate_py_finalize, 0},
     {"_reticulate_py_is_none", (DL_FUNC) &_reticulate_py_is_none, 1},
     {"_reticulate_py_compare_impl", (DL_FUNC) &_reticulate_py_compare_impl, 3},

--- a/src/libpython.cpp
+++ b/src/libpython.cpp
@@ -236,6 +236,7 @@ bool LibPython::loadSymbols(bool python3, std::string* pError)
   LOAD_PYTHON_SYMBOL(PyGILState_GetThisThreadState)
   LOAD_PYTHON_SYMBOL(PyGILState_Ensure)
   LOAD_PYTHON_SYMBOL(PyGILState_Release)
+  LOAD_PYTHON_SYMBOL(PyThreadState_Next)
 
   // PyUnicode_AsEncodedString may have several different names depending on the Python
   // version and the UCS build type 

--- a/src/libpython.cpp
+++ b/src/libpython.cpp
@@ -232,6 +232,7 @@ bool LibPython::loadSymbols(bool python3, std::string* pError)
   LOAD_PYTHON_SYMBOL(PyObject_CallFunctionObjArgs)
   LOAD_PYTHON_SYMBOL(PyType_IsSubtype)
   LOAD_PYTHON_SYMBOL(PySys_WriteStderr)
+  LOAD_PYTHON_SYMBOL(PyEval_SetProfile)
 
   // PyUnicode_AsEncodedString may have several different names depending on the Python
   // version and the UCS build type 

--- a/src/libpython.cpp
+++ b/src/libpython.cpp
@@ -233,6 +233,9 @@ bool LibPython::loadSymbols(bool python3, std::string* pError)
   LOAD_PYTHON_SYMBOL(PyType_IsSubtype)
   LOAD_PYTHON_SYMBOL(PySys_WriteStderr)
   LOAD_PYTHON_SYMBOL(PyEval_SetProfile)
+  LOAD_PYTHON_SYMBOL(PyGILState_GetThisThreadState)
+  LOAD_PYTHON_SYMBOL(PyGILState_Ensure)
+  LOAD_PYTHON_SYMBOL(PyGILState_Release)
 
   // PyUnicode_AsEncodedString may have several different names depending on the Python
   // version and the UCS build type 

--- a/src/libpython.h
+++ b/src/libpython.h
@@ -638,7 +638,14 @@ typedef struct _frame {
   PyObject *f_localsplus[1];	/* locals+stack, dynamically sized */
 } PyFrameObject;
 
+typedef
+  enum {PyGILState_LOCKED, PyGILState_UNLOCKED}
+PyGILState_STATE;
+
 LIBPYTHON_EXTERN void (*PyEval_SetProfile)(Py_tracefunc func, PyObject *obj);
+LIBPYTHON_EXTERN PyThreadState* (*PyGILState_GetThisThreadState)(void);
+LIBPYTHON_EXTERN PyGILState_STATE (*PyGILState_Ensure)(void);
+LIBPYTHON_EXTERN void (*PyGILState_Release)(PyGILState_STATE);
 
 /* End PyFrameObject */
 

--- a/src/libpython.h
+++ b/src/libpython.h
@@ -519,6 +519,129 @@ inline SharedLibrary& libPython() {
   return instance;
 }
 
+/* Start PyFrameObject */
+
+/* Bytecode object */
+typedef struct {
+  PyObject_HEAD
+  int co_argcount;		/* #arguments, except *args */
+  int co_nlocals;		/* #local variables */
+  int co_stacksize;		/* #entries needed for evaluation stack */
+  int co_flags;		/* CO_..., see below */
+  PyObject *co_code;		/* instruction opcodes */
+  PyObject *co_consts;	/* list (constants used) */
+  PyObject *co_names;		/* list of strings (names used) */
+  PyObject *co_varnames;	/* tuple of strings (local variable names) */
+  PyObject *co_freevars;	/* tuple of strings (free variable names) */
+  PyObject *co_cellvars;      /* tuple of strings (cell variable names) */
+  /* The rest doesn't count for hash/cmp */
+  PyObject *co_filename;	/* string (where it was loaded from) */
+  PyObject *co_name;		/* string (name, for reference) */
+  int co_firstlineno;		/* first source line number */
+  PyObject *co_lnotab;	/* string (encoding addr<->lineno mapping) See
+  Objects/lnotab_notes.txt for details. */
+  void *co_zombieframe;     /* for optimization only (see frameobject.c) */
+  PyObject *co_weakreflist;   /* to support weakrefs to code objects */
+} PyCodeObject;
+
+#define CO_MAXBLOCKS 20
+typedef struct {
+  int b_type;         /* what kind of block this is */
+  int b_handler;      /* where to jump to find handler */
+  int b_level;        /* value stack level to pop to */
+} PyTryBlock;
+
+typedef struct _is {
+  
+  struct _is *next;
+  struct _ts *tstate_head;
+  
+  PyObject *modules;
+  PyObject *modules_by_index;
+  PyObject *sysdict;
+  PyObject *builtins;
+  PyObject *modules_reloading;
+  
+  PyObject *codec_search_path;
+  PyObject *codec_search_cache;
+  PyObject *codec_error_registry;
+  int codecs_initialized;
+  
+} PyInterpreterState;
+
+typedef int (*Py_tracefunc)(PyObject *, struct _frame *, int, PyObject *);
+
+typedef struct _ts {
+  /* See Python/ceval.c for comments explaining most fields */
+  
+  struct _ts *next;
+  PyInterpreterState *interp;
+  
+  struct _frame *frame;
+  int recursion_depth;
+  char overflowed; /* The stack has overflowed. Allow 50 more calls
+  to handle the runtime error. */
+  char recursion_critical; /* The current calls must not cause 
+  a stack overflow. */
+  /* 'tracing' keeps track of the execution depth when tracing/profiling.
+  This is to prevent the actual trace/profile code from being recorded in
+  the trace/profile. */
+  int tracing;
+  int use_tracing;
+  
+  Py_tracefunc c_profilefunc;
+  Py_tracefunc c_tracefunc;
+  PyObject *c_profileobj;
+  PyObject *c_traceobj;
+  
+  PyObject *curexc_type;
+  PyObject *curexc_value;
+  PyObject *curexc_traceback;
+  
+  PyObject *exc_type;
+  PyObject *exc_value;
+  PyObject *exc_traceback;
+  
+  PyObject *dict;
+
+  int tick_counter;
+  
+  int gilstate_counter;
+  
+  PyObject *async_exc;
+  long thread_id;
+  
+} PyThreadState;
+
+typedef struct _frame {
+  PyObject_VAR_HEAD
+  struct _frame *f_back;	/* previous frame, or NULL */
+  PyCodeObject *f_code;	/* code segment */
+  PyObject *f_builtins;	/* builtin symbol table (PyDictObject) */
+  PyObject *f_globals;	/* global symbol table (PyDictObject) */
+  PyObject *f_locals;		/* local symbol table (any mapping) */
+  PyObject **f_valuestack;	/* points after the last local */
+  /* Next free slot in f_valuestack.  Frame creation sets to f_valuestack.
+  Frame evaluation usually NULLs it, but a frame that yields sets it
+  to the current stack top. */
+  PyObject **f_stacktop;
+  PyObject *f_trace;		/* Trace function */
+  
+  PyObject *f_exc_type, *f_exc_value, *f_exc_traceback;
+  
+  PyThreadState *f_tstate;
+  int f_lasti;		/* Last instruction if called */
+  
+  int f_lineno;		/* Current line number */
+  int f_iblock;		/* index in f_blockstack */
+  PyTryBlock f_blockstack[CO_MAXBLOCKS]; /* for try and loop blocks */
+  PyObject *f_localsplus[1];	/* locals+stack, dynamically sized */
+} PyFrameObject;
+
+LIBPYTHON_EXTERN void (*PyEval_SetProfile)(Py_tracefunc func, PyObject *obj);
+
+/* End PyFrameObject */
+
 } // namespace libpython
 
 #endif

--- a/src/libpython.h
+++ b/src/libpython.h
@@ -646,6 +646,7 @@ LIBPYTHON_EXTERN void (*PyEval_SetProfile)(Py_tracefunc func, PyObject *obj);
 LIBPYTHON_EXTERN PyThreadState* (*PyGILState_GetThisThreadState)(void);
 LIBPYTHON_EXTERN PyGILState_STATE (*PyGILState_Ensure)(void);
 LIBPYTHON_EXTERN void (*PyGILState_Release)(PyGILState_STATE);
+LIBPYTHON_EXTERN PyThreadState* (*PyThreadState_Next)(PyThreadState*);
 
 /* End PyFrameObject */
 

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -1397,6 +1397,9 @@ void py_activate_virtualenv(const std::string& script)
     stop(py_fetch_error());
 }
 
+int py_tracefunc(PyObject *obj, PyFrameObject *frame, int what, PyObject *arg) {
+  return 0;
+}
 
 // [[Rcpp::export]]
 void py_initialize(const std::string& python,
@@ -1478,6 +1481,9 @@ void py_initialize(const std::string& python,
     import_numpy_api(is_python3(), &s_numpy_load_error);
   else
     s_numpy_load_error = numpy_load_error;
+  
+  // initialize trace
+  PyEval_SetProfile(&py_tracefunc, NULL);
   
   // poll for events while executing python code
   event_loop::initialize();

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -1408,7 +1408,7 @@ void trace_print(int threadId, PyFrameObject *frame) {
     frame = frame->f_back;
   }
   
-  tracemsg = "THREAD(" + std::to_string(threadId) + "): [" + tracemsg + "]\n";
+  tracemsg = "THREAD: [" + tracemsg + "]\n";
   fprintf(stderr, tracemsg.c_str(), tracemsg.size());
 }
 

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -1412,8 +1412,10 @@ int py_tracefunc(PyObject *obj, PyFrameObject *frame, int what, PyObject *arg) {
     frame = frame->f_back;
   }
   
-  tracemsg = tracemsg + "\n";
-  Rprintf(tracemsg.c_str());
+  Rcpp::Environment base("package:base"); 
+  Rcpp::Function message = base["message"];  
+  
+  message(tracemsg.c_str());
   
   return 0;
 }


### PR DESCRIPTION
When an R program using Python hangs, it is helpful to print the callstacks from the running threads every X milliseconds, this PR adds this functionality. Usage:

```r
Sys.setenv(RETICULATE_DUMP_STACK_TRACE = 1000)
library(reticulate)
reticulate::py_eval("1+1")
```

Output:

```
THREAD: []
THREAD: [<module> <module> compile _compile compile parse _parse_sub _parse _parse_sub _parse _parse_sub _parse _parse_sub _parse _parse_sub _parse _parse_sub _parse ]
[1] 2
```