### PR TITLE
Add scipy installation on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ addons:
     packages:
       - python2.7
       - python-numpy
-
+      - python-scipy


### PR DESCRIPTION
Currently [test-python-scipy-sparse-matrix.R](https://github.com/rstudio/reticulate/blob/master/tests/testthat/test-python-scipy-sparse-matrix.R) is skipped if `scipy` is not installed. Given that this feature is being used by other projects, we should test this at least on Travis to make sure it always works. 
