### PR TITLE
Search for any unconventional Python library extensions in Linux

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -335,23 +335,19 @@ python_config <- function(python, required_module, python_versions, forced = NUL
     python_libdir_config <- function(var) {
       python_libdir <- config[[var]]
       ext <- switch(Sys.info()[["sysname"]], Darwin = ".dylib", Windows = ".dll", ".so")
-      libpython <- file.path(python_libdir, paste0("libpython" , version, c("", "m"), ext))
-      libpython_exists <- libpython[file.exists(libpython)]
-      if (length(libpython_exists) > 0)
-        libpython_exists[[1]]
-      else
-        libpython[[1]]
+      pattern <- paste0("^libpython", version, "m?", ext)
+      libpython <- list.files(python_libdir, pattern = pattern, full.names = TRUE)
     }
-    if (!is.null(config$LIBPL)) {
-      libpython <- python_libdir_config("LIBPL")
-      if (!file.exists(libpython)) {
-        if (!is.null(config$LIBDIR))
-          libpython <- python_libdir_config("LIBDIR")
+    for (libsrc in c("LIBPL", "LIBDIR")) {
+      if (!is.null(config[[libsrc]])) {
+        libpython <- python_libdir_config(libsrc)
+        if (length(libpython))
+          break
         else
           libpython <- NULL
+      } else {
+        libpython <- NULL
       }
-    } else {
-      libpython <- NULL
     }
   }
 
@@ -397,7 +393,7 @@ python_config <- function(python, required_module, python_versions, forced = NUL
   # return config info
   structure(class = "py_config", list(
     python = python,
-    libpython = libpython,
+    libpython = libpython[1],
     pythonhome = pythonhome,
     virtualenv = virtualenv,
     virtualenv_activate = virtualenv_activate,

--- a/R/package.R
+++ b/R/package.R
@@ -65,8 +65,8 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
   # check for basic python prerequsities
   if (is.null(config)) {
     stop("Installation of Python not found, Python bindings not loaded.")
-  } else if (!is_windows() && (is.null(config$libpython) || !file.exists(config$libpython))) {
-    stop("Python shared library '", config$libpython, "' not found, Python bindings not loaded.")
+  } else if (!is_windows() && is.null(config$libpython)) {
+    stop("Python shared library not found, Python bindings not loaded.")
   } else if (is_incompatible_arch(config)) {
     stop("Your current architecture is ", current_python_arch(), " however this version of ",
          "Python is compiled for ", config$architecture, ".")


### PR DESCRIPTION
In some Linux distributions such as Centos 7, Python library is only available as `libpython2.7.so.1.0` (if `python-devel` package is not installed). This patch ensures that these library files are found.

Related issue: https://github.com/rstudio/reticulate/issues/291#issuecomment-424299557, https://github.com/rocker-org/rocker/issues/296 .