### PR TITLE
implement auto-printing of matplotlib plots

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -120,10 +120,20 @@ py_compile_eval <- function(code) {
   compiled <- builtins$compile(code, '<string>', 'single')
   output <- py_capture_output(builtins$eval(compiled, globals, locals))
 
+  # save the value that was produced
+  .globals$py_last_value <- py_last_value()
+
   # py_capture_output can append an extra trailing newline, so remove it
   if (grepl("\n{2,}$", output))
     output <- sub("\n$", "", output)
 
   # and return
   invisible(output)
+}
+
+py_last_value <- function() {
+  tryCatch(
+    py_eval("_", convert = FALSE),
+    error = function(e) r_to_py(NULL)
+  )
 }

--- a/tests/testthat/resources/eng-reticulate-example.Rmd
+++ b/tests/testthat/resources/eng-reticulate-example.Rmd
@@ -4,6 +4,7 @@ title: "Using reticulate's Python Engine with knitr"
 
 ```{r setup, include = FALSE}
 library(reticulate)
+reticulate::use_python("/usr/local/bin/python3", required = TRUE)
 knitr::knit_engines$set(python = eng_python)
 ```
 
@@ -122,4 +123,12 @@ Output from bare statements should also be printed.
 ```{python}
 "Hello, world!"
 [x for x in range(10)]
+```
+
+Expressions that generate plots should be shown.
+
+```{python}
+import numpy as np, pandas as pd
+a = np.random.normal(size=1000)
+pd.Series(a).hist()
 ```


### PR DESCRIPTION
This PR implements auto-printing of matplotlib plots, when the last statement within a chunk produces a matplotlib object of some kind. Works in the IDE as well as in rendered documents.

<img width="622" alt="screen shot 2019-01-16 at 3 35 13 pm" src="https://user-images.githubusercontent.com/1976582/51285666-995f4780-19a4-11e9-9372-d29ec1b650d7.png">

<img width="598" alt="screen shot 2019-01-16 at 3 35 28 pm" src="https://user-images.githubusercontent.com/1976582/51285677-a0865580-19a4-11e9-81b1-18f2db292dd8.png">


Closes https://github.com/rstudio/rstudio/issues/4167.