### PR TITLE
fix conversion of boolean matrices (closes #280)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 
 Install the development version with: `install_github("rstudio/reticulate")`
 
+- Fixed an issue where logical R matrices would not be converted correctly to
+  their NumPy counterpart. (#280)
+
 - Fixed an issue where Python chunks containing multiple statements on the same
   line would be evaluated and printed multiple times.
 

--- a/src/libpython.h
+++ b/src/libpython.h
@@ -436,6 +436,19 @@ LIBPYTHON_EXTERN void **PyArray_API;
          (*(int (*)(PyObject *, void *, PyArray_Descr *)) \
             PyArray_API[63])
 
+// NOTE: PyArray_Malloc has a bit of indirection for different
+// versions of Python, but the underlying intention is to
+// always use the system allocator (through malloc). See:
+//
+// https://github.com/numpy/numpy/blob/f5758d6fe15c2b506290bfc5379a10027617b331/numpy/core/include/numpy/ndarraytypes.h#L348-L367
+// https://github.com/python/cpython/blob/28f713601d3ec80820e842dcb25a234093f1ff18/Objects/obmalloc.c#L66-L76
+//
+#ifdef __cplusplus
+#define PyArray_malloc std::malloc
+#else
+#define PyArray_malloc malloc
+#endif
+
 #define PyArray_New                                                                                          \
           (*(PyObject * (*)(PyTypeObject *, int, npy_intp *, int, npy_intp *, void *, int, int, PyObject *)) \
              PyArray_API[93])

--- a/src/libpython.h
+++ b/src/libpython.h
@@ -480,6 +480,7 @@ bool import_numpy_api(bool python3, std::string* pError);
 
 #define NPY_ARRAY_C_CONTIGUOUS    0x0001
 #define NPY_ARRAY_F_CONTIGUOUS    0x0002
+#define NPY_ARRAY_OWNDATA         0x0004
 #define NPY_ARRAY_ALIGNED         0x0100
 #define NPY_ARRAY_FARRAY_RO    (NPY_ARRAY_F_CONTIGUOUS | NPY_ARRAY_ALIGNED)
 #define NPY_ARRAY_CARRAY_RO    (NPY_ARRAY_C_CONTIGUOUS | NPY_ARRAY_ALIGNED)
@@ -487,6 +488,7 @@ bool import_numpy_api(bool python3, std::string* pError);
 #define NPY_ARRAY_WRITEABLE       0x0400
 #define NPY_ARRAY_BEHAVED      (NPY_ARRAY_ALIGNED | NPY_ARRAY_WRITEABLE)
 #define NPY_ARRAY_FARRAY       (NPY_ARRAY_F_CONTIGUOUS | NPY_ARRAY_BEHAVED)
+
 
 class SharedLibrary {
 

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -255,7 +255,7 @@ int narrow_array_typenum(PyArray_Descr* descr) {
 bool is_numpy_str(PyObject* x) {
   if (!isPyArrayScalar(x))
     return false; // ndarray or other, not string
-  
+
   PyArray_DescrPtr descrPtr(PyArray_DescrFromScalar(x));
   int typenum = narrow_array_typenum(descrPtr);
   return (typenum == NPY_STRING || typenum == NPY_UNICODE);
@@ -274,7 +274,7 @@ bool is_python_str(PyObject* x) {
 
   else if (is_numpy_str(x))
     return true;
-  
+
   else
     return false;
 }
@@ -995,6 +995,21 @@ PyObject* r_to_py(RObject x, bool convert) {
            "converted");
     }
 
+    int flags = NPY_ARRAY_FARRAY_RO;
+
+    // because R logical vectors are just ints under the
+    // hood, we need to explicitly construct a boolean
+    // vector for our Python array. note that the created
+    // array will own the data so we do not free it after
+    if (typenum == NPY_BOOL) {
+      R_xlen_t n = XLENGTH(sexp);
+      bool* converted = (bool*) std::malloc(n * sizeof(bool));
+      for (R_xlen_t i = 0; i < n; i++)
+        converted[i] = LOGICAL(sexp)[i];
+      data = converted;
+      flags |= NPY_ARRAY_OWNDATA;
+    }
+
     // create the matrix
     PyObject* array = PyArray_New(&PyArray_Type,
                                    nd,
@@ -1003,7 +1018,7 @@ PyObject* r_to_py(RObject x, bool convert) {
                                    NULL,
                                    data,
                                    0,
-                                   NPY_ARRAY_FARRAY_RO,
+                                   flags,
                                    NULL);
 
     // check for error

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -1003,7 +1003,7 @@ PyObject* r_to_py(RObject x, bool convert) {
     // array will own the data so we do not free it after
     if (typenum == NPY_BOOL) {
       R_xlen_t n = XLENGTH(sexp);
-      bool* converted = (bool*) std::malloc(n * sizeof(bool));
+      bool* converted = (bool*) PyArray_malloc(n * sizeof(bool));
       for (R_xlen_t i = 0; i < n; i++)
         converted[i] = LOGICAL(sexp)[i];
       data = converted;

--- a/tests/testthat/test-python-numpy.R
+++ b/tests/testthat/test-python-numpy.R
@@ -76,3 +76,10 @@ test_that("numpy length functions works", {
   np <- import("numpy")
   test_array(r_to_py(matrix(c(1:8), nrow = 2, ncol = 4)))
 })
+
+test_that("boolean matrices are converted appropriately", {
+  skip_if_no_numpy()
+
+  A <- matrix(TRUE, nrow = 2, ncol = 2)
+  expect_equal(A, py_to_r(r_to_py(A)))
+})


### PR DESCRIPTION
This PR fixes #280 by converting the (`int`-flavored) R logical vector into a plain array of `bool`s before creating the NumPy array.

We set the `NPY_ARRAY_OWNDATA` flag to tell NumPy that it should own + manage the data passed in to the constructor when doing this, so that Python / NumPy itself can free the malloc'ed data when the associated Python object goes out of scope.