### PR TITLE
implement notion of 'default' env for python actions

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -375,7 +375,7 @@ python_config <- function(python, required_module, python_versions, forced = NUL
 
   # check to see if this is a Python virtualenv
   root <- dirname(dirname(python))
-  virtualenv <- if (is_python_virtualenv(root))
+  virtualenv <- if (is_virtualenv(root))
     root
   else
     ""

--- a/R/config.R
+++ b/R/config.R
@@ -119,8 +119,7 @@ py_discover_config <- function(required_module = NULL, use_environment = NULL) {
   # if RETICULATE_PYTHON_ENV is specified then use that
   reticulate_python_env <- Sys.getenv("RETICULATE_PYTHON_ENV", unset = NA)
   if (!is.na(reticulate_python_env)) {
-    suffix <- if (is_windows()) "Scripts/python.exe" else "bin/python"
-    python <- file.path(reticulate_python_env, suffix)
+    python <- python_binary_path(reticulate_python_env)
     python_version <- normalize_python_path(python)
     if (!python_version$exists)
       stop("Python specified in RETICULATE_PYTHON_ENV (", reticulate_python_env, ") does not exist")

--- a/R/config.R
+++ b/R/config.R
@@ -106,13 +106,26 @@ py_discover_config <- function(required_module = NULL, use_environment = NULL) {
   }
 
   # if RETICULATE_PYTHON is specified then use it without scanning further
-  reticulate_python_env <- Sys.getenv("RETICULATE_PYTHON", unset = NA)
-  if (!is.na(reticulate_python_env)) {
-    python_version <- normalize_python_path(reticulate_python_env)
+  reticulate_env <- Sys.getenv("RETICULATE_PYTHON", unset = NA)
+  if (!is.na(reticulate_env)) {
+    python_version <- normalize_python_path(reticulate_env)
     if (!python_version$exists)
-      stop("Python specified in RETICULATE_PYTHON (", reticulate_python_env, ") does not exist")
+      stop("Python specified in RETICULATE_PYTHON (", reticulate_env, ") does not exist")
     python_version <- python_version$path
     config <- python_config(python_version, required_module, python_version, forced = "RETICULATE_PYTHON")
+    return(config)
+  }
+
+  # if RETICULATE_PYTHON_ENV is specified then use that
+  reticulate_python_env <- Sys.getenv("RETICULATE_PYTHON_ENV", unset = NA)
+  if (!is.na(reticulate_python_env)) {
+    suffix <- if (is_windows()) "Scripts/python.exe" else "bin/python"
+    python <- file.path(reticulate_python_env, suffix)
+    python_version <- normalize_python_path(python)
+    if (!python_version$exists)
+      stop("Python specified in RETICULATE_PYTHON_ENV (", reticulate_python_env, ") does not exist")
+    path <- python_version$path
+    config <- python_config(path, required_module, path, forced = "RETICULATE_PYTHON_ENV")
     return(config)
   }
 

--- a/R/install.R
+++ b/R/install.R
@@ -25,7 +25,7 @@
 #' @export
 py_install <- function(
   packages,
-  envname = "r-reticulate",
+  envname = NULL,
   method = c("auto", "virtualenv", "conda"),
   conda = "auto",
   ...) {
@@ -35,6 +35,11 @@ py_install <- function(
     stop("Installing Python packages into a virtualenv is not supported on Windows",
          call. = FALSE)
   }
+
+  # when envname is NULL, use default-supplied environment
+  # (or r-reticulate environment otherwise for backwards compatibility)
+  if (is.null(envname))
+    envname <- Sys.getenv("RETICULATE_PYTHON_ENV", unset = "r-reticulate")
 
   # find out which methods we can try
   method_available <- function(name) method %in% c("auto", name)

--- a/R/use_python.R
+++ b/R/use_python.R
@@ -40,7 +40,8 @@ use_python <- function(python, required = FALSE) {
 
 #' @rdname use_python
 #' @export
-use_virtualenv <- function(virtualenv, required = FALSE) {
+use_virtualenv <- function(virtualenv = NULL, required = FALSE) {
+  virtualenv <- virtualenv_path(virtualenv)
 
   # prepend root virtualenv directory it doesn't exist and
   # it's not an absolute path
@@ -70,7 +71,15 @@ use_virtualenv <- function(virtualenv, required = FALSE) {
 
 #' @rdname use_python
 #' @export
-use_condaenv <- function(condaenv, conda = "auto", required = FALSE) {
+use_condaenv <- function(condaenv = NULL, conda = "auto", required = FALSE) {
+
+  # check for condaenv supplied by path
+  condaenv <- condaenv_resolve(condaenv)
+  if (grepl("[/\\]", condaenv, fixed = TRUE) && is_condaenv(condaenv)) {
+    python <- conda_python(condaenv)
+    use_python(python, required = required)
+    return(invisible(NULL))
+  }
 
   # list all conda environments
   conda_envs <- conda_list(conda)

--- a/R/use_python.R
+++ b/R/use_python.R
@@ -41,32 +41,19 @@ use_python <- function(python, required = FALSE) {
 #' @rdname use_python
 #' @export
 use_virtualenv <- function(virtualenv = NULL, required = FALSE) {
+
+  # resolve path to virtualenv
   virtualenv <- virtualenv_path(virtualenv)
-
-  # prepend root virtualenv directory it doesn't exist and
-  # it's not an absolute path
-  if (!utils::file_test("-d", virtualenv) &
-      !grepl("^/|^[a-zA-Z]:/|^~", virtualenv, perl = TRUE)) {
-    workon_home <- Sys.getenv("WORKON_HOME", unset = "~/.virtualenvs")
-    virtualenv <- file.path(workon_home, virtualenv)
-  }
-
-  # compute the bin dir
-  if (is_windows())
-    python_dir <- file.path(virtualenv, "Scripts")
-  else
-    python_dir <- file.path(virtualenv, "bin")
-
 
   # validate it if required
   if (required && !is_virtualenv(virtualenv))
     stop("Directory ", virtualenv, " is not a Python virtualenv")
 
-  # set the option
-  python <- file.path(python_dir, "python")
-  if (is_windows())
-    python <- paste0(python, ".exe")
+  # get path to Python binary
+  suffix <- if (is_windows()) "Scripts/python.exe" else "bin/python"
+  python <- file.path(virtualenv, suffix)
   use_python(python, required = required)
+
 }
 
 #' @rdname use_python

--- a/R/use_python.R
+++ b/R/use_python.R
@@ -58,7 +58,7 @@ use_virtualenv <- function(virtualenv, required = FALSE) {
 
 
   # validate it if required
-  if (required && !is_python_virtualenv(virtualenv))
+  if (required && !is_virtualenv(virtualenv))
     stop("Directory ", virtualenv, " is not a Python virtualenv")
 
   # set the option

--- a/R/utils.R
+++ b/R/utils.R
@@ -137,3 +137,26 @@ py_last_value <- function() {
     error = function(e) r_to_py(NULL)
   )
 }
+
+python_binary_path <- function(dir) {
+
+  # check for condaenv
+  if (is_condaenv(dir)) {
+    suffix <- if (is_windows()) "python.exe" else "bin/python"
+    return(file.path(dir, suffix))
+  }
+
+  # check for virtualenv
+  if (is_virtualenv(dir)) {
+    suffix <- if (is_windows()) "Scripts/python.exe" else "bin/python"
+    return(file.path(dir, suffix))
+  }
+
+  # check for directory containing Python
+  suffix <- if (is_windows()) "python.exe" else "python"
+  if (file.exists(file.path(dir, suffix)))
+    return(file.path(dir, suffix))
+
+  stop("failed to discover Python binary associated with path '", dir, "'")
+
+}

--- a/R/virtualenv.R
+++ b/R/virtualenv.R
@@ -195,7 +195,7 @@ virtualenv_path <- function(envname = NULL) {
     if (!is.na(default)) {
       path <- normalizePath(default, winslash = "/", mustWork = FALSE)
       if (!is_virtualenv(path)) {
-        fmt <- "there is no conda environment at path '%s'"
+        fmt <- "there is no virtual environment at path '%s'"
         stop(sprintf(fmt, path))
       }
       return(path)

--- a/man/conda-tools.Rd
+++ b/man/conda-tools.Rd
@@ -13,18 +13,18 @@
 \usage{
 conda_list(conda = "auto")
 
-conda_create(envname, packages = "python", conda = "auto")
+conda_create(envname = NULL, packages = "python", conda = "auto")
 
 conda_remove(envname, packages = NULL, conda = "auto")
 
-conda_install(envname, packages, forge = TRUE, pip = FALSE,
+conda_install(envname = NULL, packages, forge = TRUE, pip = FALSE,
   pip_ignore_installed = TRUE, conda = "auto")
 
 conda_binary(conda = "auto")
 
 conda_version(conda = "auto")
 
-conda_python(envname, conda = "auto")
+conda_python(envname = NULL, conda = "auto")
 }
 \arguments{
 \item{conda}{Path to conda executable (or "auto" to find conda using the

--- a/man/py_install.Rd
+++ b/man/py_install.Rd
@@ -4,8 +4,8 @@
 \alias{py_install}
 \title{Install Python packages}
 \usage{
-py_install(packages, envname = "r-reticulate", method = c("auto",
-  "virtualenv", "conda"), conda = "auto", ...)
+py_install(packages, envname = NULL, method = c("auto", "virtualenv",
+  "conda"), conda = "auto", ...)
 }
 \arguments{
 \item{packages}{Character vector with package names to install}

--- a/man/virtualenv-tools.Rd
+++ b/man/virtualenv-tools.Rd
@@ -12,21 +12,24 @@
 \usage{
 virtualenv_list()
 
-virtualenv_create(envname, python = NULL)
+virtualenv_create(envname = NULL, python = NULL)
 
-virtualenv_install(envname, packages, ignore_installed = TRUE)
+virtualenv_install(envname = NULL, packages, ignore_installed = TRUE)
 
-virtualenv_remove(envname, packages = NULL, confirm = interactive())
+virtualenv_remove(envname = NULL, packages = NULL,
+  confirm = interactive())
 
 virtualenv_root()
 
-virtualenv_python(envname)
+virtualenv_python(envname = NULL)
 }
 \arguments{
 \item{envname}{The name of, or path to, a Python virtual environment. If
 this name contains any slashes, the name will be interpreted as a path;
 if the name does not contain slashes, it will be treated as a virtual
-environment within \code{virtualenv_root()}.}
+environment within \code{virtualenv_root()}. When \code{NULL}, the virtual environment
+as specified by the \code{RETICULATE_PYTHON_ENV} environment variable will be
+used instead.}
 
 \item{python}{The path to a Python interpreter, to be used with the created
 virtual environment. When \code{NULL}, the Python interpreter associated with


### PR DESCRIPTION
This PR implements the notion of a 'default' Python environment, as managed through the `RETICULATE_PYTHON_ENV` environment variable. The idea is that all of the various functions `virtualenv_create()`, `py_install()`, `conda_install()` and so on would use this environment by default if `envname = NULL` (the default) and the aforementioned environment variable is set.