### PR TITLE
fixes conda environment being ignored if numpy not present

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -207,7 +207,8 @@ py_discover_config <- function(required_module = NULL, use_environment = NULL) {
     if (has_compatible_arch && (is.null(config$numpy) || has_preferred_numpy))
       valid_python_versions <- c(valid_python_versions, python_version)
     has_required_module <- is.null(config$required_module) || !is.null(config$required_module_path)
-    if (has_python_gte_27 && has_compatible_arch && has_preferred_numpy && has_required_module)
+    if (has_python_gte_27 && has_compatible_arch && (is.null(config$numpy) || has_preferred_numpy) &&
+      has_required_module)
       return(config)
   }
 

--- a/R/config.R
+++ b/R/config.R
@@ -204,7 +204,7 @@ py_discover_config <- function(required_module = NULL, use_environment = NULL) {
     has_python_gte_27 <- as.numeric_version(config$version) >= "2.7"
     has_compatible_arch <- !is_incompatible_arch(config)
     has_preferred_numpy <- !is.null(config$numpy) && config$numpy$version >= "1.6"
-    if (has_compatible_arch && has_preferred_numpy)
+    if (has_compatible_arch && (is.null(config$numpy) || has_preferred_numpy))
       valid_python_versions <- c(valid_python_versions, python_version)
     has_required_module <- is.null(config$required_module) || !is.null(config$required_module_path)
     if (has_python_gte_27 && has_compatible_arch && has_preferred_numpy && has_required_module)


### PR DESCRIPTION
Passed environment in current `delay_load` code fails if `numpy` is not present in the passed environment. This fix ignores the check for numpy version if numpy is not installed in the environment.