### PR TITLE
don't call __getitem__ for '$'

### DIFF
--- a/R/python.R
+++ b/R/python.R
@@ -271,13 +271,7 @@ py_get_attr_or_item <- function(x, name, prefer_attr) {
 
   # get the attrib and convert as needed
   if (prefer_attr) {
-
-    if (py_has_attr(x, name)) {
-      object <- py_get_attr(x, name)
-    } else {
-      object <- py_get_item(x, name)
-    }
-
+    object <- py_get_attr(x, name)
   } else {
 
     # if we have an attribute, attempt to get the item


### PR DESCRIPTION
This PR fixes the unhelpful error message seen in https://github.com/rstudio/keras/issues/400#issuecomment-388769194.

The issue there was our attempt to fall back to item access from attribute access ended up emitting a `getitem`-related error, which is rather confusing in that context. The fix here is to ensure that (by default) `$` only accesses attributes.

Note that Python dictionaries still have their own `$` operator that allow item access, and Pandas DataFrames own `__getattr__` falls back to items when no such attribute exists in their own implementation.