### PR TITLE
handle complex names (#274)

### DIFF
--- a/R/conversion.R
+++ b/R/conversion.R
@@ -240,11 +240,12 @@ py_to_r.pandas.core.frame.DataFrame <- function(x) {
   np <- import("numpy", convert = TRUE)
 
   # extract numpy arrays associated with each column
-  columns <- py_to_r(x$columns$values)
-  converted <- lapply(columns, function(column) {
+  columns <- x$columns$values
+  converted <- lapply(seq_along(columns) - 1L, function(i) {
+    column <- columns[[i]]
     py_to_r(py_get_item(x, column)$values)
   })
-  names(converted) <- columns
+  names(converted) <- py_to_r(x$columns$format())
 
   # clean up converted objects
   for (i in seq_along(converted)) {
@@ -256,10 +257,7 @@ py_to_r.pandas.core.frame.DataFrame <- function(x) {
     }
   }
 
-  # re-order based on ordering of pandas DataFrame. note that
-  # as.data.frame() will not handle list columns correctly, so
-  # we construct the data.frame 'by hand'
-  df <- converted[columns]
+  df <- converted
   class(df) <- "data.frame"
   attr(df, "row.names") <- c(NA_integer_, -nrow(x))
 

--- a/tests/testthat/test-python-pandas.R
+++ b/tests/testthat/test-python-pandas.R
@@ -80,4 +80,17 @@ test_that("data.frames with length-one factor columns can be converted", {
 
 })
 
+test_that("complex names are handled", {
+  skip_if_no_pandas()
 
+  pd <- import("pandas", convert = FALSE)
+
+  d <- dict(col1 = list(1,2))
+
+  d[tuple("col1", "col2")] <- list(4, 5)
+
+  p <- pd$DataFrame(data = d)
+  r <- py_to_r(p)
+  expect_equal(names(r), c("col1", "(col1, col2)"))
+
+})


### PR DESCRIPTION
This PR ensures that we convert non-string names to strings (using `format()`) when converting Pandas DataFrames.