### PR TITLE
revamp python virtualenv helper internals

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,6 +41,6 @@ Suggests:
     callr,
     rmarkdown
 LinkingTo: Rcpp
-RoxygenNote: 6.1.0
+RoxygenNote: 6.1.1
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr

--- a/R/pip.R
+++ b/R/pip.R
@@ -1,0 +1,55 @@
+pip_version <- function(pip) {
+
+  # if we don't have pip, just return a placeholder version
+  if (!file.exists(pip))
+    return(numeric_version("0.0"))
+
+  # otherwise, ask pip what version it is
+  output <- system2(pip, "--version", stdout = TRUE)
+  parts <- strsplit(output, "\\s+")[[1]]
+  version <- parts[[2]]
+  numeric_version(version)
+
+}
+
+
+pip_install <- function(pip, packages, ignore_installed = TRUE) {
+
+  # notify user
+  msg <- paste("Installing", paste(shQuote(packages), collapse = ", "), "...")
+  writeLines(msg)
+
+  # construct command line arguments
+  args <- c("install", "--upgrade")
+  if (ignore_installed)
+    args <- c(args, "--ignore-installed")
+  args <- c(args, packages)
+
+  # run it
+  result <- system2(pip, args)
+  if (result != 0L) {
+    msg <- paste("Error installing package(s):", paste(shQuote(packages), collapse = ", "))
+    stop(msg, call. = FALSE)
+  }
+
+  invisible(packages)
+
+}
+
+pip_uninstall <- function(pip, packages) {
+
+  # notify user
+  msg <- paste("Removing", paste(shQuote(packages), collapse = ", "), "...")
+  writeLines(msg)
+
+  # construct command line arguments
+  args <- c("uninstall", "--yes", packages)
+  result <- system2(pip, args)
+  if (result != 0L) {
+    msg <- paste("Error removing package(s):", paste(shQuote(packages), collapse = ", "))
+    stop(msg, call. = FALSE)
+  }
+
+  packages
+
+}

--- a/R/pip.R
+++ b/R/pip.R
@@ -15,10 +15,6 @@ pip_version <- function(pip) {
 
 pip_install <- function(pip, packages, ignore_installed = TRUE) {
 
-  # notify user
-  msg <- paste("Installing", paste(shQuote(packages), collapse = ", "), "...")
-  writeLines(msg)
-
   # construct command line arguments
   args <- c("install", "--upgrade")
   if (ignore_installed)
@@ -28,7 +24,8 @@ pip_install <- function(pip, packages, ignore_installed = TRUE) {
   # run it
   result <- system2(pip, args)
   if (result != 0L) {
-    msg <- paste("Error installing package(s):", paste(shQuote(packages), collapse = ", "))
+    pkglist <- paste(shQuote(packages), collapse = ", ")
+    msg <- paste("Error installing package(s):", pkglist)
     stop(msg, call. = FALSE)
   }
 
@@ -38,15 +35,12 @@ pip_install <- function(pip, packages, ignore_installed = TRUE) {
 
 pip_uninstall <- function(pip, packages) {
 
-  # notify user
-  msg <- paste("Removing", paste(shQuote(packages), collapse = ", "), "...")
-  writeLines(msg)
-
-  # construct command line arguments
+  # run it
   args <- c("uninstall", "--yes", packages)
   result <- system2(pip, args)
   if (result != 0L) {
-    msg <- paste("Error removing package(s):", paste(shQuote(packages), collapse = ", "))
+    pkglist <- paste(shQuote(packages), collapse = ", ")
+    msg <- paste("Error removing package(s):", pkglist)
     stop(msg, call. = FALSE)
   }
 

--- a/R/python-tools.R
+++ b/R/python-tools.R
@@ -1,0 +1,30 @@
+python_has_module <- function(python, module) {
+  code <- paste("import", module)
+  args <- c("-E", "-c", shQuote(code))
+  status <- system2(python, args, stdout = FALSE, stderr = FALSE)
+  status == 0L
+}
+
+python_version <- function(python) {
+  code <- "import platform; print(platform.python_version())"
+  args <- c("-E", "-c", shQuote(code))
+  output <- system2(python, args, stdout = TRUE)
+  numeric_version(output)
+}
+
+python_module_version <- function(python, module) {
+  fmt <- "import %1$s; print(%1$s.__version__)"
+  code <- sprintf(fmt, module)
+  args <- c("-E", "-c", shQuote(code))
+  output <- system2(python, args, stdout = TRUE)
+  numeric_version(output)
+}
+
+python_unix_binary <- function(bin) {
+  locations <- file.path(c("/usr/bin", "/usr/local/bin", path.expand("~/.local/bin")), bin)
+  locations <- locations[file.exists(locations)]
+  if (length(locations) > 0)
+    locations[[1]]
+  else
+    NULL
+}

--- a/R/virtualenv.R
+++ b/R/virtualenv.R
@@ -204,7 +204,7 @@ virtualenv_default_python <- function(python) {
   if (!is.null(python))
     return(python)
 
-  config <- py_config()
+  config <- py_discover_config()
   normalizePath(config$python, winslash = "/")
 }
 

--- a/R/virtualenv.R
+++ b/R/virtualenv.R
@@ -1,9 +1,6 @@
-
-
-
-#' Interface to virtualenv
+#' Interface to Python Virtual Environments
 #'
-#' R functions for managing Python [virtual environments](https://virtualenv.pypa.io/en/stable/)
+#' R functions for managing Python [virtual environments](https://virtualenv.pypa.io/en/stable/).
 #'
 #' @details
 #' Virtual environments are by default located at `~/.virtualenvs`. You can change this
@@ -12,297 +9,228 @@
 #' Virtual environment functions are not supported on Windows (the use of
 #' [conda environments][conda-tools] is recommended on Windows).
 #'
-#' @param envname Name of virtual environment
-#' @param packages Character vector with package names to install or remove.
-#' @param ignore_installed Ignore any previously installed versions of packages
-#' @param confirm Confirm before removing packages or virtual environments
-#'
-#' @return `virtualenv_list()` returns a chracter vector with the names
-#'  of available virtual environments. `virtualenv_root()` returns the
-#'  root directory for virtual environments.
-#'
+#' @param envname The name of, or path to, a Python virtual environment.
+#' @param packages A character vector with package names to install or remove.
+#' @param ignore_installed Boolean; ignore previously-installed versions of the
+#'   requested packages?
+#' @param confirm Boolean; confirm before removing packages or virtual
+#'   environments?
+#' @param python The path to a Python interpreter. When `NULL`, the active
+#'   Python interpreter associated with the current session will be used.
 #'
 #' @name virtualenv-tools
+NULL
+
+
+
+#' @inheritParams virtualenv-tools
+#' @rdname virtualenv-tools
 #' @export
 virtualenv_list <- function() {
-
-  config <- virtualenv_config()
-
-  if (utils::file_test("-d", config$root)) {
-    list.files(config$root)
-  } else {
+  root <- virtualenv_root()
+  if (file.exists(virtualenv_root()))
+    list.files(root)
+  else
     character()
-  }
 }
 
+#' @inheritParams virtualenv-tools
+#' @rdname virtualenv-tools
+#' @export
+virtualenv_create <- function(envname, python = NULL) {
+  path <- virtualenv_path(envname)
+
+  # check and see if we already have a virtual environment
+  if (virtualenv_exists(path)) {
+    writeLines(paste("virtualenv:", path))
+    return(invisible(path))
+  }
+
+  # if the user hasn't requested a particular Python binary,
+  # infer from the currently active Python session
+  python <- virtualenv_default_python(python)
+
+  # choose appropriate tool for creating virtualenv
+  module <- virtualenv_module(python)
+  args <- c("-m", module, "--system-site-packages", path.expand(path))
+  result <- system2(python, shQuote(args))
+  if (result != 0L) {
+    fmt <- "Error creating virtual environment '%s' [error code %d]"
+    msg <- sprintf(fmt, envname, result)
+    stop(msg, call. = FALSE)
+  }
+
+  invisible(path)
+}
+
+
+
+#' @inheritParams virtualenv-tools
+#' @rdname virtualenv-tools
+#' @export
+virtualenv_install <- function(envname, packages, ignore_installed = TRUE) {
+  path <- virtualenv_create(envname)
+
+  # ensure we have a recent version of pip installed
+  pip <- virtualenv_pip(path)
+  if (pip_version(pip) < "8.1") {
+    pip_install(pip, "pip")
+    pip_install(pip, "wheel")
+    pip_install(pip, "setuptools")
+  }
+
+  # now install the requested package
+  pip_install(pip, packages, ignore_installed = ignore_installed)
+}
+
+
+
+#' @inheritParams virtualenv-tools
+#' @rdname virtualenv-tools
+#' @export
+virtualenv_remove <- function(envname, packages = NULL, confirm = interactive()) {
+  path <- virtualenv_path(envname)
+
+  # packages = NULL means remove the entire virtualenv
+  if (is.null(packages)) {
+
+    if (confirm) {
+      prompt <- sprintf("Remove virtualenv at %s? [Y/n]: ", path)
+      response <- readline(prompt = prompt)
+      if (tolower(response) != "y") {
+        writeLines("Operation aborted.")
+        return(invisible(NULL))
+      }
+    }
+
+    unlink(path, recursive = TRUE)
+    return(invisible(NULL))
+
+  }
+
+  # otherwise, remove the requested packages
+  if (confirm) {
+    fmt <- "Remove %s from %s? [Y/n]: "
+    prompt <- sprintf(fmt, paste(packages, sep = ", "), path)
+    response <- readline(prompt = prompt)
+    if (tolower(response) != "y") {
+      writeLines("Operation aborted.")
+      return(invisible(NULL))
+    }
+  }
+
+  pip <- virtualenv_pip(path)
+  pip_uninstall(pip, packages)
+  invisible(NULL)
+}
+
+
+
+#' @inheritParams virtualenv-tools
 #' @rdname virtualenv-tools
 #' @export
 virtualenv_root <- function() {
   Sys.getenv("WORKON_HOME", unset = "~/.virtualenvs")
 }
 
-#' @rdname virtualenv-tools
-#' @export
-virtualenv_create <- function(envname) {
-
-  config <- virtualenv_config()
-
-  virtualenv_path <- file.path(config$root, envname)
-  virtualenv_bin <- function(bin) path.expand(file.path(virtualenv_path, "bin", bin))
-
-  if (!utils::file_test("-d", virtualenv_path) || !file.exists(virtualenv_bin("activate"))) {
-    cat("Creating virtualenv at ", virtualenv_path, "\n")
-    result <- system2(config$virtualenv, shQuote(c(
-      "--system-site-packages",
-      "--python", config$python,
-      path.expand(virtualenv_path)))
-    )
-    if (result != 0L)
-      stop("Error ", result, " occurred creating virtualenv at ", virtualenv_path,
-           call. = FALSE)
-  } else {
-    cat("virtualenv:", virtualenv_path, "\n")
-  }
-
-  invisible(NULL)
-}
-
-#' @rdname virtualenv-tools
-#' @export
-virtualenv_install <- function(envname, packages, ignore_installed = FALSE) {
-
-  virtualenv_create(envname)
-
-  config <- virtualenv_config()
-  virtualenv_path <- file.path(config$root, envname)
-  virtualenv_bin <- function(bin) path.expand(file.path(virtualenv_path, "bin", bin))
-
-  # see what version of pip is installed (assume 0.1 on error)
-  installed_pip_version <- function() {
-    tryCatch({
-      # check existing version
-      cmd <- sprintf("%ssource %s && %s --version%s",
-                     ifelse(is_osx(), "", "/bin/bash -c \""),
-                     shQuote(path.expand(virtualenv_bin("activate"))),
-                     shQuote(path.expand(virtualenv_bin(config$pip_version))),
-                     ifelse(is_osx(), "", "\""))
-      result <- system(cmd, intern = TRUE, ignore.stderr = TRUE)
-
-      # parse result
-      matches <- regexec("^[^ ]+\\s+(\\d+)\\.(\\d+).*$", result)
-      matches <- regmatches(result, matches)[[1]]
-
-      # return as R numeric version
-      numeric_version(paste(matches[[2]], matches[[3]], sep = "."))
-
-    }, error = function(e) {
-      warning("Error occurred checking pip version: ", e$message)
-      numeric_version("0.1")
-    })
-  }
-
-  # function to call pip within virtual env
-  pip_install <- function(packages, message, ignore_installed_package) {
-    cmd <- sprintf("%ssource %s && %s install %s --upgrade %s%s",
-                   ifelse(is_osx(), "", "/bin/bash -c \""),
-                   shQuote(path.expand(virtualenv_bin("activate"))),
-                   shQuote(path.expand(virtualenv_bin(config$pip_version))),
-                   ifelse(ignore_installed_package, "--ignore-installed", ""),
-                   paste(shQuote(packages), collapse = " "),
-                   ifelse(is_osx(), "", "\""))
-    cat(message, "...\n")
-    result <- system(cmd)
-    if (result != 0L)
-      stop("Error ", result, " occurred installing packages", call. = FALSE)
-    invisible(NULL)
-  }
-
-  # upgrade pip and related utilities if its older than 8.1
-  if (installed_pip_version() < "8.1") {
-    pip_install("pip", "Upgrading pip", TRUE)
-    pip_install("wheel", "Upgrading wheel", TRUE)
-    pip_install("setuptools", "Upgrading setuptools", TRUE)
-  }
-
-  # install packages
-  pip_install(packages, "Installing packages", ignore_installed)
-}
 
 
-#' @rdname virtualenv-tools
-#' @export
-virtualenv_remove <- function(envname, packages = NULL, confirm = interactive()) {
-
-  config <- virtualenv_config()
-  virtualenv_path <- file.path(config$root, envname)
-  virtualenv_bin <- function(bin) path.expand(file.path(virtualenv_path, "bin", bin))
-
-  # packages = NULL means remove the entire virtualenv
-  if (is.null(packages)) {
-
-    if (confirm) {
-      prompt <- readline(sprintf("Remove virtualenv at %s? [Y/n]: ", virtualenv_path))
-      if (nzchar(prompt) && tolower(prompt) != 'y')
-        return(invisible(NULL))
-    }
-
-    unlink(virtualenv_path, recursive = TRUE)
-
-  } else {
-
-    # function to call pip within virtual env
-    pip_uninstall <- function(packages) {
-      cmd <- sprintf("%ssource %s && %s uninstall --yes %s%s",
-                     ifelse(is_osx(), "", "/bin/bash -c \""),
-                     shQuote(path.expand(virtualenv_bin("activate"))),
-                     shQuote(path.expand(virtualenv_bin(config$pip_version))),
-                     paste(shQuote(packages), collapse = " "),
-                     ifelse(is_osx(), "", "\""))
-      cat(sprintf("Uninstalling %s", paste(packages, sep = ", ")), "...\n")
-      result <- system(cmd)
-      if (result != 0L)
-        stop("Error ", result, " occurred removing packages", call. = FALSE)
-    }
-
-    if (confirm) {
-      prompt <- readline(sprintf("Remove %s from virtualenv %s? [Y/n]: ",
-                                 paste(packages, sep = ", "), virtualenv_path))
-      if (nzchar(prompt) && tolower(prompt) != 'y')
-        return(invisible(NULL))
-    }
-
-    pip_uninstall(packages)
-
-  }
-
-  invisible(NULL)
-}
-
+#' @inheritParams virtualenv-tools
 #' @rdname virtualenv-tools
 #' @export
 virtualenv_python <- function(envname) {
-  config <- virtualenv_config()
-  virtualenv_path <- file.path(config$root, envname)
-  if (utils::file_test("-d", virtualenv_path))
-    path.expand(file.path(virtualenv_path, "bin", "python"))
+  path.expand(file.path(virtualenv_path(envname), "bin/python"))
+}
+
+
+
+virtualenv_exists <- function(envname) {
+  path <- virtualenv_path(envname)
+
+  if (!utils::file_test("-d", path))
+    return(FALSE)
+
+  if (!file.exists(file.path(path, "bin/activate")))
+    return(FALSE)
+
+  TRUE
+}
+
+
+
+virtualenv_path <- function(envname) {
+
+  if (grepl("[/\\]", envname)) {
+    if (file.exists(envname))
+      envname <- normalizePath(envname, winslash = "/")
+    return(envname)
+  }
+
+  file.path(virtualenv_root(), envname)
+
+}
+
+
+virtualenv_pip <- function(envname) {
+  file.path(virtualenv_path(envname), "bin/pip")
+}
+
+
+
+virtualenv_default_python <- function(python) {
+
+  if (!is.null(python))
+    return(python)
+
+  config <- py_config()
+  normalizePath(config$python, winslash = "/")
+}
+
+
+
+virtualenv_module <- function(python) {
+
+  py_version <- python_version(python)
+  modules <- if (py_version < 3)
+    c("virtualenv")
   else
-    stop("virtualenv ", envname, " not found")
+    c("venv", "virtualenv")
+
+  for (module in modules)
+    if (python_has_module(python, module))
+      return(module)
+
+  # provide some diagnostics for the user
+  commands <- new_stack()
+  commands$push("tools for interacting with Python virtual environments are not installed.")
+  commands$push("")
+
+  # if we don't have pip, recommend its installation
+  if (!python_has_module(python, "pip")) {
+    commands$push("Install pip with:")
+    if (python_has_module(python, "easy_install")) {
+      commands$push(paste("$", python, "-m easy_install --upgrade --user pip"))
+    } else if (is_ubuntu() && dirname(python) == "/usr/bin") {
+      package <- if (py_version < 3) "python-virtualenv" else "python3-venv"
+      commands$push(paste("$ sudo apt-get install", package))
+    } else {
+      commands$push("$ curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py")
+      commands$push(paste("$", python, "get-pip.py"))
+    }
+    commands$push("")
+  }
+
+  # then, recommend installation of virtualenv or ven with pip
+  commands$push(paste("Install", modules[[1]], "with:"))
+  commands$push(paste("$", python, "-m pip install --upgrade --user", module))
+
+  # report to user
+  message <- paste(commands$data(), collapse = "\n")
+  stop(message, call. = FALSE)
+
 }
 
 
-virtualenv_config <- function() {
-
-  # not supported on windows
-  if (is_windows()) {
-    stop("virtualenv functions are not supported on windows (try conda environments instead)",
-         call. = FALSE)
-  }
-
-  # find system python binary
-  pyver <- ""
-  python <- python_unix_binary("python")
-  if (is.null(python)) {
-    # try for python3 if we are on linux
-    if (is_linux()) {
-      python <- python_unix_binary("python3")
-      if (is.null(python))
-        stop("Unable to locate Python on this system.", call. = FALSE)
-      pyver <- "3"
-    }
-  }
-
-  # find required binaries
-  pip <- python_unix_binary(paste0("pip", pyver))
-  have_pip <- !is.null(pip)
-  virtualenv <- python_unix_binary("virtualenv")
-  have_virtualenv <- !is.null(virtualenv)
-
-  # validate that we have the required tools for the method
-  install_commands <- NULL
-  if (is_osx()) {
-    if (!have_pip)
-      install_commands <- c(install_commands, "$ sudo /usr/bin/easy_install pip")
-    if (!have_virtualenv) {
-      if (is.null(pip))
-        pip <- "/usr/local/bin/pip"
-      install_commands <- c(install_commands, sprintf("$ sudo %s install --upgrade virtualenv", pip))
-    }
-    if (!is.null(install_commands))
-      install_commands <- paste(install_commands, collapse = "\n")
-  } else if (is_ubuntu()) {
-    if (!have_pip) {
-      install_commands <- c(install_commands, paste0("$ sudo apt-get install python", pyver ,"-pip"))
-      pip <- paste0("/usr/bin/pip", pyver)
-    }
-    if (!have_virtualenv) {
-      if (identical(pyver, "3"))
-        install_commands <- c(install_commands, paste("$ sudo", pip, "install virtualenv"))
-      else
-        install_commands <- c(install_commands, "$ sudo apt-get install python-virtualenv")
-    }
-    if (!is.null(install_commands))
-      install_commands <- paste(install_commands, collapse = "\n")
-  } else {
-    if (!have_pip)
-      install_commands <- c(install_commands, "pip")
-    if (!have_virtualenv)
-      install_commands <- c(install_commands, "virtualenv")
-    if (!is.null(install_commands)) {
-      install_commands <- paste("Please install the following Python packages before proceeding:",
-                                paste(install_commands, collapse = ", "))
-    }
-  }
-  if (!is.null(install_commands)) {
-
-    # if these are terminal commands then add special preface
-    if (grepl("^\\$ ", install_commands)) {
-      install_commands <- paste0(
-        "Execute the following at a terminal to install the prerequisites:\n\n",
-        install_commands
-      )
-    }
-
-    stop("Prerequisites for using Python virtualenvs not available.\n\n",
-         install_commands, "\n\n", call. = FALSE)
-  }
-
-  # return config
-  list(
-    python = python,
-    virtualenv = virtualenv,
-    pip_version = ifelse(python_version(python) >= "3.0", "pip3", "pip"),
-    root = virtualenv_root()
-  )
-}
-
-python_unix_binary <- function(bin) {
-  locations <- file.path(c("/usr/bin", "/usr/local/bin", path.expand("~/.local/bin")), bin)
-  locations <- locations[file.exists(locations)]
-  if (length(locations) > 0)
-    locations[[1]]
-  else
-    NULL
-}
-
-python_version <- function(python) {
-
-  # check for the version
-  result <- system2(python, "--version", stdout = TRUE, stderr = TRUE)
-
-  # check for error
-  error_status <- attr(result, "status")
-  if (!is.null(error_status))
-    stop("Error ", error_status, " occurred while checking for python version", call. = FALSE)
-
-  # parse out the major and minor version numbers
-  matches <- regexec("^[^ ]+\\s+(\\d+)\\.(\\d+).*$", result)
-  matches <- regmatches(result, matches)[[1]]
-  if (length(matches) != 3)
-    stop("Unable to parse Python version '", result[[1]], "'", call. = FALSE)
-
-  # return as R numeric version
-  numeric_version(paste(matches[[2]], matches[[3]], sep = "."))
-}
 
 is_python_virtualenv <- function(dir) {
 

--- a/man/virtualenv-tools.Rd
+++ b/man/virtualenv-tools.Rd
@@ -14,7 +14,7 @@ virtualenv_list()
 
 virtualenv_create(envname, python = NULL)
 
-virtualenv_install(envname, packages, ignored_installed = FALSE)
+virtualenv_install(envname, packages, ignore_installed = TRUE)
 
 virtualenv_remove(envname, packages = NULL, confirm = interactive())
 
@@ -23,22 +23,32 @@ virtualenv_root()
 virtualenv_python(envname)
 }
 \arguments{
-\item{envname}{The name of, or path to, a Python virtual environment.}
+\item{envname}{The name of, or path to, a Python virtual environment. If
+this name contains any slashes, the name will be interpreted as a path;
+if the name does not contain slashes, it will be treated as a virtual
+environment within \code{\link[=virtualenv_root]{virtualenv_root()}}.}
+
+\item{python}{The path to a Python interpreter, to be used with the created
+virtual environment. When \code{NULL}, the Python interpreter associated with
+the current session will be used.}
 
 \item{packages}{A character vector with package names to install or remove.}
 
+\item{ignore_installed}{Boolean; ignore previously-installed versions of the
+requested packages? (This should normally be \code{TRUE}, so that pre-installed
+packages available in the site libraries are ignored and new copies are
+made available in the virtual environment.)}
+
 \item{confirm}{Boolean; confirm before removing packages or virtual
 environments?}
-
-\item{ignore_installed}{Boolean; ignore previously-installed versions of the
-requested packages?}
 }
 \description{
 R functions for managing Python \href{https://virtualenv.pypa.io/en/stable/}{virtual environments}.
 }
 \details{
-Virtual environments are by default located at \code{~/.virtualenvs}. You can change this
-behavior by defining the \code{WORKON_HOME} environment variable.
+Virtual environments are by default located at \code{~/.virtualenvs} (accessed
+with the \code{\link[=virtualenv_root]{virtualenv_root()}} function). You can change the default location
+by defining defining the \code{WORKON_HOME} environment variable.
 
 Virtual environment functions are not supported on Windows (the use of
 \link[=conda-tools]{conda environments} is recommended on Windows).

--- a/man/virtualenv-tools.Rd
+++ b/man/virtualenv-tools.Rd
@@ -3,41 +3,38 @@
 \name{virtualenv-tools}
 \alias{virtualenv-tools}
 \alias{virtualenv_list}
-\alias{virtualenv_root}
 \alias{virtualenv_create}
 \alias{virtualenv_install}
 \alias{virtualenv_remove}
+\alias{virtualenv_root}
 \alias{virtualenv_python}
-\title{Interface to virtualenv}
+\title{Interface to Python Virtual Environments}
 \usage{
 virtualenv_list()
 
-virtualenv_root()
+virtualenv_create(envname, python = NULL)
 
-virtualenv_create(envname)
-
-virtualenv_install(envname, packages, ignore_installed = FALSE)
+virtualenv_install(envname, packages, ignored_installed = FALSE)
 
 virtualenv_remove(envname, packages = NULL, confirm = interactive())
+
+virtualenv_root()
 
 virtualenv_python(envname)
 }
 \arguments{
-\item{envname}{Name of virtual environment}
+\item{envname}{The name of, or path to, a Python virtual environment.}
 
-\item{packages}{Character vector with package names to install or remove.}
+\item{packages}{A character vector with package names to install or remove.}
 
-\item{ignore_installed}{Ignore any previously installed versions of packages}
+\item{confirm}{Boolean; confirm before removing packages or virtual
+environments?}
 
-\item{confirm}{Confirm before removing packages or virtual environments}
-}
-\value{
-\code{virtualenv_list()} returns a chracter vector with the names
-of available virtual environments. \code{virtualenv_root()} returns the
-root directory for virtual environments.
+\item{ignore_installed}{Boolean; ignore previously-installed versions of the
+requested packages?}
 }
 \description{
-R functions for managing Python \href{https://virtualenv.pypa.io/en/stable/}{virtual environments}
+R functions for managing Python \href{https://virtualenv.pypa.io/en/stable/}{virtual environments}.
 }
 \details{
 Virtual environments are by default located at \code{~/.virtualenvs}. You can change this


### PR DESCRIPTION
This PR revamps the internals around how Python virtual environments are created + used in reticulate.

Primary goals here:

1. Refactor the existing code, as it was getting a bit difficult to manage;
2. Create a separate `pip` interface that can be used internally for installing / removing packages,
3. Better handle the nuances between `virtualenv`, `venv`, and where they might (might not) be available for different Python installations.

One major change this PR makes: we now attempt to use `virtualenv` and `venv` as modules whenever possible. This avoids some potential ambiguities -- for example, when one sees a `virtualenv` executable on the PATH, it's hard to ascertain which Python installation it's actually associated with, and in general it's safer to use Python x.y.z to create a virtual environment associated with Python version x.y.z. This advice comes from https://docs.python.org/3/library/venv.html:

> Note The pyvenv script has been deprecated as of Python 3.6 in favor of using python3 -m venv to help prevent any potential confusion as to which Python interpreter a virtual environment will be based on.

We still use the `pip` binary as needed, though -- since virtual environments always create this as a companion to the regular Python binary + other infrastructure.
 