### PR TITLE
Flowery support?

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,8 @@ Imports:
     graphics,
     jsonlite,
     Rcpp (>= 0.12.7),
-    Matrix
+    Matrix,
+    flowery
 Suggests:
     testthat,
     knitr,
@@ -44,3 +45,5 @@ LinkingTo: Rcpp
 RoxygenNote: 6.1.1
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
+Remotes:
+    lionel-/flowery

--- a/R/python.R
+++ b/R/python.R
@@ -718,8 +718,13 @@ iterate <- function(it, f = base::identity, simplify = TRUE) {
   # resolve iterator
   it <- as_iterator(it)
 
+  result <- list()
+  i <- 1
   # perform iteration
-  result <- flowery::drain(it)
+  while(!flowery::is_done(it)) {
+    result[[i]] <- it()
+    i <- i + 1
+  }
 
   # simplify if requested and appropriate
   if (simplify) {

--- a/R/python.R
+++ b/R/python.R
@@ -782,7 +782,7 @@ as_flowery_iterator <- function(x) {
   flowery::generator({
     nxt <- iter_next(x)
     while(!is.null(nxt)) {
-      yield(nxt)
+      flowery::yield(nxt)
       nxt <- iter_next(x)
     }
   })

--- a/tests/testthat/test-python-iterators.R
+++ b/tests/testthat/test-python-iterators.R
@@ -92,3 +92,13 @@ test_that("generator functions are always called on the main thread", {
   gen <- py_iterator(sequence_generator(10L))
   expect_equal(test$iterateOnThread(gen), 11L:19L)
 })
+
+test_that("can iterate using flowery syntax", {
+  iter <- as_iterator(test$makeIterator(c(1:5)))
+  flowery::iterate(
+    for (i in iter) {
+      x <- i
+    }
+  )
+  expect_equal(x, 5)
+})


### PR DESCRIPTION
In `tfdatasets` we are probably using [`flowery`](https://github.com/lionel-/flowery) as the backend to iterate over datasets (which are python iterators)  since it provides a nice syntax for R users and a lot of methods, docs, etc on how to deal with iterators.

It turns out that it's not that hard to support directly in reticulate in a backward compatible way. It would allow us to iterate over any python iterator:

``` r
library(reticulate)
builtins <- import_builtins(convert = FALSE)
range <- builtins$range(1L, 10L)

flowery::iterate(
  for(i in as_iterator(range)){
    print(i)
  }
)
#> 1
#> 2
#> 3
#> 4
#> 5
#> 6
#> 7
#> 8
#> 9
#> NULL
```

<sup>Created on 2019-04-17 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

Do you think it makes sense to implement it? 