### PR TITLE
ensure single lines of code emitted to document

### DIFF
--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -127,7 +127,7 @@ eng_python <- function(options) {
   }
   
   # if we have leftover input, add that now
-  if (pending_source_index < n) {
+  if (pending_source_index <= n) {
     leftover <- extract(code, c(pending_source_index, n))
     outputs[[length(outputs) + 1]] <- structure(
       list(src = leftover),

--- a/tests/testthat/resources/example.Rmd
+++ b/tests/testthat/resources/example.Rmd
@@ -58,3 +58,13 @@ mpg = r["mtcars$mpg[1:5]"]
 print mpg
 ```
 
+- #126: Ensure single-line Python chunks that produce no output still have source code emitted.
+
+```{python}
+y = "a,b,c".split(",")
+```
+
+```{python}
+print y
+```
+


### PR DESCRIPTION
It looks like there was an off-by-one error wherein the final line of code in a Python chunk, if it did not produce any output, would not be emitted into the document.

Closes #126.