### PR TITLE
fix for conversion of date objects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@ Install the development version with: `devtools::install_github("rstudio/reticul
 
 - Fixed an issue where vectors of R Dates were not converted correctly. (#454)
 
+- Fixed an issue where R Dates could not be passed to Python functions. (#458)
+
 ## reticulate 1.11.1 (CRAN)
 
 - Fixed a failing virtual environment test on CRAN.

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -136,7 +136,7 @@ r_to_py.POSIXt <- function(x, convert = FALSE) {
   if (py_module_available("numpy"))
     return(np_array(as.numeric(x) * 1E9, dtype = "datetime64[ns]"))
 
-  datetime <- import("datetime", convert = convert)
+  datetime <- import("datetime", convert = FALSE)
   datetime$datetime$fromtimestamp(as.double(x))
 }
 
@@ -154,7 +154,7 @@ py_to_r.datetime.datetime <- function(x) {
 #' @export
 r_to_py.Date <- function(x, convert = FALSE) {
 
-  datetime <- import("datetime", convert = convert)
+  datetime <- import("datetime", convert = FALSE)
   items <- lapply(x, function(item) {
     iso <- strsplit(format(item), "-", fixed = TRUE)[[1]]
     year <- as.integer(iso[[1]])

--- a/tests/testthat/test-python-datetime.R
+++ b/tests/testthat/test-python-datetime.R
@@ -46,3 +46,11 @@ test_that("R times are converted to NumPy datetime64", {
   )
 
 })
+
+test_that("R datetimes can be passed to Python functions", {
+  skip_if_no_python()
+  py_run_string("def identity(x): return x")
+  main <- import_main()
+  date <- Sys.Date()
+  expect_equal(date, main$identity(Sys.Date()))
+})


### PR DESCRIPTION
Closes #458.

@jjallaire I think my error here was passing along the `convert` argument during the imports of the `datetime` module, when (if I understand correctly) it's normally used for the Python capsules and especially for handling conversion of R functions. Let me know if this change looks right to you.