### PR TITLE
avoid use of local dict (#437)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: reticulate
 Type: Package
 Title: Interface to 'Python'
-Version: 1.10.0.9004
+Version: 1.10.0.9005
 Authors@R: c(
   person("JJ", "Allaire", role = c("aut", "cre"), email = "jj@rstudio.com"),
   person("Kevin", "Ushey", role = c("aut"),

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -1437,10 +1437,9 @@ void py_activate_virtualenv(const std::string& script)
   PyObject* main = PyImport_AddModule("__main__");
   PyObject* mainDict = PyModule_GetDict(main);
 
-  // create local dict with __file__
-  PyObjectPtr localDict(PyDict_New());
+  // inject __file__
   PyObjectPtr file(as_python_str(script));
-  int res = PyDict_SetItemString(localDict, "__file__", file);
+  int res = PyDict_SetItemString(mainDict, "__file__", file);
   if (res != 0)
     stop(py_fetch_error());
 
@@ -1452,7 +1451,7 @@ void py_activate_virtualenv(const std::string& script)
                    (std::istreambuf_iterator<char>()));
 
   // run string
-  PyObjectPtr runRes(PyRun_StringFlags(code.c_str(), Py_file_input, mainDict, localDict, NULL));
+  PyObjectPtr runRes(PyRun_StringFlags(code.c_str(), Py_file_input, mainDict, NULL, NULL));
   if (runRes.is_null())
     stop(py_fetch_error());
 }


### PR DESCRIPTION
Fixes https://github.com/rstudio/reticulate/issues/437. For whatever reason, the use of a local dict causes some issues with name resolution when attempting to source `activate_this.py`.