### PR TITLE
revamp py_install()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ r:
   - 3.3
   - 3.4
   - 3.5
+  - 3.6
 
 addons:
   apt:
@@ -16,3 +17,5 @@ addons:
       - python2.7
       - python-numpy
       - python-scipy
+      - python-virtualenv
+      - python3-venv

--- a/R/conda.R
+++ b/R/conda.R
@@ -331,6 +331,22 @@ condaenv_resolve <- function(envname = NULL) {
 
 }
 
+condaenv_exists <- function(envname = NULL, conda = "auto") {
+
+  # check that conda is installed
+  condabin <- tryCatch(conda_binary(conda = conda), error = identity)
+  if (inherits(condabin, "error"))
+    return(FALSE)
+
+  # check that the environment exists
+  python <- tryCatch(conda_python(envname, conda = conda), error = identity)
+  if (inherits(python, "error"))
+    return(FALSE)
+
+  file.exists(python)
+
+}
+
 conda_args <- function(action, envname = NULL, ...) {
 
   envname <- condaenv_resolve(envname)

--- a/R/conda.R
+++ b/R/conda.R
@@ -147,8 +147,8 @@ conda_install <- function(envname = NULL, packages, forge = TRUE, pip = FALSE, p
   envname <- condaenv_resolve(envname)
 
   # create the environment if needed
-  python <- conda_python(envname = envname, conda = conda)
-  if (!file.exists(python))
+  python <- tryCatch(conda_python(envname = envname, conda = conda), error = identity)
+  if (inherits(python, "error") || !file.exists(python))
     conda_create(envname, conda = conda)
 
   if (pip) {

--- a/R/install.R
+++ b/R/install.R
@@ -1,14 +1,57 @@
 
+py_install_method_detect <- function(envname, conda = "auto") {
 
+  # on Windows, we always use conda environments
+  if (is_windows()) {
+
+    # validate that conda is available
+    conda <- tryCatch(conda_binary(conda = conda), error = identity)
+    if (inherits(conda, "error")) {
+      msg <- paste(
+        "Conda installation not found (failed to locate conda binary)",
+        "Please install Anaconda 3.x for Windows (https://www.anaconda.com/download/#windows) before proceeding.",
+        sep = "\n"
+      )
+      stop(msg, call. = FALSE)
+    }
+
+    # return it
+    return("conda")
+
+  }
+
+  # try to find an existing virtualenv
+  if (virtualenv_exists(envname))
+    return("virtualenv")
+
+  # try to find an existing condaenv
+  if (condaenv_exists(envname, conda = conda))
+    return("conda")
+
+  # check to see if virtualenv or venv is available
+  python <- virtualenv_default_python()
+  if (python_has_module(python, "virtualenv") || python_has_module(python, "venv"))
+    return("virtualenv")
+
+  # check to see if conda is available
+  conda <- tryCatch(conda_binary(conda = conda), error = identity)
+  if (!inherits(conda, "error"))
+    return("conda")
+
+  # default to virtualenv
+  "virtualenv"
+
+}
 
 #' Install Python packages
 #'
-#' Install Python packages into a virtualenv or conda env.
+#' Install Python packages into a virtual environment or Conda environment.
 #'
 #' @inheritParams conda_install
 #'
-#' @param packages Character vector with package names to install
-#' @param envname Name of environment to install packages into
+#' @param packages Character vector with package names to install.
+#' @param envname The name, or full path, of the environment in which Python
+#'   packages are to be installed.
 #' @param method Installation method. By default, "auto" automatically finds a
 #'   method that will work in the local environment. Change the default to force
 #'   a specific installation method. Note that the "virtualenv" method is not
@@ -23,12 +66,16 @@
 #' @seealso [conda-tools], [virtualenv-tools]
 #'
 #' @export
-py_install <- function(
-  packages,
-  envname = NULL,
-  method = c("auto", "virtualenv", "conda"),
-  conda = "auto",
-  ...) {
+py_install <- function(packages,
+                       envname = Sys.getenv("RETICULATE_PYTHON_ENV", unset = "r-reticulate"),
+                       method = c("auto", "virtualenv", "conda"),
+                       conda = "auto",
+                       ...)
+{
+  # resolve 'auto' method
+  method <- match.arg(method)
+  if (method == "auto")
+    method <- py_install_method_detect(envname = envname, conda = conda)
 
   # validate method
   if (identical(method, "virtualenv") && is_windows()) {
@@ -36,132 +83,14 @@ py_install <- function(
          call. = FALSE)
   }
 
-  # when envname is NULL, use default-supplied environment
-  # (or r-reticulate environment otherwise for backwards compatibility)
-  if (is.null(envname))
-    envname <- Sys.getenv("RETICULATE_PYTHON_ENV", unset = "r-reticulate")
-
-  # find out which methods we can try
-  method_available <- function(name) any(method %in% c("auto", name))
-  virtualenv_available <- method_available("virtualenv")
-  conda_available <- method_available("conda")
-
-  # resolve and look for conda
-  conda <- tryCatch(conda_binary(conda), error = function(e) NULL)
-  have_conda <- conda_available && !is.null(conda)
-
-  # mac and linux
-  if (is_unix()) {
-
-    # check for explicit conda method
-    if (identical(method, "conda")) {
-
-      # validate that we have conda
-      if (!have_conda)
-        stop("Conda installation failed (no conda binary found)\n", call. = FALSE)
-
-      # do install
-      conda_install(envname, packages = packages, conda = conda, ...)
-
-    } else {
-
-      # find system python binary
-      pyver <- ""
-      python <- python_unix_binary("python")
-      if (is.null(python)) {
-        # try for python3 if we are on linux
-        if (is_linux()) {
-          python <- python_unix_binary("python3")
-          if (is.null(python))
-            stop("Unable to locate Python on this system.", call. = FALSE)
-          pyver <- "3"
-        }
-      }
-      # find other required tools
-      pip <- python_unix_binary(paste0("pip", pyver))
-      have_pip <- !is.null(pip)
-      virtualenv <- python_unix_binary("virtualenv")
-      have_virtualenv <- virtualenv_available && !is.null(virtualenv)
-
-      # if we don't have pip and virtualenv then try for conda if it's allowed
-      if ((!have_pip || !have_virtualenv) && have_conda) {
-
-        conda_install(envname, packages = packages, conda = conda, ...)
-
-      # otherwise this is either an "auto" installation w/o working conda
-      # or it's an explicit "virtualenv" installation
-      } else {
-
-        # validate that we have the required tools for the method
-        install_commands <- NULL
-        if (is_osx()) {
-          if (!have_pip)
-            install_commands <- c(install_commands, "$ sudo /usr/bin/easy_install pip")
-          if (!have_virtualenv) {
-            if (is.null(pip))
-              pip <- "/usr/local/bin/pip"
-            install_commands <- c(install_commands, sprintf("$ sudo %s install --upgrade virtualenv", pip))
-          }
-          if (!is.null(install_commands))
-            install_commands <- paste(install_commands, collapse = "\n")
-        } else if (is_ubuntu()) {
-          if (!have_pip) {
-            install_commands <- c(install_commands, paste0("$ sudo apt-get install python", pyver ,"-pip"))
-            pip <- paste0("/usr/bin/pip", pyver)
-          }
-          if (!have_virtualenv) {
-            if (identical(pyver, "3"))
-              install_commands <- c(install_commands, paste("$ sudo", pip, "install virtualenv"))
-            else
-              install_commands <- c(install_commands, "$ sudo apt-get install python-virtualenv")
-          }
-          if (!is.null(install_commands))
-            install_commands <- paste(install_commands, collapse = "\n")
-        } else {
-          if (!have_pip)
-            install_commands <- c(install_commands, "pip")
-          if (!have_virtualenv)
-            install_commands <- c(install_commands, "virtualenv")
-          if (!is.null(install_commands)) {
-            install_commands <- paste("Please install the following Python packages before proceeding:",
-                                      paste(install_commands, collapse = ", "))
-          }
-        }
-        if (!is.null(install_commands)) {
-
-          # if these are terminal commands then add special preface
-          if (grepl("^\\$ ", install_commands)) {
-            install_commands <- paste0(
-              "Execute the following at a terminal to install the prerequisites:\n\n",
-              install_commands
-            )
-          }
-
-          stop("Prerequisites for installing Python packages not available.\n\n",
-               install_commands, "\n\n", call. = FALSE)
-        }
-
-        # do the install
-        virtualenv_install(envname, packages, ...)
-      }
-    }
-
-  # windows installation
-  } else {
-
-    # validate that we have conda
-    if (!have_conda) {
-      stop("Windows Conda installation failed (no conda binary found)\n\n",
-           "Install Anaconda 3.x for Windows (https://www.anaconda.com/download/#windows)\n",
-           "before proceeding",
-           call. = FALSE)
-    }
-
-    # do the install
-    conda_install(envname, packages, conda = conda, ...)
-  }
-
-  cat("\nInstallation complete.\n\n")
+  # perform the install
+  switch(
+    method,
+    virtualenv = virtualenv_install(envname = envname, packages = packages, ...),
+    conda = conda_install(envname, packages = packages, conda = conda, ...),
+    stop("unrecognized installation method '", method, "'")
+  )
 
   invisible(NULL)
+
 }

--- a/R/install.R
+++ b/R/install.R
@@ -9,7 +9,7 @@ py_install_method_detect <- function(envname, conda = "auto") {
     if (inherits(conda, "error")) {
       msg <- paste(
         "Conda installation not found (failed to locate conda binary)",
-        "Please install Anaconda 3.x for Windows (https://www.anaconda.com/download/#windows) before proceeding.",
+        "Please install Anaconda for Windows (https://www.anaconda.com/download/#windows) before proceeding.",
         sep = "\n"
       )
       stop(msg, call. = FALSE)

--- a/R/python-tools.R
+++ b/R/python-tools.R
@@ -19,12 +19,3 @@ python_module_version <- function(python, module) {
   output <- system2(python, args, stdout = TRUE, stderr = FALSE)
   numeric_version(output)
 }
-
-python_unix_binary <- function(bin) {
-  locations <- file.path(c("/usr/bin", "/usr/local/bin", path.expand("~/.local/bin")), bin)
-  locations <- locations[file.exists(locations)]
-  if (length(locations) > 0)
-    locations[[1]]
-  else
-    NULL
-}

--- a/R/python-tools.R
+++ b/R/python-tools.R
@@ -9,7 +9,8 @@ python_version <- function(python) {
   code <- "import platform; print(platform.python_version())"
   args <- c("-E", "-c", shQuote(code))
   output <- system2(python, args, stdout = TRUE, stderr = FALSE)
-  numeric_version(output)
+  sanitized <- gsub("[^0-9.-]", "", output)
+  numeric_version(sanitized)
 }
 
 python_module_version <- function(python, module) {

--- a/R/virtualenv.R
+++ b/R/virtualenv.R
@@ -272,7 +272,7 @@ virtualenv_module <- function(python) {
 
   # virtualenv not available: instruct the user to install
   commands <- new_stack()
-  commands$push("tools for managing Python virtual environments are not installed.")
+  commands$push("Tools for managing Python virtual environments are not installed.")
   commands$push("")
 
   # if we don't have pip, recommend its installation

--- a/man/py_install.Rd
+++ b/man/py_install.Rd
@@ -4,13 +4,15 @@
 \alias{py_install}
 \title{Install Python packages}
 \usage{
-py_install(packages, envname = NULL, method = c("auto", "virtualenv",
-  "conda"), conda = "auto", ...)
+py_install(packages, envname = Sys.getenv("RETICULATE_PYTHON_ENV", unset
+  = "r-reticulate"), method = c("auto", "virtualenv", "conda"),
+  conda = "auto", ...)
 }
 \arguments{
-\item{packages}{Character vector with package names to install}
+\item{packages}{Character vector with package names to install.}
 
-\item{envname}{Name of environment to install packages into}
+\item{envname}{The name, or full path, of the environment in which Python
+packages are to be installed.}
 
 \item{method}{Installation method. By default, "auto" automatically finds a
 method that will work in the local environment. Change the default to force
@@ -24,7 +26,7 @@ PATH and other conventional install locations).}
 or \code{\link[=virtualenv_install]{virtualenv_install()}}.}
 }
 \description{
-Install Python packages into a virtualenv or conda env.
+Install Python packages into a virtual environment or Conda environment.
 }
 \details{
 On Linux and OS X the "virtualenv" method will be used by default

--- a/tests/testthat/helper-utils.R
+++ b/tests/testthat/helper-utils.R
@@ -1,3 +1,11 @@
+
+# prefer Python 3 if available
+if (is.na(Sys.getenv("RETICULATE_PYTHON", unset = NA))) {
+  python <- Sys.which("python3")
+  if (nzchar(python))
+    reticulate::use_python(python, required = TRUE)
+}
+
 # import some modules used by the tests
 if (py_available(initialize = TRUE)) {
   test <- import("rpytools.test")

--- a/tests/testthat/resources/venv-activate.R
+++ b/tests/testthat/resources/venv-activate.R
@@ -1,6 +1,9 @@
 args <- commandArgs(TRUE)
 venv <- args[[1]]
 
+Sys.unsetenv("RETICULATE_PYTHON")
+Sys.unsetenv("RETICULATE_PYTHON_ENV")
+
 reticulate::use_virtualenv(venv, required = TRUE)
 sys <- reticulate::import("sys")
 cat(sys$path, sep = "\n")

--- a/tests/testthat/test-py_func.R
+++ b/tests/testthat/test-py_func.R
@@ -1,4 +1,4 @@
-context("Function Wrapping")
+context("function wrapping")
 
 test_that("R functions can be wrapped in a Python function with the same signature", {
   skip_if_no_python()

--- a/tests/testthat/test-python-virtual-environments.R
+++ b/tests/testthat/test-python-virtual-environments.R
@@ -1,8 +1,11 @@
-context("Virtual Environments")
+context("virtual environments")
 
 test_that("reticulate can bind to virtual environments created with venv", {
   skip_if_no_python()
   skip_on_cran()
+
+  Sys.unsetenv("RETICULATE_PYTHON")
+  Sys.unsetenv("RETICULATE_PYTHON_ENV")
 
   # find Python 3 binary for testing
   python3 <- Sys.which("python3")


### PR DESCRIPTION
Closes #543.

This PR makes the following changes:

- When type is "auto", we try to detect and infer the environment type directly if an envname was supplied.

- `python_unix_binary()` is removed, and we now instead query `RETICULATE_PYTHON` as well as the PATH for the version of Python to use when creating a new virtual environment. This is done in the `virtualenv_default_python()` function. (note that this detection is not required for Conda environments)

Effectively, this takes some of the logic that was inlined in `py_install()` and delegates back to the already-existing `virtualenv_` and `condaenv_` functions for accomplishing the same.