### PR TITLE
allow creation + use of pre-existing virtualenvs

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -127,3 +127,4 @@ py_compile_eval <- function(code) {
   # and return
   invisible(output)
 }
+


### PR DESCRIPTION
Closes #393. With this PR, one can now use (for example)

``` r
path <- "/path/to/my/venv"
reticulate::virtualenv_create(path)
reticulate::virtualenv_install(path, "numpy")
```

to work with virtual environments located outside of `WORKON_HOME`.

(The semantics here are to interpret environment 'names' containing a slash as paths, rather than as environment names within `WORKON_HOME`)