### PR TITLE
Adding important documentation to py_config man.

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -2,7 +2,9 @@
 
 #' Python configuration
 #'
-#' Information on Python and Numpy versions detected
+#' Information on Python and Numpy versions detected.
+#' Note: Python will be initialized and therefore [py_available()] will return
+#' `TRUE`. If this is not desired, check the [py_discover_config()] function.
 #'
 #' @return Python configuration object; Logical indicating whether Python
 #'   bindings are available

--- a/man/py_config.Rd
+++ b/man/py_config.Rd
@@ -11,5 +11,7 @@ Python configuration object; Logical indicating whether Python
 bindings are available
 }
 \description{
-Information on Python and Numpy versions detected
+Information on Python and Numpy versions detected.
+Note: Python will be initialized and therefore \code{\link[=py_available]{py_available()}} will return
+\code{TRUE}. If this is not desired, check the \code{\link[=py_discover_config]{py_discover_config()}} function.
 }


### PR DESCRIPTION
I added to the `py_config` man pages that it initializes Python, i.e., `py_available()` will return `TRUE` after its execution.
In the `autokeras::install_autokeras()` function from my `autokeras` package I was testing with `py_config()` if the Python version was 3.6 (as required by the Python Auto-Keras lib), and then I was calling `keras::install_keras()` which fails if `py_available()`. I had to figure out that I should use `py_discover_config()` instead of `py_config()` by debugging. Hence, I think the adding Ive made to the man page would result useful :) .