### PR TITLE
address issue with pandas DataFrame names that clash with DataFrame methods

### DIFF
--- a/R/conversion.R
+++ b/R/conversion.R
@@ -233,7 +233,7 @@ py_to_r.pandas.core.frame.DataFrame <- function(x) {
   # extract numpy arrays associated with each column
   columns <- py_to_r(x$columns$values)
   converted <- lapply(columns, function(column) {
-    py_to_r(x[[column]]$as_matrix())
+    py_to_r(x$`__getitem__`(column)$as_matrix())
   })
   names(converted) <- columns
 
@@ -247,9 +247,9 @@ py_to_r.pandas.core.frame.DataFrame <- function(x) {
     }
 
     # convert categorical variables to factors
-    if (identical(py_to_r(x[[column]]$dtype$name), "category")) {
-      levels <- py_to_r(x[[column]]$values$categories$values)
-      ordered <- py_to_r(x[[column]]$dtype$ordered)
+    if (identical(py_to_r(x$`__getitem__`(column)$dtype$name), "category")) {
+      levels <- py_to_r(x$`__getitem__`(column)$values$categories$values)
+      ordered <- py_to_r(x$`__getitem__`(column)$dtype$ordered)
       converted[[i]] <- factor(converted[[i]], levels = levels, ordered = ordered)
     }
 


### PR DESCRIPTION
This PR seeks to fix the issue raised in https://github.com/rstudio/reticulate/issues/244, that reticulate fails to convert pandas DataFrames where a column name matches a DataFrame method.  

The change is to use ``x$`__getitem__`(column) `` instead of `x[[column]]` within py_to_r.pandas.core.frame.DataFrame method.  This avoids `x[[column]]` being converted to `x.column`.  Accessing a column as an attribute fails when the column name clashes with a pandas method, as described in [pandas documentation](https://pandas.pydata.org/pandas-docs/stable/indexing.html#attribute-access)