### PR TITLE
Add DatetimeIndex conversion handling with timezone support

### DIFF
--- a/R/conversion.R
+++ b/R/conversion.R
@@ -266,6 +266,23 @@ py_to_r.pandas.core.frame.DataFrame <- function(x) {
       }
     }
     
+    else if (inherits(index, "pandas.core.indexes.datetimes.DatetimeIndex")) {
+      py_tz <- index[["tz"]]
+      tz <- NULL
+      
+      if(inherits(py_tz, "pytz.tzinfo.BaseTzInfo") || 
+         inherits(py_tz, "pytz.UTC")) {
+        tz <- tryCatch(py_to_r(py_tz$zone), error = identity)
+      }
+      
+      converted <- tryCatch(py_to_r(index$values), error = identity)
+      
+      if(!is.null(tz) && tz %in% OlsonNames()) {
+        attr(converted, "tzone") <- tz
+      }
+      rownames(df) <- converted
+    }
+    
     else {
       converted <- tryCatch(py_to_r(index$values), error = identity)
       if (is.character(converted) || is.numeric(converted))


### PR DESCRIPTION
Use this if you want, but I wouldn't care if you weren't ready to support this yet! I figured it would be nice to at least support the conversion of a `DatetimeIndex` that has a time zone over to R. Right now these would just be stored as character rownames with the correct clock time, but a specialized `as.data.frame` for Pandas DataFrames could use this to correctly convert to a POSIXct `.index` column with the right time zone.

``` r
library(reticulate)

ex <- data.frame(
  x = 1:10,
  idx = as.POSIXct("2017-01-01", "UTC") + 0:9
)

ex_py <- r_to_py(ex)

ex_py_indexed <- ex_py$set_index('idx')
ex_py_indexed
#>                       x
#> idx                    
#> 2017-01-01 00:00:00   1
#> 2017-01-01 00:00:01   2
#> 2017-01-01 00:00:02   3
#> 2017-01-01 00:00:03   4
#> 2017-01-01 00:00:04   5
#> 2017-01-01 00:00:05   6
#> 2017-01-01 00:00:06   7
#> 2017-01-01 00:00:07   8
#> 2017-01-01 00:00:08   9
#> 2017-01-01 00:00:09  10

####
# Can go back to R, keeps as rownames
py_to_r(ex_py_indexed)
#>                      x
#> 2017-01-01 00:00:00  1
#> 2017-01-01 00:00:01  2
#> 2017-01-01 00:00:02  3
#> 2017-01-01 00:00:03  4
#> 2017-01-01 00:00:04  5
#> 2017-01-01 00:00:05  6
#> 2017-01-01 00:00:06  7
#> 2017-01-01 00:00:07  8
#> 2017-01-01 00:00:08  9
#> 2017-01-01 00:00:09 10

####
# Localize to America/New_York
# Basically saying "these clock times are in the America/New_York tz"
# The -05:00 is the offset from UTC
ex_py_NY <- ex_py_indexed$tz_localize('America/New_York')
ex_py_NY
#>                             x
#> idx                          
#> 2017-01-01 00:00:00-05:00   1
#> 2017-01-01 00:00:01-05:00   2
#> 2017-01-01 00:00:02-05:00   3
#> 2017-01-01 00:00:03-05:00   4
#> 2017-01-01 00:00:04-05:00   5
#> 2017-01-01 00:00:05-05:00   6
#> 2017-01-01 00:00:06-05:00   7
#> 2017-01-01 00:00:07-05:00   8
#> 2017-01-01 00:00:08-05:00   9
#> 2017-01-01 00:00:09-05:00  10

# Maintain the America/New_York clock time when going to R rownames
py_to_r(ex_py_NY)
#>                      x
#> 2017-01-01 00:00:00  1
#> 2017-01-01 00:00:01  2
#> 2017-01-01 00:00:02  3
#> 2017-01-01 00:00:03  4
#> 2017-01-01 00:00:04  5
#> 2017-01-01 00:00:05  6
#> 2017-01-01 00:00:06  7
#> 2017-01-01 00:00:07  8
#> 2017-01-01 00:00:08  9
#> 2017-01-01 00:00:09 10

####
# Convert to America/New_York
# Must first localize as UTC
ex_py_UTC <- ex_py_indexed$tz_localize('UTC')
ex_py_UTC$index
#> DatetimeIndex(['2017-01-01 00:00:00+00:00', '2017-01-01 00:00:01+00:00',
#>                '2017-01-01 00:00:02+00:00', '2017-01-01 00:00:03+00:00',
#>                '2017-01-01 00:00:04+00:00', '2017-01-01 00:00:05+00:00',
#>                '2017-01-01 00:00:06+00:00', '2017-01-01 00:00:07+00:00',
#>                '2017-01-01 00:00:08+00:00', '2017-01-01 00:00:09+00:00'],
#>               dtype='datetime64[ns, UTC]', name='idx', freq=None)

# This says, "These were UTC times, now convert them to America/New_York"
# which is an offset of 5 hours apparently
ex_py_NY_converted <- ex_py_UTC$tz_convert('America/New_York')
ex_py_NY_converted
#>                             x
#> idx                          
#> 2016-12-31 19:00:00-05:00   1
#> 2016-12-31 19:00:01-05:00   2
#> 2016-12-31 19:00:02-05:00   3
#> 2016-12-31 19:00:03-05:00   4
#> 2016-12-31 19:00:04-05:00   5
#> 2016-12-31 19:00:05-05:00   6
#> 2016-12-31 19:00:06-05:00   7
#> 2016-12-31 19:00:07-05:00   8
#> 2016-12-31 19:00:08-05:00   9
#> 2016-12-31 19:00:09-05:00  10

# Again, maintain the clock time
py_to_r(ex_py_NY_converted)
#>                      x
#> 2016-12-31 19:00:00  1
#> 2016-12-31 19:00:01  2
#> 2016-12-31 19:00:02  3
#> 2016-12-31 19:00:03  4
#> 2016-12-31 19:00:04  5
#> 2016-12-31 19:00:05  6
#> 2016-12-31 19:00:06  7
#> 2016-12-31 19:00:07  8
#> 2016-12-31 19:00:08  9
#> 2016-12-31 19:00:09 10
```

Created on 2018-03-07 by the [reprex package](http://reprex.tidyverse.org) (v0.1.1.9000).