### PR TITLE
Add source_python() support to source script from URL

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@ Install the development version with: `install_github("rstudio/reticulate")`
 
 - Added support for conversion between `Matrix::dgCMatrix` objects in R and `Scipy` CSC matrices in Python.
 
+- `source_python()` can now source a Python script from a URL into R environments.
+
 
 ## reticulate 1.6 (CRAN)
 

--- a/R/source.R
+++ b/R/source.R
@@ -15,10 +15,21 @@
 #' @export
 source_python <- function(file, envir = parent.frame(), convert = TRUE) {
   
+  # Copy lines from URL to a local tempory file
+  tmp_file <- NULL
+  if (!file.exists(file) && isTRUE(grepl("http", file))) {
+    lines <- readLines(file, warn = FALSE)
+    file <- tmp_file <- tempfile(fileext = ".py")
+    cat(lines, file = tmp_file, sep = "\n")
+  }
+
   # source the python script (locally so we can track what mutations are
   # made in the file scope)
   dict <- py_run_file(file, local = TRUE, convert = convert)
   
+  # Remove the temporarily created file (if any)
+  if (!is.null(tmp_file)) unlink(tmp_file)
+
   # replay changes into the python main module
   main <- import_main(convert = FALSE)
   update <- py_to_r(py_get_attr(main$`__dict__`, "update"))

--- a/tests/testthat/test-python-source.R
+++ b/tests/testthat/test-python-source.R
@@ -1,8 +1,14 @@
 context("source")
 
-test_that("Python scripts can be sourced", {
+test_that("Python scripts can be sourced from local file", {
   skip_if_no_python()
   source_python('script.py')
+  expect_equal(add(2, 4), 6)
+})
+
+test_that("Python scripts can be sourced from a URL", {
+  skip_if_no_python()
+  source_python('https://raw.githubusercontent.com/rstudio/reticulate/master/tests/testthat/script.py')
   expect_equal(add(2, 4), 6)
 })
 


### PR DESCRIPTION
`source()` can accepts a wider range of R `connection` objects but I think users of reticulate may only want to source file from local or from URL (e.g. Github snippet). 