### PR TITLE
allow reticulate to be compiled to use debug Python

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@
 
 Install the development version of reticulate with `remotes::install_github("rstudio/reticulate")`.
 
+- It is now possible to compile `reticulate` with support for debug
+  versions of Python by setting the `RETICULATE_PYTHON_DEBUG` preprocessor
+  define during compilation. (#548)
+
 - reticulate now warns if it did not honor the user's request to load a
   particular version of Python, as through e.g. `reticulate::use_python()`.
   (#545)

--- a/R/config.R
+++ b/R/config.R
@@ -392,7 +392,7 @@ python_config <- function(python, required_module, python_versions, forced = NUL
     python_libdir_config <- function(var) {
       python_libdir <- config[[var]]
       ext <- switch(Sys.info()[["sysname"]], Darwin = ".dylib", Windows = ".dll", ".so")
-      pattern <- paste0("^libpython", version, "m?", ext)
+      pattern <- paste0("^libpython", version, "d?m?", ext)
       libpython <- list.files(python_libdir, pattern = pattern, full.names = TRUE)
     }
     for (libsrc in c("LIBPL", "LIBDIR")) {

--- a/src/libpython.cpp
+++ b/src/libpython.cpp
@@ -253,7 +253,15 @@ bool LibPython::loadSymbols(bool python3, std::string* pError)
     return false;
 
   if (python3) {
-    LOAD_PYTHON_SYMBOL(PyModule_Create2)
+
+    // Debug versions of Python will provide PyModule_Create2TraceRefs,
+    // while release versions will provide PyModule_Create
+#ifdef RETICULATE_PYTHON_DEBUG
+    LOAD_PYTHON_SYMBOL_AS(PyModule_Create2TraceRefs, PyModule_Create)
+#else
+    LOAD_PYTHON_SYMBOL_AS(PyModule_Create2, PyModule_Create)
+#endif
+
     LOAD_PYTHON_SYMBOL(PyImport_AppendInittab)
     LOAD_PYTHON_SYMBOL_AS(Py_SetProgramName, Py_SetProgramName_v3)
     LOAD_PYTHON_SYMBOL_AS(Py_SetPythonHome, Py_SetPythonHome_v3)

--- a/src/libpython.h
+++ b/src/libpython.h
@@ -33,8 +33,20 @@ typedef long Py_ssize_t;
 #define Py_file_input 257
 #define Py_eval_input 258
 
+#ifdef RETICULATE_PYTHON_DEBUG
+
+#define _PyObject_HEAD_EXTRA            \
+    struct _object *_ob_next;           \
+    struct _object *_ob_prev;
+
+#define _PyObject_EXTRA_INIT 0, 0,
+
+#else
+
 #define _PyObject_HEAD_EXTRA
 #define _PyObject_EXTRA_INIT
+
+#endif /* RETICULATE_PYTHON_DEBUG */
 
 #define PyObject_HEAD  \
 _PyObject_HEAD_EXTRA   \
@@ -155,7 +167,7 @@ LIBPYTHON_EXTERN PyObject* (*PyImport_Import)(PyObject * name);
 LIBPYTHON_EXTERN PyObject* (*PyImport_GetModuleDict)();
 
 
-LIBPYTHON_EXTERN PyObject* (*PyModule_Create2)(PyModuleDef *def, int);
+LIBPYTHON_EXTERN PyObject* (*PyModule_Create)(PyModuleDef *def, int);
 LIBPYTHON_EXTERN int (*PyImport_AppendInittab)(const char *name, PyObject* (*initfunc)());
 
 LIBPYTHON_EXTERN PyObject* (*Py_BuildValue)(const char *format, ...);

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -1424,7 +1424,7 @@ static struct PyModuleDef RPYCallModuleDef = {
 };
 
 extern "C" PyObject* initializeRPYCall(void) {
-  return PyModule_Create2(&RPYCallModuleDef, _PYTHON3_ABI_VERSION);
+  return PyModule_Create(&RPYCallModuleDef, _PYTHON3_ABI_VERSION);
 }
 
 // forward declare py_run_file


### PR DESCRIPTION
This is a simpler version of #546, which simply allows the user to choose between debug / release versions of Python at compile time for reticulate. The user can define `RETICULATE_PYTHON_DEBUG` to declare that they're building a version of reticulate that should work with debug versions of Python.

This is less useful than #546, but safer, and since this is already a feature intended for 'expert' users it's probably okay to hide it behind a pre-processor define (ie I imagine we'd only use this internally when attempting to debug crashes / segfaults)