### PR TITLE
Update help for `quiet`

### DIFF
--- a/R/repl.R
+++ b/R/repl.R
@@ -30,7 +30,7 @@
 #'   the REPL is launched.
 #'   
 #' @param quiet Boolean; print a startup banner when launching the REPL? If
-#'   `FALSE`, the banner will be suppressed.
+#'   `TRUE`, the banner will be suppressed.
 #' 
 #' @seealso [py], for accessing objects created using the Python REPL.
 #' 


### PR DESCRIPTION
It looks like this boolean has been documented in reverse. `quiet=TRUE` suppresses the banner (which makes sense). This edit just corrects that.