### PR TITLE
don't drop blank lines in reticulate engine

### DIFF
--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -60,7 +60,7 @@ eng_python <- function(options) {
   # helper function for extracting range of code, dropping blank lines
   extract <- function(code, range) {
     snippet <- code[range[1]:range[2]]
-    paste(snippet[nzchar(snippet)], collapse = "\n")
+    paste(snippet, collapse = "\n")
   }
 
   # helper function for running a snippet of code and capturing output


### PR DESCRIPTION
Fixes an issue noted by https://github.com/rstudio/rstudio/issues/1556#issuecomment-410789560.

Putting this up as a PR as I do not recall the original motivation for stripping these blank lines, but it seems it was done very early on (https://github.com/rstudio/reticulate/commit/93886117f4f414cb1b88d7932071d9e3b4ddbae7).

I don't seem to notice any ill effects from including the blank lines (and they are then properly reflected in the resulting rendered document) so I think this should be safe.