### PR TITLE
Make variables defined using %as% operator in with() available after execution of the with block

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: reticulate
 Type: Package
 Title: Interface to 'Python'
-Version: 1.9
+Version: 1.9.0.9000
 Authors@R: c(
   person("JJ", "Allaire", role = c("aut", "cre"), email = "jj@rstudio.com"),
   person("Kevin", "Ushey", role = c("aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,12 @@
 
+## reticulate 1.10 (development)
+
+Install the development version with: `install_github("rstudio/reticulate")`
+
+- Make variables defined using `%as%` operator in `with()` available after 
+  execution of the with block (same behavior as Python).
+
+
 ## reticulate 1.9 (CRAN)
 
 - Detect python 3 in environments where there is no python 2 (e.g. Ubuntu 18.04)

--- a/R/python.R
+++ b/R/python.R
@@ -646,10 +646,7 @@ with.python.builtin.object <- function(data, expr, as = NULL, ...) {
     envir <- parent.frame()
 
   # assign the context if we have an as parameter
-  asRestore <- NULL
   if (!is.null(as)) {
-    if (exists(as, envir = envir))
-      asRestore <- get(as, envir = envir)
     assign(as, context, envir = envir)
   }
 
@@ -657,11 +654,6 @@ with.python.builtin.object <- function(data, expr, as = NULL, ...) {
   tryCatch(force(expr),
            finally = {
              data$`__exit__`(NULL, NULL, NULL)
-             if (!is.null(as)) {
-               remove(list = as, envir = envir)
-               if (!is.null(asRestore))
-                 assign(as, asRestore, envir = envir)
-             }
            }
           )
 }


### PR DESCRIPTION
Same behavior as Python. See https://stackoverflow.com/questions/6432355/variable-defined-with-with-statement-available-outside-of-with-block

@kevinushey Could you review this?

cc @skeydan re: https://github.com/rstudio/tfsandbox/issues/4