### PR TITLE
allow configuration of reticulate engine

### DIFF
--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -112,9 +112,9 @@ eng_python <- function(options) {
       
       # append pending source to outputs (respecting 'echo' option)
       if (!identical(options$echo, FALSE)) {
-        extracted <- extract(code, c(pending_source_index, range[2]))
         if (is.numeric(options$echo))
           warning("numeric 'echo' chunk option not supported by reticulate engine")
+        extracted <- extract(code, c(pending_source_index, range[2]))
         output <- structure(list(src = extracted), class = "source")
         outputs[[length(outputs) + 1]] <- output
       }
@@ -138,7 +138,9 @@ eng_python <- function(options) {
   }
   
   # if we have leftover input, add that now
-  if (pending_source_index <= n) {
+  if (!identical(options$echo, FALSE) && pending_source_index <= n) {
+    if (is.numeric(options$echo))
+      warning("numeric 'echo' chunk option not supported by reticulate engine")
     leftover <- extract(code, c(pending_source_index, n))
     outputs[[length(outputs) + 1]] <- structure(
       list(src = leftover),

--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -220,6 +220,11 @@ eng_python_synchronize_before <- function() {
   .knitEnv <- yoink("knitr", ".knitEnv")
   envir <- .knitEnv$knit_global
   
+  # when running in notebook mode, no environment will be set -- in such
+  # a case we want the R code to populate in the global environment
+  if (is.null(envir))
+    envir <- globalenv()
+  
   # define the getters, setters we'll attach to the Python class
   getter <- function(self, code) {
     r_to_py(eval(parse(text = as_r_value(code)), envir = envir))

--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -150,10 +150,7 @@ eng_python <- function(options) {
   
   eng_python_synchronize_after()
   
-  # TODO: development version of knitr supplies new 'engine_output()'
-  # interface -- use that when it's on CRAN
-  # https://github.com/yihui/knitr/commit/71bfd8796d485ed7bb9db0920acdf02464b3df9a
-  wrap <- yoink("knitr", "wrap")
+  wrap <- getOption("reticulate.engine.wrap", eng_python_wrap)
   wrap(outputs, options)
   
 }
@@ -196,7 +193,7 @@ eng_python_initialize_matplotlib <- function(options,
   show <- plt$show
   defer(plt$show <- show, envir = envir)
   plt$show <- function(...) {
-    hook <- getOption("reticulate.matplotlib.show", eng_python_matplotlib_show)
+    hook <- getOption("reticulate.engine.matplotlib.show", eng_python_matplotlib_show)
     graphic <- hook(plt, options)
     context$pending_plots[[length(context$pending_plots) + 1]] <<- graphic
   }
@@ -244,5 +241,12 @@ eng_python_synchronize_before <- function() {
 }
 
 # synchronize objects Python -> R
-eng_python_synchronize_after <- function() {
+eng_python_synchronize_after <- function() {}
+
+eng_python_wrap <- function(outputs, options) {
+  # TODO: development version of knitr supplies new 'engine_output()'
+  # interface -- use that when it's on CRAN
+  # https://github.com/yihui/knitr/commit/71bfd8796d485ed7bb9db0920acdf02464b3df9a
+  wrap <- yoink("knitr", "wrap")
+  wrap(outputs, options)
 }

--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -106,6 +106,10 @@ eng_python <- function(options) {
       if (is.numeric(options$eval))
         warning("numeric 'eval' chunk option not supported by reticulate engine")
       captured <- py_capture_output(py_run_string(snippet, convert = FALSE))
+      
+      # trim a trailing newline
+      if (nzchar(captured))
+        captured <- sub("\n$", "", captured)
     }
     
     if (nzchar(captured) || length(context$pending_plots)) {
@@ -214,13 +218,11 @@ eng_python_synchronize_before <- function() {
   R <- main$R
   
   # extract active knit environment
-  .knitEnv <- yoink("knitr", ".knitEnv")
-  envir <- .knitEnv$knit_global
-  
-  # when running in notebook mode, no environment will be set -- in such
-  # a case we want the R code to populate in the global environment
-  if (is.null(envir))
-    envir <- globalenv()
+  envir <- getOption("reticulate.engine.environment")
+  if (is.null(envir)) {
+    .knitEnv <- yoink("knitr", ".knitEnv")
+    envir <- .knitEnv$knit_global
+  }
   
   # define the getters, setters we'll attach to the Python class
   getter <- function(self, code) {


### PR DESCRIPTION
This PR opens up the reticulate engine a bit, providing the required endpoints for the RStudio IDE (or other front-ends) to hook in and handle various kinds of outputs produced by the engine.

This PR adds support for the following R options:

- `reticulate.engine.matplotlib.show`: Controls what happens when a `matplotlib` plot is shown;
- `reticulate.engine.wrap`: Controls how the generated list of outputs should be post-processed.
- `reticulate.engine.environment`: Controls what R environment is used for R <-> Python synchronization.

The intention is for the RStudio IDE to set these hooks to route console + plot output back to the Notebook cache, and display them in the IDE.
  