### PR TITLE
attempt to disallow Qt-based matplotlib backends

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -475,6 +475,18 @@ is_ubuntu <- function() {
   }
 }
 
+is_rstudio <- function() {
+  exists("RStudio.Version", envir = globalenv())
+}
+
+is_rstudio_desktop <- function() {
+  if (!exists("RStudio.Version", envir = globalenv()))
+    return(FALSE)
+
+  RStudio.Version <- get("RStudio.Version", envir = globalenv())
+  version <- RStudio.Version()
+  identical(version$mode, "desktop")
+}
 
 clean_version <- function(version) {
   gsub("\\.$", "", gsub("[A-Za-z_+].*$", "", version))

--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -211,6 +211,26 @@ eng_python_initialize_matplotlib <- function(options,
   if (!py_module_available("matplotlib"))
     return()
 
+  # attempt to enforce a non-Qt matplotlib backend. this is especially important
+  # with RStudio Desktop as attempting to use a Qt backend will cause issues due
+  # to mismatched Qt versions between RStudio and Anaconda environments, and
+  # will cause crashes when attempting to generate plots
+  if (is_rstudio_desktop()) {
+
+    matplotlib <- import("matplotlib", convert = TRUE)
+
+    # check to see if a backend has already been initialized. if so, we
+    # need to switch backends; otherwise, we can simply request to use a
+    # specific one when the backend is initialized later
+    sys <- import("sys", convert = FALSE)
+    if ("matplotlib.backends" %in% names(sys$modules))
+      matplotlib$pyplot$switch_backend("agg")
+    else
+      matplotlib$use("agg", warn = FALSE, force = TRUE)
+  }
+
+  # double-check that we can load 'pyplot' (this can fail if matplotlib
+  # is installed but is initialized to a backend missing some required components)
   if (!py_module_available("matplotlib.pyplot"))
     return()
 


### PR DESCRIPTION
Fixes #296.

The issue here: in Anaconda environments, `matplotlib` will see that Qt libraries and supporting packages are available, and select a Qt backend as the default backend to use for plots. Unfortunately, attempting to do so within RStudio will then fail due to the difference in versions between Qt used by RStudio and Anaconda.

To fix this, we enforce the default `agg` backend when this specific combination is detected.