### PR TITLE
implement mechanism for module load hooks

### DIFF
--- a/R/python.R
+++ b/R/python.R
@@ -62,7 +62,19 @@ import <- function(module, as = NULL, convert = TRUE, delay_load = FALSE) {
     ensure_python_initialized(required_module = module)
 
     # import the module
-    py_module_import(module, convert = convert)
+    hookName <- paste("reticulate", module, "load", sep = "::")
+    module <- py_module_import(module, convert = convert)
+
+    # run load hooks
+    hooks <- getHook(hookName)
+    for (hook in hooks)
+      tryCatch(hook(module), error = warning)
+
+    # remove hooks (we only want to run on first import)
+    setHook(hookName, list(), "replace")
+
+    # return imported module
+    module
   }
 
   # delay load case (wait until first access)


### PR DESCRIPTION
This PR allows clients of `reticulate` to register hooks that get run when a module is loaded. This can be useful for e.g. front-ends that need to take some action in response to a module of interest being loaded.

One motivating example is with `matplotlib.pyplot`. One might want to override the `show()` method, so that the plot is shown in a custom way (e.g. in RStudio, shown in the Plots pane). Having an import hook would make it possible to ensure that code of this form:

```R
library(reticulate)
matplotlib <- import("matplotlib")
plt <- import("matplotlib.pyplot")
plt$plot(1:5, 1:5)
plt$show()
```

would work without issue.

Note that this is different from the existing delay_load system -- that allows the user themselves to register hooks that get run when their module is loaded; in our case, we want to hook into the user's code rather than allow them to hook their own code.