### PR TITLE
Normalizing path before py_save/load_object.

### DIFF
--- a/R/pickle.R
+++ b/R/pickle.R
@@ -11,7 +11,8 @@
 py_save_object <- function(object, filename, pickle = "pickle") {
   builtins <- import_builtins()
   pickle <- import(pickle)
-  handle <- builtins$open(filename, "wb")
+  norm_filename <- normalizePath(filename, mustWork = FALSE)
+  handle <- builtins$open(norm_filename, "wb")
   on.exit(handle$close(), add = TRUE)
   pickle$dump(object, handle, protocol = pickle$HIGHEST_PROTOCOL)
 }
@@ -21,7 +22,8 @@ py_save_object <- function(object, filename, pickle = "pickle") {
 py_load_object <- function(filename, pickle = "pickle") {
   builtins <- import_builtins()
   pickle <- import(pickle)
-  handle <- builtins$open(filename, "rb")
+  norm_filename <- normalizePath(filename)
+  handle <- builtins$open(norm_filename, "rb")
   on.exit(handle$close(), add = TRUE)
   pickle$load(handle)
 }

--- a/R/pickle.R
+++ b/R/pickle.R
@@ -11,8 +11,9 @@
 py_save_object <- function(object, filename, pickle = "pickle") {
   builtins <- import_builtins()
   pickle <- import(pickle)
-  norm_filename <- normalizePath(filename, mustWork = FALSE)
-  handle <- builtins$open(norm_filename, "wb")
+  # do tilde expansion here, as Python doesnt do it
+  exp_filename <- path.expand(filename)
+  handle <- builtins$open(exp_filename, "wb")
   on.exit(handle$close(), add = TRUE)
   pickle$dump(object, handle, protocol = pickle$HIGHEST_PROTOCOL)
 }
@@ -22,8 +23,9 @@ py_save_object <- function(object, filename, pickle = "pickle") {
 py_load_object <- function(filename, pickle = "pickle") {
   builtins <- import_builtins()
   pickle <- import(pickle)
-  norm_filename <- normalizePath(filename)
-  handle <- builtins$open(norm_filename, "rb")
+  # do tilde expansion here, as Python doesnt do it
+  exp_filename <- path.expand(filename)
+  handle <- builtins$open(exp_filename, "rb")
   on.exit(handle$close(), add = TRUE)
   pickle$load(handle)
 }


### PR DESCRIPTION
reticulate's `py_save_object` and `py_load_object` functions use the `open` function from `builtin` Python lib.
For some reason, the `open` function gives an error if the file path uses '~' as a shortcut for the home dir:
``` r
library("reticulate")
py_run_string("my_object = [8,8,1,8]")

dir.exists("~/mytmp")
```

    ## [1] TRUE

``` r
unlink("~/mytmp/my_object.pkl")
file.exists("~/mytmp/my_object.pkl")
```

    ## [1] FALSE

``` r
try(py_save_object(py$my_object, "~/mytmp/my_object.pkl"))[[1]]
```

    ## [1] "Error in py_call_impl(callable, dots$args, dots$keywords) : 
    ## FileNotFoundError: [Errno 2] No such file or directory: '~/mytmp/my_object.pkl'\n"

However, if using the same path but in full path (or regular path) it works.

``` r
py_save_object(py$my_object, "/home/jcrodriguez/mytmp/my_object.pkl")
```

``` r
try(my_object <- py_load_object("~/mytmp/my_object.pkl"))[[1]]
```

    ## [1] "Error in py_call_impl(callable, dots$args, dots$keywords) : 
    ## FileNotFoundError: [Errno 2] No such file or directory: '~/mytmp/my_object.pkl'\n"

``` r
my_object <- py_load_object("/home/jcrodriguez/mytmp/my_object.pkl")
my_object
```

    ## [1] 8 8 1 8

## Fix

If in reticulate code we use `normalizePath` function then we get it work:

``` r
library("reticulate")
py_run_string("my_object = [8,8,1,8]")

dir.exists("~/mytmp")
```

    ## [1] TRUE

``` r
unlink("~/mytmp/my_object.pkl")
file.exists("~/mytmp/my_object.pkl")
```

    ## [1] FALSE

``` r
py_save_object(py$my_object, "~/mytmp/my_object.pkl")
```

``` r
my_object <- py_load_object("~/mytmp/my_object.pkl")
my_object
```

    ## [1] 8 8 1 8