### PR TITLE
Fixed issue with not failing use_condaenv when required but not found

### DIFF
--- a/R/use_python.R
+++ b/R/use_python.R
@@ -68,7 +68,7 @@ use_condaenv <- function(condaenv, conda = "auto", required = FALSE) {
   
   # look for one with that name
   conda_env_python <- subset(conda_envs, conda_envs$name == condaenv)$python
-  if (is.null(conda_env_python) && required)
+  if (length(conda_env_python) == 0 && required)
     stop("Unable to locate conda environment '", condaenv, "'.")
   
   if (!is.null(condaenv))


### PR DESCRIPTION
If a conda env is not found,  `conda_env_python` is length 0 character instead of `NULL`.
```
> subset(conda_envs, conda_envs$name == condaenv)$python
character(0)
```
`use_condaenv` should fail now when `required = TRUE` and when the conda env is not found.