### PR TITLE
open main program when libPath is empty

### DIFF
--- a/src/libpython.cpp
+++ b/src/libpython.cpp
@@ -57,9 +57,17 @@ bool loadLibrary(const std::string& libPath, void** ppLib, std::string* pError)
 {
   *ppLib = NULL;
 #ifdef _WIN32
-  *ppLib = (void*)::LoadLibraryEx(libPath.c_str(), NULL, 0);
+  if (libPath.empty()) {
+    *ppLib = (void*)::LoadLibraryEx(NULL, NULL, 0);
+  } else {
+    *ppLib = (void*)::LoadLibraryEx(libPath.c_str(), NULL, 0);
+  }
 #else
-  *ppLib = ::dlopen(libPath.c_str(), RTLD_NOW|RTLD_GLOBAL);
+  if (libPath.empty()) {
+    *ppLib = ::dlopen(NULL, RTLD_NOW|RTLD_GLOBAL);
+  } else {
+    *ppLib = ::dlopen(libPath.c_str(), RTLD_NOW|RTLD_GLOBAL);
+  }
 #endif
   if (*ppLib == NULL)
   {
@@ -349,4 +357,3 @@ bool import_numpy_api(bool python3, std::string* pError) {
 
 
 } // namespace libpython
-


### PR DESCRIPTION
It is a non-invasive version of my previous PR #279 for handling the case that R is embedded in a Python environment.

Basically, it allows me to hijack `reticulate::py_discover_config` 

```r
py_discover_config <- funciton(...) {
    return list(
        python = "/usr/bin/python",
        libpython = "",
        ...
        ...
    )
}
```
so that reticulate would load the symbols from the main program instead. It virtually makes no changes to regular use. I hope it can get merged quicker. (PS: My last PR sat here for 9 months and I decided to close it and look for other options)