### PR TITLE
don't disable convert when converting lists

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 
 Install the development version with: `devtools::install_github("rstudio/reticulate")`
 
+- Fixed an issue where Python objects within Python lists would not be
+  converted to R objects as expected.
+
 - Fixed an issue where single-row data.frames with row names could not
   be converted. (#468)
 

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -51,7 +51,10 @@ r_to_py.list <- function(x, convert = FALSE) {
 
 #' @export
 py_to_r.python.builtin.list <- function(x) {
-  disable_conversion_scope(x)
+
+  # NOTE: we don't disable conversion in this context
+  # as we want to ensure sub-objects inherit convert-ability
+  # see e.g. https://github.com/rstudio/keras/issues/732
 
   # give internal code a chance to perform efficient
   # conversion of e.g. numeric vectors and the like


### PR DESCRIPTION
Fixes the issue described in https://github.com/rstudio/keras/issues/732.

I wanted to add a unit test for this behavior but for the life of me couldn't produce a a standalone example that exhibits the same behavior :/