### PR TITLE
allow default environment for py_install

### DIFF
--- a/R/conda.R
+++ b/R/conda.R
@@ -129,6 +129,10 @@ conda_install <- function(envname, packages, forge = TRUE, pip = FALSE, pip_igno
   # resolve conda binary
   conda <- conda_binary(conda)
 
+  # resolve envname
+  if (is.null(envname))
+    envname <- "r-reticulate"
+
   # create the environment if needed
   conda_envs <- conda_list(conda = conda)
   conda_envs <- subset(conda_envs, conda_envs$name == envname)

--- a/R/install.R
+++ b/R/install.R
@@ -8,7 +8,9 @@
 #' @inheritParams conda_install
 #'
 #' @param packages Character vector with package names to install
-#' @param envname Name of environment to install packages into
+#' @param envname The name of the environment in which packages will be installed.
+#'   When `NULL` and attempting to install into a virtual environment, the active
+#'   virtual environment (if any) will be used.
 #' @param method Installation method. By default, "auto" automatically finds a
 #'   method that will work in the local environment. Change the default to force
 #'   a specific installation method. Note that the "virtualenv" method is not
@@ -25,7 +27,7 @@
 #' @export
 py_install <- function(
   packages,
-  envname = "r-reticulate",
+  envname = NULL,
   method = c("auto", "virtualenv", "conda"),
   conda = "auto",
   ...) {

--- a/R/virtualenv.R
+++ b/R/virtualenv.R
@@ -77,11 +77,13 @@ virtualenv_create <- function(envname, python = NULL) {
 #' @inheritParams virtualenv-tools
 #' @rdname virtualenv-tools
 #' @export
-virtualenv_install <- function(envname, packages, ignore_installed = TRUE) {
+virtualenv_install <- function(envname = NULL, packages, ignore_installed = TRUE) {
 
   path <- virtualenv_path(envname)
   if (file.exists(path))
-    writeLines(paste("Using virtual environment", shQuote(envname), "..."))
+    writeLines(paste("Using virtual environment", shQuote(basename(path)), "..."))
+  else if (is.null(envname))
+    stop("virtualenv_install() called without active virtual environment")
   else
     path <- virtualenv_create(envname)
 
@@ -179,6 +181,18 @@ virtualenv_exists <- function(envname) {
 
 
 virtualenv_path <- function(envname) {
+
+  # if envname is NULL but Python is already active, then
+  # use the path to the current virtual environment
+  if (is.null(envname) && py_available()) {
+    config <- py_config()
+    if (nzchar(config$virtualenv))
+      return(config$virtualenv)
+  }
+
+  # if envname is still NULL, err
+  if (is.null(envname))
+    stop("missing environment name")
 
   # treat environment 'names' containins slashes as paths
   # rather than environments living in WORKON_HOME

--- a/R/virtualenv.R
+++ b/R/virtualenv.R
@@ -182,15 +182,18 @@ virtualenv_exists <- function(envname) {
 
 virtualenv_path <- function(envname) {
 
-  # if envname is NULL but Python is already active, then
-  # use the path to the current virtual environment
-  if (is.null(envname) && py_available()) {
-    config <- py_config()
-    if (nzchar(config$virtualenv))
-      return(config$virtualenv)
+  # if envname is NULL, check for an active renv environment
+  # and use its virtual environment if available
+  if (is.null(envname)) {
+    renv <- Sys.getenv("RENV_PROJECT", unset = NA)
+    if (!is.na(renv)) {
+      path <- file.path(renv, "renv/r-reticulate")
+      if (utils::file_test("-d", path))
+        return(path)
+    }
   }
 
-  # if envname is still NULL, err
+  # err if no env supplied here
   if (is.null(envname))
     stop("missing environment name")
 

--- a/R/virtualenv.R
+++ b/R/virtualenv.R
@@ -219,7 +219,15 @@ virtualenv_default_python <- function(python) {
     return(python)
 
   config <- py_discover_config()
-  normalizePath(config$python, winslash = "/")
+  if (!nzchar(config$virtualenv))
+    return(normalizePath(config$python, winslash = "/"))
+
+  home <- strsplit(config$pythonhome, .Platform$path.sep, fixed = TRUE)[[1]][[1]]
+  binary <- if (is_windows())
+    file.path(home, "Scripts/python.exe")
+  else
+    file.path(home, "bin/python")
+
 }
 
 

--- a/man/py_install.Rd
+++ b/man/py_install.Rd
@@ -4,13 +4,15 @@
 \alias{py_install}
 \title{Install Python packages}
 \usage{
-py_install(packages, envname = "r-reticulate", method = c("auto",
-  "virtualenv", "conda"), conda = "auto", ...)
+py_install(packages, envname = NULL, method = c("auto", "virtualenv",
+  "conda"), conda = "auto", ...)
 }
 \arguments{
 \item{packages}{Character vector with package names to install}
 
-\item{envname}{Name of environment to install packages into}
+\item{envname}{The name of the environment in which packages will be installed.
+When \code{NULL} and attempting to install into a virtual environment, the active
+virtual environment (if any) will be used.}
 
 \item{method}{Installation method. By default, "auto" automatically finds a
 method that will work in the local environment. Change the default to force

--- a/man/virtualenv-tools.Rd
+++ b/man/virtualenv-tools.Rd
@@ -14,7 +14,7 @@ virtualenv_list()
 
 virtualenv_create(envname, python = NULL)
 
-virtualenv_install(envname, packages, ignore_installed = TRUE)
+virtualenv_install(envname = NULL, packages, ignore_installed = TRUE)
 
 virtualenv_remove(envname, packages = NULL, confirm = interactive())
 


### PR DESCRIPTION
This PR teaches `py_install()` to install packages into the currently active virtual environment (if any). This would mean that e.g.

```r
library(reticulate)
virtualenv_create("test")
use_virtualenv("test", required = TRUE)
py_available(TRUE)
py_install("numpy")
```

would install into the active `test` environment, rather than the default `r-reticulate` environment.

The intention in this PR is that (e.g. `renv`) could then automatically initialize `reticulate` when R is launched, and then `py_install()` would then just "do the right thing" based on the environment that `renv` has told `reticulate` to use.

Some questions worth answering if we like this PR:

- Do we want to implement similar handling for Conda environments?
- What about the case where the user has called `use_virtualenv()` but has not yet initialized Python?