### PR TITLE
modify PATH before discovering Python config

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -294,9 +294,7 @@ python_environments <- function(env_dirs, required_module = NULL) {
     envs
 }
 
-
-
-python_config <- function(python, required_module, python_versions, forced = NULL) {
+python_munge_path <- function(python) {
 
   # add the python bin dir to the PATH (so that any execution of python from
   # within the interpreter, from a system call, or from within a terminal
@@ -326,15 +324,15 @@ python_config <- function(python, required_module, python_versions, forced = NUL
       python_dirs <- c(python_dirs, normalizePath(python_library_bin))
   }
 
-  # restore the PATH when we're done if we're not explicitly initializing Python
-  # (need to differentiate between a plain config discovery and true init)
-  PATH <- Sys.getenv("PATH")
-  if (!.globals$py_initializing)
-    on.exit(Sys.setenv(PATH = PATH), add = TRUE)
+  path_prepend(python_dirs)
 
-  Sys.setenv(PATH = paste(paste(python_dirs, collapse =  .Platform$path.sep),
-                          PATH,
-                          sep = .Platform$path.sep))
+}
+
+python_config <- function(python, required_module, python_versions, forced = NULL) {
+
+  # update and restore PATH when done
+  oldpath <- python_munge_path(python)
+  on.exit(Sys.setenv(PATH = oldpath), add = TRUE)
 
   # collect configuration information
   if (!is.null(required_module)) {

--- a/R/config.R
+++ b/R/config.R
@@ -305,7 +305,8 @@ python_config <- function(python, required_module, python_versions, forced = NUL
   # we do this up-front in python_config as otherwise attempts to discover
   # and load numpy can fail, especially on Windows
   # https://github.com/rstudio/reticulate/issues/367
-  python_home <- python_dirs <- dirname(python)
+  python_home <- dirname(python)
+  python_dirs <- c(normalizePath(python_home))
   if (is_windows()) {
 
     # include the Scripts path, as well

--- a/R/package.R
+++ b/R/package.R
@@ -17,6 +17,7 @@ NULL
 .globals <- new.env(parent = emptyenv())
 .globals$required_python_version <- NULL
 .globals$use_python_versions <- c()
+.globals$py_initializing <- FALSE
 .globals$py_config <- NULL
 .globals$delay_load_module <- NULL
 .globals$delay_load_environment <- NULL
@@ -32,16 +33,22 @@ is_python_initialized <- function() {
 
 
 ensure_python_initialized <- function(required_module = NULL) {
+
   if (!is_python_initialized()) {
-     # give delay load modules priority
-     use_environment <- NULL
-     if (!is.null(.globals$delay_load_module)) {
-        required_module <- .globals$delay_load_module
-        use_environment <- .globals$delay_load_environment
-        .globals$delay_load_module <- NULL # one shot
-        .globals$delay_load_environment <- NULL
-        .globals$delay_load_priority <- 0
-     }
+    # give delay load modules priority
+    use_environment <- NULL
+    if (!is.null(.globals$delay_load_module)) {
+      required_module <- .globals$delay_load_module
+      use_environment <- .globals$delay_load_environment
+      .globals$delay_load_module <- NULL # one shot
+      .globals$delay_load_environment <- NULL
+      .globals$delay_load_priority <- 0
+    }
+
+    # mark as initializing (so we know to save any PATH changes)
+    .globals$py_initializing <- TRUE
+    on.exit(.globals$py_initializing <- FALSE, add = TRUE)
+
     .globals$py_config <- initialize_python(required_module, use_environment)
 
     # generate 'R' helper object
@@ -78,42 +85,12 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
   else
     numpy_load_error <- ""
 
-
-  # add the python bin dir to the PATH (so that any execution of python from
-  # within the interpreter, from a system call, or from within a terminal
-  # hosted within the front end will use the same version of python.
-  python_home <- dirname(config$python)
-  python_dirs <- c(normalizePath(python_home))
-
-  if (is_windows()) {
-
-    # include the Scripts path, as well
-    python_scripts <- file.path(python_home, "Scripts")
-    if (file.exists(python_scripts))
-      python_dirs <- c(python_dirs, normalizePath(python_scripts))
-
-    # we saw some crashes occurring when Python modules attempted to load
-    # dynamic libraries at runtime; e.g.
-    #
-    #   Intel MKL FATAL ERROR: Cannot load mkl_intel_thread.dll
-    #
-    # we work around this by putting the associated binary directory
-    # on the PATH so it can be successfully resolved
-    python_bin <- file.path(python_home, "Library/bin")
-    if (file.exists(python_bin))
-      python_dirs <- c(python_dirs, normalizePath(python_bin))
-  }
-
-  Sys.setenv(PATH = paste(paste(python_dirs, collapse =  .Platform$path.sep),
-                          Sys.getenv("PATH"),
-                          sep = .Platform$path.sep))
-
   # if we're a virtual environment then set VIRTUAL_ENV (need to
   # set this before initializing Python so that module paths are
   # set as appropriate)
   if (nzchar(config$virtualenv))
     Sys.setenv(VIRTUAL_ENV = config$virtualenv)
-  
+
   # set R_SESSION_INITIALIZED flag (used by rpy2)
   curr_session_env <- Sys.getenv("R_SESSION_INITIALIZED", unset = NA)
   Sys.setenv(R_SESSION_INITIALIZED = sprintf('PID=%s:NAME="reticulate"', Sys.getpid()))

--- a/R/package.R
+++ b/R/package.R
@@ -17,7 +17,6 @@ NULL
 .globals <- new.env(parent = emptyenv())
 .globals$required_python_version <- NULL
 .globals$use_python_versions <- c()
-.globals$py_initializing <- FALSE
 .globals$py_config <- NULL
 .globals$delay_load_module <- NULL
 .globals$delay_load_environment <- NULL
@@ -44,10 +43,6 @@ ensure_python_initialized <- function(required_module = NULL) {
       .globals$delay_load_environment <- NULL
       .globals$delay_load_priority <- 0
     }
-
-    # mark as initializing (so we know to save any PATH changes)
-    .globals$py_initializing <- TRUE
-    on.exit(.globals$py_initializing <- FALSE, add = TRUE)
 
     .globals$py_config <- initialize_python(required_module, use_environment)
 

--- a/R/package.R
+++ b/R/package.R
@@ -96,6 +96,7 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
   Sys.setenv(R_SESSION_INITIALIZED = sprintf('PID=%s:NAME="reticulate"', Sys.getpid()))
 
   # initialize python
+  oldpath <- python_munge_path(config$python)
   tryCatch(
     {
       py_initialize(config$python,
@@ -107,6 +108,7 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
                     numpy_load_error)
     },
     error = function(e) {
+      Sys.setenv(PATH = oldpath)
       if (is.na(curr_session_env)) {
         Sys.unsetenv("R_SESSION_INITIALIZED")
       } else {

--- a/R/utils.R
+++ b/R/utils.R
@@ -137,3 +137,16 @@ py_last_value <- function() {
     error = function(e) r_to_py(NULL)
   )
 }
+
+# prepends entries to the PATH (either moving or adding them as appropriate)
+# and returns the previously-set PATH
+path_prepend <- function(entries) {
+  oldpath <- Sys.getenv("PATH")
+  if (length(entries)) {
+    splat <- strsplit(oldpath, split = .Platform$path.sep, fixed = TRUE)[[1]]
+    newpath <- c(entries, setdiff(splat, path.expand(entries)))
+    Sys.setenv(PATH = paste(newpath, collapse = .Platform$path.sep))
+  }
+  oldpath
+}
+

--- a/R/utils.R
+++ b/R/utils.R
@@ -143,8 +143,9 @@ py_last_value <- function() {
 path_prepend <- function(entries) {
   oldpath <- Sys.getenv("PATH")
   if (length(entries)) {
+    entries <- path.expand(entries)
     splat <- strsplit(oldpath, split = .Platform$path.sep, fixed = TRUE)[[1]]
-    newpath <- c(entries, setdiff(splat, path.expand(entries)))
+    newpath <- c(entries, setdiff(splat, entries))
     Sys.setenv(PATH = paste(newpath, collapse = .Platform$path.sep))
   }
   oldpath

--- a/R/virtualenv.R
+++ b/R/virtualenv.R
@@ -204,7 +204,7 @@ virtualenv_default_python <- function(python) {
   if (!is.null(python))
     return(python)
 
-  config <- py_config()
+  config <- py_discover_config()
   normalizePath(config$python, winslash = "/")
 }
 

--- a/R/virtualenv.R
+++ b/R/virtualenv.R
@@ -204,7 +204,7 @@ virtualenv_default_python <- function(python) {
   if (!is.null(python))
     return(python)
 
-  config <- py_discover_config()
+  config <- py_config()
   normalizePath(config$python, winslash = "/")
 }
 

--- a/tests/testthat/test-python-knitr-engine.R
+++ b/tests/testthat/test-python-knitr-engine.R
@@ -2,6 +2,7 @@ context("knitr")
 
 test_that("An R Markdown document can be rendered using reticulate", {
   skip_on_cran()
+  skip_on_os("windows")
   skip_if_no_python()
   skip_if_not_installed("rmarkdown")
 


### PR DESCRIPTION
Closes #367.

The fix here effectively moves some of the PATH modification we do to before the attempt to discover the Python configuration + load numpy.

There's a bit of extra orchestration required here as we don't want the PATH changes to persist if we're only attempting to discover Python; ie, we only want to save the PATH changes if we're truly initializing Python. I think I got the semantics right here but it's worth double-checking that I'm doing things correctly.