### PR TITLE
handle duplicates in Pandas index

### DIFF
--- a/R/conversion.R
+++ b/R/conversion.R
@@ -272,6 +272,12 @@ py_to_r.pandas.core.frame.DataFrame <- function(x) {
   # try to explicitly whitelist a small family which we can represent
   # effectively in R
   index <- x$index
+
+  # tag the returned object with the Python index, in case
+  # the user needs to explicitly access / munge the index
+  # for some need
+  attr(df, "pandas.index") <- index
+
   if (inherits(index, c("pandas.core.indexes.base.Index",
                         "pandas.indexes.base.Index"))) {
 
@@ -312,8 +318,14 @@ py_to_r.pandas.core.frame.DataFrame <- function(x) {
 
     else {
       converted <- tryCatch(py_to_r(index$values), error = identity)
-      if (is.character(converted) || is.numeric(converted))
-        rownames(df) <- converted
+      if (is.character(converted) || is.numeric(converted)) {
+        if (any(duplicated(converted))) {
+          warning("index contains duplicated values: row names not set")
+        } else {
+          rownames(df) <- converted
+        }
+      }
+
     }
   }
 


### PR DESCRIPTION
This PR makes two changes:

- `py_to_r()` now tags the returned R data.frame with the Pandas index, as an attribute called `pandas.index`. This is for users who need to post-process the index in some way, because our default converter didn't do the right thing.

- We detect duplicate values in the index; when discovered, we don't attempt to set the index and instead emit a warning.

Fixes https://github.com/rstudio/reticulate/issues/270.

@jjallaire let me know if this feels like the right change.