### PR TITLE
implement support for variety of chunk options

### DIFF
--- a/tests/testthat/resources/eng-reticulate-example.Rmd
+++ b/tests/testthat/resources/eng-reticulate-example.Rmd
@@ -68,3 +68,32 @@ y = "a,b,c".split(",")
 print y
 ```
 
+- #130: The `echo` chunk option is respected (for `TRUE` and `FALSE` values). Output, but not source, should show in the following output.
+
+```{python echo=FALSE}
+print "Chunk with echo = FALSE"
+```
+
+- #130: The `results` chunk option is respected for Python outputs. Source, but not output, should show in the following output.
+
+```{python results='hide'}
+print "Chunk with results = 'hide'"
+```
+
+- #130: The `include` chunk option is respected for Python outputs. No chunk output should appear following this bullet.
+
+```{python include=FALSE}
+print "Chunk with include = FALSE"
+```
+
+- #130: The `eval` chunk option is respected for Python outputs.
+
+```{python eval=FALSE}
+# We have set 'eval = FALSE' here
+r["abc"] = 1
+```
+
+```{r}
+exists("abc", envir = globalenv())
+```
+

--- a/tests/testthat/test-python-knitr-engine.R
+++ b/tests/testthat/test-python-knitr-engine.R
@@ -12,7 +12,7 @@ test_that("An R Markdown document can be rendered using reticulate", {
   }
   
   status <- withr::with_dir("resources", {
-    rmarkdown::render("example.Rmd", quiet = TRUE)
+    rmarkdown::render("eng-reticulate-example.Rmd", quiet = TRUE)
   })
   expect_true(file.exists(status), "example.Rmd rendered successfully")
 })


### PR DESCRIPTION
This PR implements support for a couple knitr chunk options (mainly prompted by #130). With this PR, we now have support for the boolean forms of `echo`, `eval`, and `include`.