### PR TITLE
Add "new" pandas index types for catching DataFrame index column conversion

### DIFF
--- a/R/conversion.R
+++ b/R/conversion.R
@@ -271,9 +271,11 @@ py_to_r.pandas.core.frame.DataFrame <- function(x) {
   # try to explicitly whitelist a small family which we can represent
   # effectively in R
   index <- x$index
-  if (inherits(index, "pandas.core.indexes.base.Index")) {
+  if (inherits(index, c("pandas.core.indexes.base.Index",
+                        "pandas.indexes.base.Index"))) {
 
-    if (inherits(index, "pandas.core.indexes.range.RangeIndex") &&
+    if (inherits(index, c("pandas.core.indexes.range.RangeIndex",
+                          "pandas.indexes.range.RangeIndex")) &&
         np$issubdtype(index$dtype, np$number))
     {
       # check for a range index from 0 -> n. in such a case, we don't need
@@ -290,7 +292,8 @@ py_to_r.pandas.core.frame.DataFrame <- function(x) {
       }
     }
 
-    else if (inherits(index, "pandas.core.indexes.datetimes.DatetimeIndex")) {
+    else if (inherits(index, c("pandas.core.indexes.datetimes.DatetimeIndex",
+                               "pandas.tseries.index.DatetimeIndex"))) {
 
       converted <- tryCatch(py_to_r(index$values), error = identity)
 


### PR DESCRIPTION
When I first implemented the index handling for the conversion from Py DataFrames to R data.frames, I was using an older version of pandas (Something around 0.20.1). Since then, they reworked the top level libraries, see [here](https://pandas.pydata.org/pandas-docs/version/0.20/whatsnew.html#reorganization-of-the-library-privacy-changes). I just updated pandas recently and found that out. This changed the actual class of the index. 

For ~0.20.1

``` r
library(reticulate)
pd <- import("pandas", convert = FALSE)
rng = pd$date_range("2011-01-01", periods=2L, freq='H', tz = "UTC")
class(rng)
#>  [1] "pandas.core.indexes.datetimes.DatetimeIndex"           
#>  [2] "pandas.core.indexes.datetimelike.DatelikeOps"          
#>  [3] "pandas.core.indexes.datetimelike.TimelikeOps"          
#>  [4] "pandas.core.indexes.datetimelike.DatetimeIndexOpsMixin"
#>  [5] "pandas.core.indexes.numeric.Int64Index"                
#>  [6] "pandas.core.indexes.numeric.NumericIndex"              
#>  [7] "pandas.core.indexes.base.Index"                        
#>  [8] "pandas.core.base.IndexOpsMixin"                        
#>  [9] "pandas.core.strings.StringAccessorMixin"               
#> [10] "pandas.core.base.PandasObject"                         
#> [11] "pandas.core.base.StringMixin"                          
#> [12] "python.builtin.object"
```

For 0.22.0

``` r
library(reticulate)
pd <- import("pandas", convert = FALSE)
rng = pd$date_range("2011-01-01", periods=2L, freq='H', tz = "UTC")
class(rng)
#>  [1] "pandas.tseries.index.DatetimeIndex"       
#>  [2] "pandas.tseries.base.DatelikeOps"          
#>  [3] "pandas.tseries.base.TimelikeOps"          
#>  [4] "pandas.tseries.base.DatetimeIndexOpsMixin"
#>  [5] "pandas.indexes.numeric.Int64Index"        
#>  [6] "pandas.indexes.numeric.NumericIndex"      
#>  [7] "pandas.indexes.base.Index"                
#>  [8] "pandas.core.base.IndexOpsMixin"           
#>  [9] "pandas.core.strings.StringAccessorMixin"  
#> [10] "pandas.core.base.PandasObject"            
#> [11] "pandas.core.base.StringMixin"             
#> [12] "python.builtin.object"
```

Obviously any handling of the indexes that depended on that top level class could be broken by this. Not sure if you want to just do what I did in the commit and handle both, or require users to use a version of pandas that supports just the new classes. It really just seems to be a class naming thing, with the underlying structure of the objects remaining the same, so you might could also consider having some kind of overarching `datetimeindex` / `index` / `rangeindex` object that covered both cases.