### PR TITLE
Fixes for `py_iterator` doc

### DIFF
--- a/R/generator.R
+++ b/R/generator.R
@@ -17,7 +17,7 @@
 #' mutates it's enclosing environment via the `<<-` operator. For example:
 #'
 #' ```r
-#' sequence_generator <-function(start) {
+#' sequence_generator <- function(start) {
 #'   value <- start
 #'   function() {
 #'     value <<- value + 1
@@ -25,7 +25,7 @@
 #'   }
 #' }
 #' 
-#' g <- generator(sequence_generator(10))
+#' g <- py_iterator(sequence_generator(10))
 #' ```
 #' 
 #' @section Ending Iteration:

--- a/R/generator.R
+++ b/R/generator.R
@@ -24,7 +24,9 @@
 #'     value
 #'   }
 #' }
-#' 
+#' ```
+#' Then create an iterator using `py_iterator()`:
+#' ```r
 #' g <- py_iterator(sequence_generator(10))
 #' ```
 #' 
@@ -75,11 +77,10 @@ py_iterator <- function(fn, completed = NULL) {
       completed
     })
   }
- 
+  
   # create the generator
   tools <- import("rpytools")
   tools$generator$RGenerator(wrapped_fn, completed)
 }
-
 
 

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -46,6 +46,7 @@ reference:
       - dict
       - tuple
       - iterate
+      - py_iterator
       - with.python.builtin.object
     
   - title: "Python Configuration"
@@ -84,7 +85,6 @@ reference:
       - py_id
       - py_len
       - py_str
-      - py_iterator
       - py_unicode
       - py_set_seed
       - py_last_error


### PR DESCRIPTION
This fixes the formatting of docs for `py_iterator` and moved `py_iterator` to "Python Types" section of the reference page. 

Originally (note the additional indentation before `g` and `generator` should be `py_iterator`):
```
sequence_generator <-function(start) {
  value <- start
  function() {
    value <<- value + 1
    value
  }
}
    g <- generator(sequence_generator(10))
```

The unrelated diff is probably because I am using the newer version of pkgdown (just did a fresh install from Github). 