### PR TITLE
SSLError when installing

### DIFF
--- a/R/conda.R
+++ b/R/conda.R
@@ -277,7 +277,10 @@ find_conda <- function() {
         conda_scripts <- utils::shortPathName(
           file.path(anaconda_versions$install_path, "Scripts", "conda.exe")
         )
-        conda_locations <- c(conda_locations, conda_scripts)
+        conda_bats <- utils::shortPathName(
+          file.path(anaconda_versions$install_path, "condabin", "conda.bat")
+        )
+        conda_locations <- c(conda_locations, conda_bats, conda_scripts)
       }
     }
     conda_locations <- conda_locations[file.exists(conda_locations)]


### PR DESCRIPTION
On Windows we are seeing the following error when using `conda_create` on a clean installation (see https://github.com/rstudio/tensorflow/issues/325 )

```
> reticulate::conda_create(envname = "test")
WARNING: The conda.compat module is deprecated and will be removed in a future release.
Collecting package metadata: ...working... failed

CondaHTTPError: HTTP 000 CONNECTION FAILED for url <https://repo.anaconda.com/pkgs/msys2/noarch/repodata.json.bz2>
Elapsed: -

An HTTP error occurred when trying to retrieve this URL.
HTTP errors are often intermittent, and a simple retry will get you on your way.

If your current network has https://www.anaconda.com blocked, please file
a support request with your network engineering team.

SSLError(MaxRetryError('HTTPSConnectionPool(host=\'repo.anaconda.com\', port=443): Max retries exceeded with url: /pkgs/msys2/noarch/repodata.json.bz2 (Caused by SSLError("Can\'t connect to HTTPS URL because the SSL module is not available."))'))
```

This does not happen when we explicitly set the path to the `conda.bat` file:

```
reticulate::conda_create(envname = "test", conda = "C://Users/dfalbel/Anaconda3/condabin/conda.bat")
```

This PR adds `Anaconda3/condabin/conda.bat` to the searched conda paths.

