### PR TITLE
Fix crash on failed numpy import

### DIFF
--- a/src/libpython.cpp
+++ b/src/libpython.cpp
@@ -188,6 +188,7 @@ bool LibPython::loadSymbols(bool python3, std::string* pError)
   LOAD_PYTHON_SYMBOL(PyList_Size)
   LOAD_PYTHON_SYMBOL(PyList_GetItem)
   LOAD_PYTHON_SYMBOL(PyList_SetItem)
+  LOAD_PYTHON_SYMBOL(PyErr_Clear)
   LOAD_PYTHON_SYMBOL(PyErr_Fetch)
   LOAD_PYTHON_SYMBOL(PyErr_Occurred)
   LOAD_PYTHON_SYMBOL(PyErr_NormalizeException)
@@ -304,6 +305,7 @@ bool import_numpy_api(bool python3, std::string* pError) {
   PyObject* numpy = PyImport_ImportModule("numpy.core.multiarray");
   if (numpy == NULL) {
     *pError = "numpy.core.multiarray failed to import";
+    PyErr_Clear();
     return false;
   }
 

--- a/src/libpython.h
+++ b/src/libpython.h
@@ -228,6 +228,7 @@ LIBPYTHON_EXTERN PyObject* (*PyByteArray_FromStringAndSize)(const char *string, 
 LIBPYTHON_EXTERN char* (*PyByteArray_AsString)(PyObject *bytearray);
 LIBPYTHON_EXTERN PyObject* (*PyUnicode_FromString)(const char *u);
 
+LIBPYTHON_EXTERN void (*PyErr_Clear)();
 LIBPYTHON_EXTERN void (*PyErr_Fetch)(PyObject **, PyObject **, PyObject **);
 LIBPYTHON_EXTERN PyObject* (*PyErr_Occurred)(void);
 LIBPYTHON_EXTERN void (*PyErr_NormalizeException)(PyObject**, PyObject**, PyObject**);


### PR DESCRIPTION
This fixes the crash in #487 when numpy is not in the search path. This is a new issue after upgrading to python 3.7, so there might be other occurrences (although I didn't see anything specific in the changelog).