### PR TITLE
Deals with NULL pointter in py_to_r convertion.

### DIFF
--- a/src/python.cpp
+++ b/src/python.cpp
@@ -606,6 +606,10 @@ bool py_is_callable(PyObjectRef x) {
 // convert a python object to an R object
 SEXP py_to_r(PyObject* x, bool convert) {
 
+  // NULL pointer
+  if (x == NULL)
+    return R_NilValue;
+
   // NULL for Python None
   if (py_is_none(x))
     return R_NilValue;


### PR DESCRIPTION
When we were fixing [this issue](https://github.com/rstudio/keras/issues/801) in Keras we found that we were trying to convert a NULL pointer to an R object and this was causing a segfault.

We have fixed the problem on our side [here](https://github.com/rstudio/keras/pull/809), but it may be worth to deal with NULL pointers in `py_to_r`. I am not sure if returning `NULL` is the right behavior, maybe we should stop with an exception...
