### PR TITLE
recursively convert tuples as we do lists

### DIFF
--- a/R/conversion.R
+++ b/R/conversion.R
@@ -74,6 +74,9 @@ py_to_r.python.builtin.list <- function(x) {
   converted
 }
 
+#' @export
+py_to_r.python.builtin.tuple <- py_to_r.python.builtin.list
+
 #' R wrapper for Python objects
 #'
 #' S3 method to create a custom R wrapper for a Python object.

--- a/inst/python/rpytools/test.py
+++ b/inst/python/rpytools/test.py
@@ -1,5 +1,6 @@
 
 import threading
+import collections
 
 import sys
 is_py2 = sys.version[0] == '2'
@@ -23,6 +24,9 @@ def makeDict():
 
 def makeTuple():
   return (1.0, 2.0, 3.0)
+
+def makeTupleWithOrderedDict():
+  return (1.0, collections.OrderedDict({'b':777, 'a':22}))
 
 def makeIterator(x):
   return iter(x)

--- a/tests/testthat/test-python-lists.R
+++ b/tests/testthat/test-python-lists.R
@@ -44,3 +44,10 @@ test_that("length method for Python lists works", {
   l$append(3)
   expect_equal(length(l), 3)
 })
+
+test_that("tuples are converted recursively just like lists", {
+  skip_if_no_python()
+  t <- test$makeTupleWithOrderedDict()
+  expect_equal(class(t[[2]]), "list")
+})
+


### PR DESCRIPTION
Before modifying `test.py` I tried this R-only test 

```
 builtins <- import_builtins(convert = FALSE)
 collections <- import("collections", convert = FALSE)
 t <- builtins$tuple(list(22, collections$OrderedDict(list(list(777, "b"), list(1, "a")))))
 py_to_r(t)
 ```

but this didn't convert the ``OrderedDict``:

```
[1]]
[1] 22

[[2]]
OrderedDict([(777.0, 'b'), (1.0, 'a')])

```

