### PR TITLE
parse function arguments from docs when needed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 
 Install the development version with: `devtools::install_github("rstudio/reticulate")`
 
+- The reticulate function help handler now returns function arguments for
+  Python builtin functions.
+
 - Top-level Python statements can now include leading indent when submitted
   with `repl_python()`.
 

--- a/R/help.R
+++ b/R/help.R
@@ -269,17 +269,19 @@ help_formals_handler.python.builtin.object <- function(topic, source) {
   # for builtin functions, we need to try parsing the help documentation
   # (often, the first line provides a function signature)
   if (inherits(target, "python.builtin.builtin_function_or_method")) {
-    docs <- py_get_attr(target, "__doc__")
-    if (inherits(docs, "python.builtin.object"))
-      docs <- py_to_r(docs)
-    pieces <- strsplit(docs, "\n", fixed = TRUE)[[1]]
-    first <- pieces[[1]]
-    munged <- paste(gsub("[^(]*[(]", "function (", first), "{}")
-    parsed <- parse(text = munged)[[1]]
-    output <- list(
-      formals = names(parsed[[2]]),
-      helpHandler = "reticulate:::help_handler"
-    )
+    output <- tryCatch({
+      docs <- py_get_attr(target, "__doc__")
+      if (inherits(docs, "python.builtin.object"))
+        docs <- py_to_r(docs)
+      pieces <- strsplit(docs, "\n", fixed = TRUE)[[1]]
+      first <- pieces[[1]]
+      munged <- paste(gsub("[^(]*[(]", "function (", first), "{}")
+      parsed <- parse(text = munged)[[1]]
+      list(
+        formals = names(parsed[[2]]),
+        helpHandler = "reticulate:::help_handler"
+      )
+    }, error = function(e) NULL)
     return(output)
   }
 

--- a/tests/testthat/test-help-handlers.R
+++ b/tests/testthat/test-help-handlers.R
@@ -1,5 +1,12 @@
 context("helper handlers")
 
+test_that("Function arguments from builtin functions can be extracted", {
+  os <- import("os")
+  output <- help_formals_handler.python.builtin.object("chmod", os)
+  expected <- list(formals = c("path", "mode"), helpHandler = "reticulate:::help_handler")
+  expect_identical(output, expected)
+})
+
 test_that("Documentations in Sphinx style can be extracted correctly for help handlers", {
   skip_if_no_docutils()
 


### PR DESCRIPTION
This PR allows us to extract the arguments associated with Python builtin functions, by parsing the provided function signature. (For most Python builtin functions, the first line in the documentation gives the prototype of the function)

This code is a port of the code currently used in RStudio for autocompletion so this is just syncing up the two pieces that diverged a bit over time.