### PR TITLE
R3.6 Windows Problems with reticulate

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -354,7 +354,7 @@ python_config <- function(python, required_module, python_versions, forced = NUL
 
   config_script <- system.file("config/config.py", package = "reticulate")
   # It seems that Windows in R3.6 returns the configuration from the python file only in stderr and not in stdout
-  config <- system2(command = python, args = paste0('"', config_script, '"'), stdout = TRUE, stderr = TRUE)
+  config <- system2(command = python, args = paste0('"', config_script, '"'), stdout = TRUE, stderr = FALSE)
   status <- attr(config, "status")
   if (!is.null(status)) {
     errmsg <- attr(config, "errmsg")

--- a/R/config.R
+++ b/R/config.R
@@ -353,7 +353,8 @@ python_config <- function(python, required_module, python_versions, forced = NUL
   }
 
   config_script <- system.file("config/config.py", package = "reticulate")
-  config <- system2(command = python, args = paste0('"', config_script, '"'), stdout = TRUE)
+  # It seems that Windows in R3.6 returns the configuration from the python file only in stderr and not in stdout
+  config <- system2(command = python, args = paste0('"', config_script, '"'), stdout = TRUE, stderr = TRUE)
   status <- attr(config, "status")
   if (!is.null(status)) {
     errmsg <- attr(config, "errmsg")

--- a/R/python-tools.R
+++ b/R/python-tools.R
@@ -8,7 +8,7 @@ python_has_module <- function(python, module) {
 python_version <- function(python) {
   code <- "import platform; print(platform.python_version())"
   args <- c("-E", "-c", shQuote(code))
-  output <- system2(python, args, stdout = TRUE, stderr = TRUE)
+  output <- system2(python, args, stdout = TRUE, stderr = FALSE)
   numeric_version(output)
 }
 
@@ -16,7 +16,7 @@ python_module_version <- function(python, module) {
   fmt <- "import %1$s; print(%1$s.__version__)"
   code <- sprintf(fmt, module)
   args <- c("-E", "-c", shQuote(code))
-  output <- system2(python, args, stdout = TRUE, stderr = TRUE)
+  output <- system2(python, args, stdout = TRUE, stderr = FALSE)
   numeric_version(output)
 }
 


### PR DESCRIPTION
It seems that Windows in R3.6 using system2 call, does not return a stdout from an python call. It seems to me that it only returns data as stderr. Therefore py_config() does not return the configuration from the python file. It provides configuration detail only in stderr and not in stdout. This leeds the an mapply error, because the config is only of length=0. 

See also issue: https://github.com/rstudio/reticulate/issues/498

Additional python_version and python_module_version in python-tools.R use also the system2 command. 
I have changed those calls in my fork and it seems now it's working on my PC, maybe someone can check if this solution is a possible solution for the whole package or if there is a bug which should be corrected in R 3.6
