### PR TITLE
allow for parameter help from object directly

### DIFF
--- a/R/help.R
+++ b/R/help.R
@@ -248,7 +248,6 @@ help_url_handler.python.builtin.object <- function(topic, source) {
   }
 
   # get help page
-  page <- NULL
   inspect <- import("inspect")
   if (inspect$ismodule(source)) {
     module <- py_get_name(source)
@@ -348,7 +347,7 @@ arg_descriptions_from_doc_sphinx <- function(doc) {
   
   nms <- vapply(params, function(param) {
     name <- param$children[[1]]$astext()
-    sub(":.*", "", name)
+    sub("\\s*:.*", "", name)
   }, character(1))
   
   names(output) <- nms
@@ -390,7 +389,7 @@ sections_from_doc <- function(doc) {
     
     # collect the sections text
     section_text <- c()
-    while((section_line + 1) <= length(doc)) {
+    while ((section_line + 1) <= length(doc)) {
       line <- doc[[section_line + 1]]
       if (grepl("\\w+", line)) {
         section_text <- paste(section_text, line)

--- a/tests/testthat/test-help-handlers.R
+++ b/tests/testthat/test-help-handlers.R
@@ -26,7 +26,7 @@ Just a placeholder here.
 "
 
   doctree <- sphinx_doctree_from_doc(docs)
-  expect_equal(names(doctree$ids), c("parameters", "returns", "section1"))
+  expect_setequal(names(doctree$ids), c("parameters", "returns", "section1"))
 
   arg_descriptions <- arg_descriptions_from_doc_sphinx(docs)
   expect_equal(names(arg_descriptions), c("a", "type"))
@@ -87,6 +87,7 @@ omega: int, optional
   pass
 ')
   
+  main <- import_main(convert = FALSE)
   output <- help_completion_parameter_handler.python.builtin.object(main$foo)
   expect_equal(output$args, c("alpha", "omega"))
   expect_match(output$arg_descriptions[[1]], "The first argument.")

--- a/tests/testthat/test-help-handlers.R
+++ b/tests/testthat/test-help-handlers.R
@@ -69,3 +69,26 @@ Section1:
   expect_match(result$returns, "array-like values")
 })
 
+test_that("Parameter help can be extracted from Python objects", {
+  skip_if_no_docutils()
+  
+  py_run_string('
+def foo(alpha, omega):
+  """
+Parameters
+----------
+
+alpha: int, optional
+  The first argument.
+
+omega: int, optional
+  The last argument.
+"""
+  pass
+')
+  
+  output <- help_completion_parameter_handler.python.builtin.object(main$foo)
+  expect_equal(output$args, c("alpha", "omega"))
+  expect_match(output$arg_descriptions[[1]], "The first argument.")
+  expect_match(output$arg_descriptions[[2]], "The last argument.")
+})

--- a/tests/testthat/test-python-output.R
+++ b/tests/testthat/test-python-output.R
@@ -1,11 +1,12 @@
 context("output")
 
 capture_test_output <- function(type) {
+  sys <- import("sys", convert = TRUE)
   py_capture_output(type = type, { 
     if ("stdout" %in% type)
-      sys$stdout$write("out"); 
+      sys$stdout$write("out")
     if ("stderr" %in% type)
-    sys$stderr$write("err"); 
+      sys$stderr$write("err")
   })
 }
 


### PR DESCRIPTION
This PR makes it possible to get help from a Python object directly, rather than just from the code that can be evaluated to produce the associated object.

This PR also augments the lookup logic such that the `__init__` method is used to provide parameter help for class objects.