### PR TITLE
ensure code is auto-printed in Python chunks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,12 @@
 
 Install the development version with: `devtools::install_github("rstudio/reticulate")`
 
+- Python chunks containing errors will cause execution to halt if 'error=FALSE'
+  during render, conforming with the default knitr behavior for R chunks.
+
+- The output of bare statements (e.g. `1 + 1`) is now emitted as output when using
+  the reticulate Python engine.
+
 - Remapping of Python output streams to be R can now be explicitly enabled
   by setting the environment variable `RETICULATE_REMAP_OUTPUT_STREAMS` to 1. (#335)
 

--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -119,23 +119,11 @@ eng_python <- function(options) {
   # synchronize state R -> Python
   eng_python_synchronize_before()
 
-  # determine if we should capture errors (don't capture in rmarkdown::render())
-  capture_errors <- local({
-
-    if (identical(options$error, TRUE))
-      return(TRUE)
-
-    if (!requireNamespace("rmarkdown", quietly = TRUE))
-      return(TRUE)
-
-    rmarkdown <- asNamespace("rmarkdown")
-    context <- rmarkdown$.render_context
-    if (is.null(context))
-      return(TRUE)
-
-    is.null(context$peek())
-
-  })
+  # determine if we should capture errors
+  # (don't capture errors during knit)
+  capture_errors <-
+    identical(options$error, TRUE) ||
+    isFALSE(getOption("knitr.in.progress", default = FALSE))
 
   for (range in ranges) {
 

--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -74,14 +74,6 @@ eng_python <- function(options) {
     paste(snippet, collapse = "\n")
   }
 
-  # helper function for running a snippet of code and capturing output
-  run <- function(snippet) {
-    output <- py_capture_output(py_run_string(snippet, convert = FALSE))
-    if (nzchar(output))
-      output <- sub("\n$", "", output)
-    output
-  }
-
   # extract the code to be run -- we'll attempt to run the code line by line
   # and detect changes so that we can interleave code and output (similar to
   # what one sees when executing an R chunk in knitr). to wit, we'll do our
@@ -118,11 +110,32 @@ eng_python <- function(options) {
   # line index from which source should be emitted
   pending_source_index <- 1
 
+  # whether an error occurred during execution
+  had_error <- FALSE
+
   # actual outputs to be returned to knitr
   outputs <- list()
 
   # synchronize state R -> Python
   eng_python_synchronize_before()
+
+  # determine if we should capture errors (don't capture in rmarkdown::render())
+  capture_errors <- local({
+
+    if (identical(options$error, TRUE))
+      return(TRUE)
+
+    if (!requireNamespace("rmarkdown", quietly = TRUE))
+      return(TRUE)
+
+    rmarkdown <- asNamespace("rmarkdown")
+    context <- rmarkdown$.render_context
+    if (is.null(context))
+      return(TRUE)
+
+    is.null(context$peek())
+
+  })
 
   for (range in ranges) {
 
@@ -130,22 +143,12 @@ eng_python <- function(options) {
     snippet <- extract(code, range)
 
     # run code and capture output
-    captured <- ""
+    captured <- if (capture_errors)
+      tryCatch(py_compile_eval(snippet), error = identity)
+    else
+      py_compile_eval(snippet)
 
-    # error=TRUE implies that errors should be captured and converted
-    # into output messages
-    if (identical(options$error, TRUE)) {
-      tryCatch(
-        captured <- run(snippet),
-        error = function(e) {
-          captured <<- conditionMessage(e)
-        }
-      )
-    } else {
-      captured <- run(snippet)
-    }
-
-    if (nzchar(captured) || length(context$pending_plots)) {
+    if (length(context$pending_plots) || !identical(captured, "")) {
 
       # append pending source to outputs (respecting 'echo' option)
       if (!identical(options$echo, FALSE)) {
@@ -154,26 +157,34 @@ eng_python <- function(options) {
         outputs[[length(outputs) + 1]] <- output
       }
 
-      # append captured outputs
-      if (nzchar(captured) && isTRUE(options$include))
-        outputs[[length(outputs) + 1]] <- captured
+      # append captured outputs (respecting 'include' option)
+      if (isTRUE(options$include)) {
 
-      # append captured images / figures
-      if (length(context$pending_plots)) {
-        if (isTRUE(options$include)) {
-          for (plot in context$pending_plots)
-            outputs[[length(outputs) + 1]] <- plot
-        }
+        # append captured output
+        if (!identical(captured, ""))
+          outputs[[length(outputs) + 1]] <- captured
+
+        # append captured images / figures
+        for (plot in context$pending_plots)
+          outputs[[length(outputs) + 1]] <- plot
         context$pending_plots <- list()
+
       }
 
       # update pending source range
       pending_source_index <- range[2] + 1
+
+      # bail if we had an error with 'error=FALSE'
+      if (identical(options$error, FALSE) && inherits(captured, "error")) {
+        had_error <- TRUE
+        break
+      }
+
     }
   }
 
   # if we have leftover input, add that now
-  if (!identical(options$echo, FALSE) && pending_source_index <= n) {
+  if (!had_error && !identical(options$echo, FALSE) && pending_source_index <= n) {
     leftover <- extract(code, c(pending_source_index, n))
     outputs[[length(outputs) + 1]] <- structure(
       list(src = leftover),

--- a/R/repl.R
+++ b/R/repl.R
@@ -225,7 +225,9 @@ repl_python <- function(
 
       # submit previous code
       pasted <- paste(previous, collapse = "\n")
-      tryCatch(py_compile_eval(pasted), error = handle_error)
+      output <- tryCatch(py_compile_eval(pasted), error = handle_error)
+      if (is.character(output) && nzchar(output))
+        cat(output, sep = "")
 
       # now, handle the newest line of code submitted
       buffer$set(contents)
@@ -240,7 +242,9 @@ repl_python <- function(
     # otherwise, we should have received a code output object
     # so we can just run the code submitted thus far
     buffer$clear()
-    tryCatch(py_compile_eval(code), error = handle_error)
+    output <- tryCatch(py_compile_eval(code), error = handle_error)
+    if (is.character(output) && nzchar(output))
+      cat(output, sep = "")
 
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -96,3 +96,37 @@ new_stack <- function() {
 
 }
 
+py_compile_eval <- function(code) {
+
+  builtins <- import_builtins(convert = TRUE)
+  sys <- import("sys", convert = TRUE)
+
+  # allow 'globals' and 'locals' to both point at main module, so that
+  # evaluated code updates references there as well
+  globals <- py_eval("globals()", convert = FALSE)
+  locals <- globals
+
+  # Python's command compiler complains if the only thing you submit
+  # is a comment, so detect that case first
+  if (grepl("^\\s*#", code))
+    return(TRUE)
+
+  # Python is picky about trailing whitespace, so ensure only a single
+  # newline follows the code to be submitted
+  code <- sub("\\s*$", "\n", code)
+
+  # compile and eval the code -- using 'single' here ensures that Python
+  # auto-prints statements as they are evaluated
+  compiled <- builtins$compile(code, '<string>', 'single')
+  output <- py_capture_output(builtins$eval(compiled, globals, locals))
+
+  # py_capture_output can append an extra trailing newline, so remove it
+  if (grepl("\n{2,}$", output))
+    output <- sub("\n$", "", output)
+
+  # emit captured output
+  cat(output, sep = "")
+
+  # and return
+  invisible(output)
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -124,9 +124,6 @@ py_compile_eval <- function(code) {
   if (grepl("\n{2,}$", output))
     output <- sub("\n$", "", output)
 
-  # emit captured output
-  cat(output, sep = "")
-
   # and return
   invisible(output)
 }

--- a/tests/testthat/resources/eng-reticulate-example.Rmd
+++ b/tests/testthat/resources/eng-reticulate-example.Rmd
@@ -102,7 +102,7 @@ error occurs.
 
 ```{python, error=TRUE}
 raise RuntimeError("oops!")
-print ("This line is still reached.")
+print("This line is still reached.")
 ```
 
 Ensure that lines with multiple statements are only run once.
@@ -115,4 +115,11 @@ Ensure that syntax errors do not block document generation when `eval = FALSE`.
 
 ```{python, eval=FALSE}
 here be syntax errors
+```
+
+Output from bare statements should also be printed.
+
+```{python}
+"Hello, world!"
+[x for x in range(10)]
 ```


### PR DESCRIPTION
This PR fixes an issue where running a chunk e.g.

`````
```{python}
1 + 1
```
`````

would not produce any output when run in RStudio. Note that the execution model here is effectively the same as what we do in `repl_python()`; ie it uses the same tricks to ensure that Python auto-prints the evaluated expressions.