### PR TITLE
allow reticulate to bind to debug Python builds

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -392,7 +392,7 @@ python_config <- function(python, required_module, python_versions, forced = NUL
     python_libdir_config <- function(var) {
       python_libdir <- config[[var]]
       ext <- switch(Sys.info()[["sysname"]], Darwin = ".dylib", Windows = ".dll", ".so")
-      pattern <- paste0("^libpython", version, "m?", ext)
+      pattern <- paste0("^libpython", version, "d?m?", ext)
       libpython <- list.files(python_libdir, pattern = pattern, full.names = TRUE)
     }
     for (libsrc in c("LIBPL", "LIBDIR")) {

--- a/src/libpython-types.h
+++ b/src/libpython-types.h
@@ -1,0 +1,101 @@
+
+#ifndef LIBPYTHON_TYPES_H
+#define LIBPYTHON_TYPES_H
+
+namespace libpython {
+
+#if _WIN32 || _WIN64
+#if _WIN64
+typedef __int64 Py_ssize_t;
+#else
+typedef int Py_ssize_t;
+#endif
+#else
+typedef long Py_ssize_t;
+#endif
+
+#define METH_VARARGS  0x0001
+#define METH_KEYWORDS 0x0002
+
+#define Py_file_input 257
+#define Py_eval_input 258
+
+
+#ifdef LIBPYTHON_DEBUG
+#define _PyObject_HEAD_EXTRA struct _object *_ob_next; struct _object *_ob_prev;
+#define _PyObject_EXTRA_INIT 0, 0,
+#else
+#define _PyObject_HEAD_EXTRA
+#define _PyObject_EXTRA_INIT
+#endif
+
+
+#define PyObject_HEAD   \
+_PyObject_HEAD_EXTRA    \
+  Py_ssize_t ob_refcnt; \
+struct _typeobject *ob_type;
+
+#define PyObject_VAR_HEAD               \
+PyObject_HEAD                           \
+  Py_ssize_t ob_size;
+
+typedef struct _typeobject {
+  PyObject_VAR_HEAD
+  const char *tp_name;
+  Py_ssize_t tp_basicsize, tp_itemsize;
+} PyTypeObject;
+
+typedef struct _object {
+  PyObject_HEAD
+} PyObject;
+
+typedef PyObject *(*PyCFunction)(PyObject *, PyObject *);
+
+struct PyMethodDef {
+  const char	*ml_name;
+  PyCFunction  ml_meth;
+  int		 ml_flags;
+  const char	*ml_doc;
+};
+typedef struct PyMethodDef PyMethodDef;
+
+#define PyObject_HEAD3 PyObject ob_base;
+
+#define PyObject_HEAD_INIT(type) \
+{ _PyObject_EXTRA_INIT           \
+  1, type },
+
+#define PyModuleDef_HEAD_INIT { \
+PyObject_HEAD_INIT(NULL)        \
+  NULL,                         \
+  0,                            \
+  NULL,                         \
+}
+
+typedef int (*inquiry)(PyObject *);
+typedef int (*visitproc)(PyObject *, void *);
+typedef int (*traverseproc)(PyObject *, visitproc, void *);
+typedef void (*freefunc)(void *);
+
+typedef struct PyModuleDef_Base {
+  PyObject_HEAD3
+  PyObject* (*m_init)(void);
+  Py_ssize_t m_index;
+  PyObject* m_copy;
+} PyModuleDef_Base;
+
+typedef struct PyModuleDef {
+  PyModuleDef_Base m_base;
+  const char* m_name;
+  const char* m_doc;
+  Py_ssize_t m_size;
+  PyMethodDef *m_methods;
+  inquiry m_reload;
+  traverseproc m_traverse;
+  inquiry m_clear;
+  freefunc m_free;
+} PyModuleDef;
+
+} // namespace libpython
+
+#endif /* LIBPYTHON_TYPES_H */

--- a/src/libpython.cpp
+++ b/src/libpython.cpp
@@ -194,6 +194,8 @@ bool LibPython::loadSymbols(bool python3, std::string* pError)
   LOAD_PYTHON_SYMBOL(PyErr_NormalizeException)
   LOAD_PYTHON_SYMBOL(PyErr_ExceptionMatches)
   LOAD_PYTHON_SYMBOL(PyErr_GivenExceptionMatches)
+  LOAD_PYTHON_SYMBOL(PyObject_Print)
+  LOAD_PYTHON_SYMBOL(PyObject_Type)
   LOAD_PYTHON_SYMBOL(PyObject_Str)
   LOAD_PYTHON_SYMBOL(PyObject_Dir)
   LOAD_PYTHON_SYMBOL(PyByteArray_Size)
@@ -245,15 +247,26 @@ bool LibPython::loadSymbols(bool python3, std::string* pError)
 
   // PyUnicode_AsEncodedString may have several different names depending on the Python
   // version and the UCS build type
-  std::vector<std::string> names;
-  names.push_back("PyUnicode_AsEncodedString");
-  names.push_back("PyUnicodeUCS2_AsEncodedString");
-  names.push_back("PyUnicodeUCS4_AsEncodedString");
-  if (!loadSymbol(pLib_, names, (void**)&PyUnicode_AsEncodedString, pError) )
-    return false;
+  {
+    std::vector<std::string> names;
+    names.push_back("PyUnicode_AsEncodedString");
+    names.push_back("PyUnicodeUCS2_AsEncodedString");
+    names.push_back("PyUnicodeUCS4_AsEncodedString");
+    if (!loadSymbol(pLib_, names, (void**)&PyUnicode_AsEncodedString, pError) )
+      return false;
+  }
 
   if (python3) {
-    LOAD_PYTHON_SYMBOL(PyModule_Create2)
+
+    // PyModule_Create has different names depending on how Python was compiled
+    {
+      std::vector<std::string> names;
+      names.push_back("PyModule_Create2TraceRefs");
+      names.push_back("PyModule_Create2");
+      if (!loadSymbol(pLib_, names, (void**)&PyModule_Create, pError) )
+        return false;
+    }
+
     LOAD_PYTHON_SYMBOL(PyImport_AppendInittab)
     LOAD_PYTHON_SYMBOL_AS(Py_SetProgramName, Py_SetProgramName_v3)
     LOAD_PYTHON_SYMBOL_AS(Py_SetPythonHome, Py_SetPythonHome_v3)

--- a/src/libpython.cpp
+++ b/src/libpython.cpp
@@ -258,14 +258,9 @@ bool LibPython::loadSymbols(bool python3, std::string* pError)
 
   if (python3) {
 
-    // PyModule_Create has different names depending on how Python was compiled
-    {
-      std::vector<std::string> names;
-      names.push_back("PyModule_Create2TraceRefs");
-      names.push_back("PyModule_Create2");
-      if (!loadSymbol(pLib_, names, (void**)&PyModule_Create, pError) )
-        return false;
-    }
+    // debug versions of Python will provide PyModule_Create2TraceRefs instead
+    loadSymbol(pLib_, "PyModule_Create2", (void**) &PyModule_Create2, pError);
+    loadSymbol(pLib_, "PyModule_Create2TraceRefs", (void**) &PyModule_Create2TraceRefs, pError);
 
     LOAD_PYTHON_SYMBOL(PyImport_AppendInittab)
     LOAD_PYTHON_SYMBOL_AS(Py_SetProgramName, Py_SetProgramName_v3)

--- a/src/libpython.h
+++ b/src/libpython.h
@@ -1,6 +1,6 @@
 
-#ifndef __LIBPYTHON_HPP__
-#define __LIBPYTHON_HPP__
+#ifndef LIBPYTHON_H
+#define LIBPYTHON_H
 
 #include <string>
 #include <ostream>
@@ -15,93 +15,9 @@
 #define _PYTHON_API_VERSION 1013
 #define _PYTHON3_ABI_VERSION 3
 
+#include "libpython-types.h"
+
 namespace libpython {
-
-#if _WIN32 || _WIN64
-#if _WIN64
-typedef __int64 Py_ssize_t;
-#else
-typedef int Py_ssize_t;
-#endif
-#else
-typedef long Py_ssize_t;
-#endif
-
-#define METH_VARARGS  0x0001
-#define METH_KEYWORDS 0x0002
-
-#define Py_file_input 257
-#define Py_eval_input 258
-
-#define _PyObject_HEAD_EXTRA
-#define _PyObject_EXTRA_INIT
-
-#define PyObject_HEAD  \
-_PyObject_HEAD_EXTRA   \
-  Py_ssize_t ob_refcnt; \
-struct _typeobject *ob_type;
-
-#define PyObject_VAR_HEAD               \
-PyObject_HEAD                           \
-  Py_ssize_t ob_size;
-
-typedef struct _typeobject {
-PyObject_VAR_HEAD
-  const char *tp_name;
-  Py_ssize_t tp_basicsize, tp_itemsize;
-} PyTypeObject;
-
-typedef struct _object {
-PyObject_HEAD
-} PyObject;
-
-typedef PyObject *(*PyCFunction)(PyObject *, PyObject *);
-
-struct PyMethodDef {
-  const char	*ml_name;
-  PyCFunction  ml_meth;
-  int		 ml_flags;
-  const char	*ml_doc;
-};
-typedef struct PyMethodDef PyMethodDef;
-
-#define PyObject_HEAD3 PyObject ob_base;
-
-#define PyObject_HEAD_INIT(type) \
-{ _PyObject_EXTRA_INIT           \
-  1, type },
-
-#define PyModuleDef_HEAD_INIT { \
-PyObject_HEAD_INIT(NULL) \
-  NULL, \
-  0, \
-  NULL, \
-}
-
-typedef int (*inquiry)(PyObject *);
-typedef int (*visitproc)(PyObject *, void *);
-typedef int (*traverseproc)(PyObject *, visitproc, void *);
-typedef void (*freefunc)(void *);
-
-typedef struct PyModuleDef_Base {
-  PyObject_HEAD3
-  PyObject* (*m_init)(void);
-  Py_ssize_t m_index;
-  PyObject* m_copy;
-} PyModuleDef_Base;
-
-typedef struct PyModuleDef{
-  PyModuleDef_Base m_base;
-  const char* m_name;
-  const char* m_doc;
-  Py_ssize_t m_size;
-  PyMethodDef *m_methods;
-  inquiry m_reload;
-  traverseproc m_traverse;
-  inquiry m_clear;
-  freefunc m_free;
-} PyModuleDef;
-
 
 LIBPYTHON_EXTERN PyTypeObject* PyFunction_Type;
 LIBPYTHON_EXTERN PyTypeObject* PyModule_Type;
@@ -127,18 +43,19 @@ void initialize_type_objects(bool python3);
 
 #define Py_TYPE(ob) (((PyObject*)(ob))->ob_type)
 
-#define PyUnicode_Check(o) (Py_TYPE(o) == Py_TYPE(Py_Unicode))
-#define PyString_Check(o) (Py_TYPE(o) == Py_TYPE(Py_String))
-#define PyInt_Check(o)  (Py_TYPE(o) == Py_TYPE(Py_Int))
-#define PyLong_Check(o)  (Py_TYPE(o) == Py_TYPE(Py_Long))
-#define PyBool_Check(o) ((o == Py_False) | (o == Py_True))
-#define PyDict_Check(o) (Py_TYPE(o) == Py_TYPE(Py_Dict))
-#define PyFloat_Check(o) (Py_TYPE(o) == Py_TYPE(Py_Float))
-#define PyFunction_Check(op) ((PyTypeObject*)(Py_TYPE(op)) == PyFunction_Type)
-#define PyTuple_Check(o) (Py_TYPE(o) == Py_TYPE(Py_Tuple))
-#define PyList_Check(o) (Py_TYPE(o) == Py_TYPE(Py_List))
-#define PyComplex_Check(o) (Py_TYPE(o) == Py_TYPE(Py_Complex))
-#define PyByteArray_Check(o) (Py_TYPE(o) == Py_TYPE(Py_ByteArray))
+#define PyUnicode_Check(o)   (PyObject_Type(o) == PyObject_Type(Py_Unicode))
+#define PyString_Check(o)    (PyObject_Type(o) == PyObject_Type(Py_String))
+#define PyInt_Check(o)       (PyObject_Type(o) == PyObject_Type(Py_Int))
+#define PyLong_Check(o)      (PyObject_Type(o) == PyObject_Type(Py_Long))
+#define PyDict_Check(o)      (PyObject_Type(o) == PyObject_Type(Py_Dict))
+#define PyFloat_Check(o)     (PyObject_Type(o) == PyObject_Type(Py_Float))
+#define PyTuple_Check(o)     (PyObject_Type(o) == PyObject_Type(Py_Tuple))
+#define PyList_Check(o)      (PyObject_Type(o) == PyObject_Type(Py_List))
+#define PyComplex_Check(o)   (PyObject_Type(o) == PyObject_Type(Py_Complex))
+#define PyByteArray_Check(o) (PyObject_Type(o) == PyObject_Type(Py_ByteArray))
+
+#define PyFunction_Check(op) ((PyTypeObject*)(PyObject_Type(op)) == PyFunction_Type)
+#define PyBool_Check(o)      ((o == Py_False) | (o == Py_True))
 
 LIBPYTHON_EXTERN void (*Py_Initialize)();
 LIBPYTHON_EXTERN int (*Py_IsInitialized)();
@@ -155,7 +72,8 @@ LIBPYTHON_EXTERN PyObject* (*PyImport_Import)(PyObject * name);
 LIBPYTHON_EXTERN PyObject* (*PyImport_GetModuleDict)();
 
 
-LIBPYTHON_EXTERN PyObject* (*PyModule_Create)(PyModuleDef *def, int);
+LIBPYTHON_EXTERN PyObject* (*PyModule_Create2)(PyModuleDef *def, int);
+LIBPYTHON_EXTERN PyObject* (*PyModule_Create2TraceRefs)(PyModuleDef *def, int);
 LIBPYTHON_EXTERN int (*PyImport_AppendInittab)(const char *name, PyObject* (*initfunc)());
 
 LIBPYTHON_EXTERN PyObject* (*Py_BuildValue)(const char *format, ...);
@@ -676,6 +594,4 @@ LIBPYTHON_EXTERN PyThreadState* (*PyThreadState_Next)(PyThreadState*);
 
 } // namespace libpython
 
-#endif
-
-
+#endif /* LIBPYTHON_H */

--- a/src/libpython.h
+++ b/src/libpython.h
@@ -155,7 +155,7 @@ LIBPYTHON_EXTERN PyObject* (*PyImport_Import)(PyObject * name);
 LIBPYTHON_EXTERN PyObject* (*PyImport_GetModuleDict)();
 
 
-LIBPYTHON_EXTERN PyObject* (*PyModule_Create2)(PyModuleDef *def, int);
+LIBPYTHON_EXTERN PyObject* (*PyModule_Create)(PyModuleDef *def, int);
 LIBPYTHON_EXTERN int (*PyImport_AppendInittab)(const char *name, PyObject* (*initfunc)());
 
 LIBPYTHON_EXTERN PyObject* (*Py_BuildValue)(const char *format, ...);
@@ -163,6 +163,8 @@ LIBPYTHON_EXTERN PyObject* (*Py_BuildValue)(const char *format, ...);
 LIBPYTHON_EXTERN void (*Py_IncRef)(PyObject *);
 LIBPYTHON_EXTERN void (*Py_DecRef)(PyObject *);
 
+LIBPYTHON_EXTERN int (*PyObject_Print)(PyObject *, FILE*, int);
+LIBPYTHON_EXTERN PyObject* (*PyObject_Type)(PyObject *);
 LIBPYTHON_EXTERN PyObject* (*PyObject_Str)(PyObject *);
 
 LIBPYTHON_EXTERN int (*PyObject_IsInstance)(PyObject *object, PyObject *typeorclass);
@@ -211,6 +213,7 @@ LIBPYTHON_EXTERN PyObject* (*PyString_FromStringAndSize)(const char *, Py_ssize_
 
 LIBPYTHON_EXTERN PyObject* (*PyUnicode_EncodeLocale)(PyObject *unicode, const char *errors);
 LIBPYTHON_EXTERN PyObject* (*PyUnicode_AsEncodedString)(PyObject *unicode, const char *encoding, const char *errors);
+
 LIBPYTHON_EXTERN int (*PyBytes_AsStringAndSize)(
     PyObject *obj,      /* string or Unicode object */
     char **s,           /* pointer to buffer variable */

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -1424,7 +1424,7 @@ static struct PyModuleDef RPYCallModuleDef = {
 };
 
 extern "C" PyObject* initializeRPYCall(void) {
-  return PyModule_Create2(&RPYCallModuleDef, _PYTHON3_ABI_VERSION);
+  return PyModule_Create(&RPYCallModuleDef, _PYTHON3_ABI_VERSION);
 }
 
 // forward declare py_run_file

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -1400,7 +1400,7 @@ extern "C" PyObject* call_python_function_on_main_thread(
   return Py_None;
 }
 
-extern "C" PyObject* initializeRPYCall(void) {
+extern "C" PyObject* PyInit_rpycall(void) {
 
   if (PyModule_Create2 != NULL)
   {
@@ -1517,11 +1517,11 @@ void py_initialize(const std::string& python,
       // if R is embedded in a python environment, rpycall has to be loaded as a regular
       // module.
       PyImport_AddModule("rpycall");
-      PyDict_SetItemString(PyImport_GetModuleDict(), "rpycall", initializeRPYCall());
+      PyDict_SetItemString(PyImport_GetModuleDict(), "rpycall", PyInit_rpycall());
 
     } else {
       // add rpycall module
-      PyImport_AppendInittab("rpycall", &initializeRPYCall);
+      PyImport_AppendInittab("rpycall", &PyInit_rpycall);
 
       // initialize python
       Py_Initialize();

--- a/src/rpycall-common.h
+++ b/src/rpycall-common.h
@@ -1,0 +1,59 @@
+
+#include <Rcpp.h>
+using namespace Rcpp;
+
+#include "libpython-types.h"
+#include "reticulate_types.h"
+
+#include "event_loop.h"
+#include "tinythread.h"
+
+#include <fstream>
+#include <time.h>
+
+using namespace libpython;
+
+namespace libpython {
+
+extern "C" PyObject* call_r_function(PyObject *self, PyObject* args, PyObject* keywords);
+extern "C" PyObject* call_python_function_on_main_thread(PyObject *self, PyObject* args, PyObject* keywords);
+
+} // end namespace libpython
+
+namespace rpycall {
+namespace {
+
+PyMethodDef rpycallmethods[] = {
+
+  {
+    "call_r_function", (PyCFunction)call_r_function,
+    METH_VARARGS | METH_KEYWORDS, "Call an R function"
+  },
+
+  {
+    "call_python_function_on_main_thread", (PyCFunction)call_python_function_on_main_thread,
+    METH_VARARGS | METH_KEYWORDS, "Call a Python function on the main thread"
+  },
+
+  {
+    NULL, NULL,
+    0, NULL
+  }
+
+};
+
+static struct PyModuleDef rpycallmodule = {
+  PyModuleDef_HEAD_INIT,
+  "rpycall",
+  NULL,
+  -1,
+  rpycallmethods,
+  NULL,
+  NULL,
+  NULL,
+  NULL
+};
+
+} // end namespace rpycall
+} // end anonymous namespace
+

--- a/src/rpycall-common.h
+++ b/src/rpycall-common.h
@@ -26,18 +26,24 @@ namespace {
 PyMethodDef rpycallmethods[] = {
 
   {
-    "call_r_function", (PyCFunction)call_r_function,
-    METH_VARARGS | METH_KEYWORDS, "Call an R function"
+    "call_r_function",
+    (PyCFunction) call_r_function,
+    METH_VARARGS | METH_KEYWORDS,
+    "Call an R function"
   },
 
   {
-    "call_python_function_on_main_thread", (PyCFunction)call_python_function_on_main_thread,
-    METH_VARARGS | METH_KEYWORDS, "Call a Python function on the main thread"
+    "call_python_function_on_main_thread",
+    (PyCFunction) call_python_function_on_main_thread,
+    METH_VARARGS | METH_KEYWORDS,
+    "Call a Python function on the main thread"
   },
 
   {
-    NULL, NULL,
-    0, NULL
+    NULL,
+    NULL,
+    0,
+    NULL
   }
 
 };

--- a/src/rpycall-debug.cpp
+++ b/src/rpycall-debug.cpp
@@ -1,0 +1,17 @@
+
+#define LIBPYTHON_DEBUG
+#include "libpython-types.h"
+#include "rpycall-common.h"
+
+namespace rpycall {
+
+void* rpycall_module_debug() {
+  return &rpycallmodule;
+}
+
+void* rpycall_methods_debug() {
+  return &rpycallmethods;
+}
+
+} // namespace libpython
+

--- a/src/rpycall-release.cpp
+++ b/src/rpycall-release.cpp
@@ -1,0 +1,17 @@
+
+#define LIBPYTHON_RELEASE
+#include "libpython-types.h"
+#include "rpycall-common.h"
+
+namespace rpycall {
+
+void* rpycall_module_release() {
+  return &rpycallmodule;
+}
+
+void* rpycall_methods_release() {
+  return &rpycallmethods;
+}
+
+} // namespace libpython
+

--- a/src/rpycall.h
+++ b/src/rpycall.h
@@ -1,0 +1,12 @@
+
+#ifndef RPYCALL_H
+#define RPYCALL_H
+
+namespace rpycall {
+void* rpycall_module_debug();
+void* rpycall_module_release();
+void* rpycall_methods_debug();
+void* rpycall_methods_release();
+} // namespace rpycall
+
+#endif /* RPYCALL_H */


### PR DESCRIPTION
This PR makes it possible for reticulate to bind to debug Python builds.

The main challenge here is that the PyObject struct layout (whose layout is needed for the PyModuleDef struct) is different when debugging is enabled. Because of that, we need to include two types of definitions, and choose the appropriate one at runtime.

This also forces us to change a couple macros which tried to use the PyObject struct directly (we instead call back into libpython whenever possible to ensure we do the right thing)