### PR TITLE
always remap output streams with Windows + Python 2.7

### DIFF
--- a/R/output.R
+++ b/R/output.R
@@ -5,7 +5,8 @@ remap_output_streams <- function() {
   output$remap_output_streams(
     write_stdout,
     write_stderr,
-    tty = interactive() || isatty(stdout())
+    tty = interactive() || isatty(stdout()),
+    force = is_windows() && !is_python3()
   )
 }
 

--- a/inst/python/rpytools/output.py
+++ b/inst/python/rpytools/output.py
@@ -54,10 +54,10 @@ class OutputRemap(object):
     return None
 
 
-def remap_output_streams(r_stdout, r_stderr, tty):
-  if (sys.stdout is None):
+def remap_output_streams(r_stdout, r_stderr, tty, force):
+  if (force or sys.stdout is None):
     sys.stdout = OutputRemap(sys.stdout, r_stdout, tty)
-  if (sys.stderr is None):
+  if (force or sys.stderr is None):
     sys.stderr = OutputRemap(sys.stderr, r_stderr, tty)
 
 


### PR DESCRIPTION
Fixes https://github.com/rstudio/reticulate/issues/313.

@jjallaire can you review? I wonder if the intention was that this code would be firing more often (it seems like Python is always initialized with `stdout` and `stderr` but we might want to remap to R in those cases as well)