### PR TITLE
detect virtual environments created with venv

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -377,6 +377,13 @@ python_config <- function(python, required_module, python_versions, forced = NUL
   else
     numpy <- NULL
 
+  # check to see if this is a Python virtualenv
+  root <- dirname(dirname(python))
+  virtualenv <- if (is_python_virtualenv(root))
+    root
+  else
+    ""
+
   # check for virtualenv activate script
   activate_this <- file.path(dirname(python), "activate_this.py")
   if (file.exists(activate_this))
@@ -392,6 +399,7 @@ python_config <- function(python, required_module, python_versions, forced = NUL
     python = python,
     libpython = libpython,
     pythonhome = pythonhome,
+    virtualenv = virtualenv,
     virtualenv_activate = virtualenv_activate,
     version_string = version_string,
     version = version,

--- a/R/package.R
+++ b/R/package.R
@@ -108,6 +108,12 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
                           Sys.getenv("PATH"),
                           sep = .Platform$path.sep))
 
+  # if we're a virtual environment then set VIRTUAL_ENV (need to
+  # set this before initializing Python so that module paths are
+  # set as appropriate)
+  if (nzchar(config$virtualenv))
+    Sys.setenv(VIRTUAL_ENV = config$virtualenv)
+
   # initialize python
   py_initialize(config$python,
                 config$libpython,
@@ -116,10 +122,6 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
                 config$version >= "3.0",
                 interactive(),
                 numpy_load_error)
-
-  # if we have a virtualenv then set the VIRTUAL_ENV environment variable
-  if (nzchar(config$virtualenv_activate))
-    Sys.setenv(VIRTUAL_ENV = path.expand(dirname(dirname(config$virtualenv_activate))))
 
   # set available flag indicating we have py bindings
   config$available <- TRUE

--- a/R/use_python.R
+++ b/R/use_python.R
@@ -45,12 +45,8 @@ use_virtualenv <- function(virtualenv, required = FALSE) {
 
 
   # validate it if required
-  if (required) {
-    if (!file_test("-d", python_dir) ||
-        !file_test("-f", file.path(python_dir, "activate_this.py"))) {
-      stop("Directory ", virtualenv, " is not a Python virtualenv")
-    }
-  }
+  if (required && !is_python_virtualenv(virtualenv))
+    stop("Directory ", virtualenv, " is not a Python virtualenv")
 
   # set the option
   python <- file.path(python_dir, "python")

--- a/R/virtualenv.R
+++ b/R/virtualenv.R
@@ -304,3 +304,15 @@ python_version <- function(python) {
   numeric_version(paste(matches[[2]], matches[[3]], sep = "."))
 }
 
+is_python_virtualenv <- function(dir) {
+
+  # virtual environment created with venv
+  if (file.exists(file.path(dir, "pyvenv.cfg")))
+    return(TRUE)
+
+  # virtual environment created with virtualenv
+  if (file.exists(file.path(dir, "bin/activate_this.py")))
+    return(TRUE)
+
+  FALSE
+}

--- a/tests/testthat/resources/venv-activate.R
+++ b/tests/testthat/resources/venv-activate.R
@@ -1,0 +1,6 @@
+args <- commandArgs(TRUE)
+venv <- args[[1]]
+
+reticulate::use_virtualenv(venv, required = TRUE)
+sys <- reticulate::import("sys")
+cat(sys$path, sep = "\n")


### PR DESCRIPTION
This PR is the first step in support for Python virtual environments created by `venv`.

Note that these virtual environments are almost identical to those created with `virtualenv`. The only difference is that the `activate_this.py` script is missing. My understanding is that `activate_this.py` is a hack that tries to allow an existing Python session to bind to an existing virtual environment; whereas the preferred route is to instead run e.g.

    source bin/activate && python

which works as expected for virtual environments created by both `virtualenv` and `venv`.

Something we should discuss then is whether we need any other code changes to support virtual environments that don't contain this script. I see we use it at e.g.

https://github.com/rstudio/reticulate/blob/93c9ee9bceee360a9aa3a431735a4c78379c383e/src/python.cpp#L1433-L1458

It's worth noting that `bin/activate` effectively does two things:

1. Sets the `VIRTUAL_ENV` environment variable; its path points to the virtual environment,
2. Updates the PATH, and puts the virtual environment bin directory first.

Assuming that embedded Python sessions also respect the `VIRTUAL_ENV` environment variable, we should validate that setting that before initializing Python is enough to ensure that the newly-launched Python session uses the virtual environment as requested.