### PR TITLE
support 'error=TRUE' for reticulate chunks

### DIFF
--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -61,6 +61,11 @@ eng_python <- function(options) {
     paste(snippet[nzchar(snippet)], collapse = "\n")
   }
   
+  # helper function for running a snippet of code and capturing output
+  run <- function(snippet) {
+    py_capture_output(py_run_string(snippet, convert = FALSE))
+  }
+  
   # extract the code to be run -- we'll attempt to run the code line by line
   # and detect changes so that we can interleave code and output (similar to
   # what one sees when executing an R chunk in knitr). to wit, we'll do our
@@ -105,7 +110,19 @@ eng_python <- function(options) {
     if (!identical(options$eval, FALSE)) {
       if (is.numeric(options$eval))
         warning("numeric 'eval' chunk option not supported by reticulate engine")
-      captured <- py_capture_output(py_run_string(snippet, convert = FALSE))
+      
+      # error=TRUE implies that errors should be captured and converted
+      # into output messages
+      if (identical(options$error, TRUE)) {
+        tryCatch(
+          captured <- run(snippet),
+          error = function(e) {
+            captured <<- conditionMessage(e)
+          }
+        )
+      } else {
+        captured <- run(snippet)
+      }
       
       # trim a trailing newline
       if (nzchar(captured))

--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -63,7 +63,10 @@ eng_python <- function(options) {
   
   # helper function for running a snippet of code and capturing output
   run <- function(snippet) {
-    py_capture_output(py_run_string(snippet, convert = FALSE))
+    output <- py_capture_output(py_run_string(snippet, convert = FALSE))
+    if (nzchar(output))
+      output <- sub("\n$", "", output)
+    output
   }
   
   # extract the code to be run -- we'll attempt to run the code line by line
@@ -123,10 +126,6 @@ eng_python <- function(options) {
       } else {
         captured <- run(snippet)
       }
-      
-      # trim a trailing newline
-      if (nzchar(captured))
-        captured <- sub("\n$", "", captured)
     }
     
     if (nzchar(captured) || length(context$pending_plots)) {

--- a/tests/testthat/resources/eng-reticulate-example.Rmd
+++ b/tests/testthat/resources/eng-reticulate-example.Rmd
@@ -97,3 +97,11 @@ r["abc"] = 1
 exists("abc", envir = globalenv())
 ```
 
+Respect the `error=TRUE` chunk option -- allow execution even after a Python
+error occurs.
+
+```{python, error=TRUE}
+raise RuntimeError("oops!")
+print "This line is still reached."
+```
+


### PR DESCRIPTION
This allows Python chunk execution to continue when the `error=TRUE` chunk option is set, as is also done for R engines.

I believe this is still safe to take for the upcoming CRAN release (if that window is still open)