### PR TITLE
accept 'python_version' in py_install()

### DIFF
--- a/R/conda.R
+++ b/R/conda.R
@@ -167,9 +167,9 @@ conda_install <- function(envname = NULL,
   } else if (!is.null(python_package)) {
     args <- conda_args("install", envname, python_package)
     status <- system2(conda, shQuote(args))
-    if (result != 0L) {
+    if (status != 0L) {
       fmt <- "installation of '%s' into environment '%s' failed [error code %i]"
-      msg <- sprintf(fmt, python_package, envname, result)
+      msg <- sprintf(fmt, python_package, envname, status)
       stop(msg, call. = FALSE)
     }
   }

--- a/R/conda.R
+++ b/R/conda.R
@@ -4,10 +4,15 @@
 #' environments](https://conda.io/docs/user-guide/tasks/manage-environments.html).
 #'
 #' @param envname Name of conda environment
+#'
 #' @param conda Path to conda executable (or "auto" to find conda using the
 #'   PATH and other conventional install locations).
+#'
 #' @param packages Character vector with package names to install or remove.
+#'
 #' @param pip `TRUE` to use pip (defaults to `FALSE`)
+#'
+#' @param ... Optional arguments, reserved for future expansion.
 #'
 #' @return `conda_list()` returns a data frame with the names and paths to the
 #'   respective python binaries of available environments. `conda_create()`
@@ -144,7 +149,8 @@ conda_install <- function(envname = NULL,
                           pip = FALSE,
                           pip_ignore_installed = TRUE,
                           conda = "auto",
-                          python_version = NULL)
+                          python_version = NULL,
+                          ...)
 {
   # resolve conda binary
   conda <- conda_binary(conda)

--- a/R/conda.R
+++ b/R/conda.R
@@ -318,39 +318,10 @@ find_conda <- function() {
 
 condaenv_resolve <- function(envname = NULL) {
 
-  # handle case where envname is NULL (use default / active env)
-  if (is.null(envname)) {
-
-    default <- Sys.getenv("RETICULATE_PYTHON_ENV", unset = NA)
-    if (!is.na(default)) {
-      path <- normalizePath(default, winslash = "/", mustWork = FALSE)
-      if (!is_condaenv(path)) {
-        fmt <- "there is no conda environment at path '%s'"
-        stop(sprintf(fmt, path))
-      }
-      return(path)
-    }
-
-    # provide context of caller (if any) when emitting error
-    call <- sys.call(sys.parent())
-    if (is.null(call))
-      call <- sys.call()
-
-    fmt <- "missing environment in call to '%s'"
-    stop(sprintf(fmt, format(sys.call(sys.parent()))), call. = FALSE)
-
-  }
-
-  # treat environment 'names' containing slashes as paths
-  # rather than environments living in WORKON_HOME
-  if (grepl("[/\\]", envname)) {
-    if (file.exists(envname))
-      envname <- normalizePath(envname, winslash = "/")
-    return(envname)
-  }
-
-  # no slashes; just use the environment name as-is
-  envname
+  python_environment_resolve(
+    envname = envname,
+    resolve = identity
+  )
 
 }
 

--- a/R/conda.R
+++ b/R/conda.R
@@ -138,18 +138,29 @@ conda_remove <- function(envname, packages = NULL, conda = "auto") {
 #' @keywords internal
 #'
 #' @export
-conda_install <- function(envname = NULL, packages, forge = TRUE, pip = FALSE, pip_ignore_installed = TRUE, conda = "auto") {
-
+conda_install <- function(envname = NULL,
+                          packages,
+                          forge = TRUE,
+                          pip = FALSE,
+                          pip_ignore_installed = TRUE,
+                          conda = "auto",
+                          python_version = NULL)
+{
   # resolve conda binary
   conda <- conda_binary(conda)
 
   # resolve environment name
   envname <- condaenv_resolve(envname)
 
+  # honor request for specific Python
+  python_package <- NULL
+  if (!is.null(python_version))
+    python_package <- paste("python", python_version, sep = "=")
+
   # create the environment if needed
   python <- tryCatch(conda_python(envname = envname, conda = conda), error = identity)
   if (inherits(python, "error") || !file.exists(python))
-    conda_create(envname, conda = conda)
+    conda_create(envname, packages = python_package, conda = conda)
 
   if (pip) {
     # use pip package manager
@@ -168,7 +179,7 @@ conda_install <- function(envname = NULL, packages, forge = TRUE, pip = FALSE, p
     args <- conda_args("install", envname)
     if (forge)
       args <- c(args, "-c", "conda-forge")
-    args <- c(args, packages)
+    args <- c(args, python_package, packages)
     result <- system2(conda, shQuote(args))
   }
 
@@ -343,6 +354,7 @@ condaenv_exists <- function(envname = NULL, conda = "auto") {
   if (inherits(python, "error"))
     return(FALSE)
 
+  # validate the Python binary exists
   file.exists(python)
 
 }

--- a/R/install.R
+++ b/R/install.R
@@ -82,10 +82,6 @@ py_install <- function(packages,
   if (method == "auto")
     method <- py_install_method_detect(envname = envname, conda = conda)
 
-  # handle NULL envname (may be passed from upstream calls)
-  if (is.null(envname))
-    envname <- Sys.getenv("RETICULATE_PYTHON_ENV", unset = "r-reticulate")
-
   # validate method
   if (identical(method, "virtualenv") && is_windows()) {
     stop("Installing Python packages into a virtualenv is not supported on Windows",
@@ -93,8 +89,7 @@ py_install <- function(packages,
   }
 
   # perform the install
-  switch(
-    method,
+  switch(method,
     virtualenv = virtualenv_install(envname = envname, packages = packages, ...),
     conda = conda_install(envname, packages = packages, conda = conda, python_version = python_version, ...),
     stop("unrecognized installation method '", method, "'")

--- a/R/install.R
+++ b/R/install.R
@@ -51,11 +51,15 @@ py_install_method_detect <- function(envname, conda = "auto") {
 #'
 #' @param packages Character vector with package names to install.
 #' @param envname The name, or full path, of the environment in which Python
-#'   packages are to be installed.
+#'   packages are to be installed. When `NULL` (the default), the active
+#'   environment as set by the `RETICULATE_PYTHON_ENV` variable will be used;
+#'   if that is unset, then the `r-reticulate` environment will be used.
 #' @param method Installation method. By default, "auto" automatically finds a
 #'   method that will work in the local environment. Change the default to force
 #'   a specific installation method. Note that the "virtualenv" method is not
 #'   available on Windows.
+#' @param python_version The requested Python version. Ignored when attempting
+#'   to install with a Python virtual environment.
 #' @param ... Additional arguments passed to [conda_install()]
 #'   or [virtualenv_install()].
 #'
@@ -67,15 +71,20 @@ py_install_method_detect <- function(envname, conda = "auto") {
 #'
 #' @export
 py_install <- function(packages,
-                       envname = Sys.getenv("RETICULATE_PYTHON_ENV", unset = "r-reticulate"),
+                       envname = NULL,
                        method = c("auto", "virtualenv", "conda"),
                        conda = "auto",
+                       python_version = NULL,
                        ...)
 {
   # resolve 'auto' method
   method <- match.arg(method)
   if (method == "auto")
     method <- py_install_method_detect(envname = envname, conda = conda)
+
+  # handle NULL envname (may be passed from upstream calls)
+  if (is.null(envname))
+    envname <- Sys.getenv("RETICULATE_PYTHON_ENV", unset = "r-reticulate")
 
   # validate method
   if (identical(method, "virtualenv") && is_windows()) {
@@ -87,7 +96,7 @@ py_install <- function(packages,
   switch(
     method,
     virtualenv = virtualenv_install(envname = envname, packages = packages, ...),
-    conda = conda_install(envname, packages = packages, conda = conda, ...),
+    conda = conda_install(envname, packages = packages, conda = conda, python_version = python_version, ...),
     stop("unrecognized installation method '", method, "'")
   )
 

--- a/R/python-environments.R
+++ b/R/python-environments.R
@@ -1,0 +1,16 @@
+
+python_environment_resolve <- function(envname = NULL, resolve = identity) {
+
+  # use RETICULATE_PYTHON_ENV as default
+  envname <- envname %||% Sys.getenv("RETICULATE_PYTHON_ENV", unset = "r-reticulate")
+
+  # treat environment 'names' containing slashes as full paths
+  if (grepl("[/\\]", envname)) {
+    envname <- normalizePath(envname, winslash = "/", mustWork = FALSE)
+    return(envname)
+  }
+
+  # otherwise, resolve the environment name as necessary
+  resolve(envname)
+
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,4 +1,5 @@
 
+`%||%` <- function(x, y) if (is.null(x)) y else x
 
 traceback_enabled <- function() {
 

--- a/R/virtualenv.R
+++ b/R/virtualenv.R
@@ -170,7 +170,11 @@ virtualenv_python <- function(envname = NULL) {
 
 
 virtualenv_exists <- function(envname = NULL) {
-  path <- virtualenv_path(envname)
+
+  # try to resolve path
+  path <- tryCatch(virtualenv_path(envname), error = identity)
+  if (inherits(path, "error"))
+    return(FALSE)
 
   # check that the directory exists
   if (!utils::file_test("-d", path))

--- a/R/virtualenv.R
+++ b/R/virtualenv.R
@@ -30,6 +30,8 @@
 #'   virtual environment. When `NULL`, the Python interpreter associated with
 #'   the current session will be used.
 #'
+#' @param ... Optional arguments; currently ignored for future expansion.
+#'
 #' @name virtualenv-tools
 NULL
 
@@ -87,8 +89,11 @@ virtualenv_create <- function(envname = NULL, python = NULL) {
 #' @inheritParams virtualenv-tools
 #' @rdname virtualenv-tools
 #' @export
-virtualenv_install <- function(envname = NULL, packages, ignore_installed = TRUE) {
-
+virtualenv_install <- function(envname = NULL,
+                               packages,
+                               ignore_installed = TRUE,
+                               ...)
+{
   # create virtual environment on demand
   path <- virtualenv_path(envname)
   if (!file.exists(path))

--- a/man/conda-tools.Rd
+++ b/man/conda-tools.Rd
@@ -18,7 +18,7 @@ conda_create(envname = NULL, packages = "python", conda = "auto")
 conda_remove(envname, packages = NULL, conda = "auto")
 
 conda_install(envname = NULL, packages, forge = TRUE, pip = FALSE,
-  pip_ignore_installed = TRUE, conda = "auto")
+  pip_ignore_installed = TRUE, conda = "auto", python_version = NULL)
 
 conda_binary(conda = "auto")
 

--- a/man/conda-tools.Rd
+++ b/man/conda-tools.Rd
@@ -18,7 +18,8 @@ conda_create(envname = NULL, packages = "python", conda = "auto")
 conda_remove(envname, packages = NULL, conda = "auto")
 
 conda_install(envname = NULL, packages, forge = TRUE, pip = FALSE,
-  pip_ignore_installed = TRUE, conda = "auto", python_version = NULL)
+  pip_ignore_installed = TRUE, conda = "auto", python_version = NULL,
+  ...)
 
 conda_binary(conda = "auto")
 
@@ -43,6 +44,8 @@ so that specific package versions can be installed even if they are downgrades. 
 option is useful for situations where you don't want a pip install to attempt an overwrite
 of a conda binary package (e.g. SciPy on Windows which is very difficult to install via
 pip due to compilation requirements).}
+
+\item{...}{Optional arguments, reserved for future expansion.}
 }
 \value{
 \code{conda_list()} returns a data frame with the names and paths to the

--- a/man/py_install.Rd
+++ b/man/py_install.Rd
@@ -4,15 +4,16 @@
 \alias{py_install}
 \title{Install Python packages}
 \usage{
-py_install(packages, envname = Sys.getenv("RETICULATE_PYTHON_ENV", unset
-  = "r-reticulate"), method = c("auto", "virtualenv", "conda"),
-  conda = "auto", ...)
+py_install(packages, envname = NULL, method = c("auto", "virtualenv",
+  "conda"), conda = "auto", python_version = NULL, ...)
 }
 \arguments{
 \item{packages}{Character vector with package names to install.}
 
 \item{envname}{The name, or full path, of the environment in which Python
-packages are to be installed.}
+packages are to be installed. When \code{NULL} (the default), the active
+environment as set by the \code{RETICULATE_PYTHON_ENV} variable will be used;
+if that is unset, then the \code{r-reticulate} environment will be used.}
 
 \item{method}{Installation method. By default, "auto" automatically finds a
 method that will work in the local environment. Change the default to force
@@ -21,6 +22,9 @@ available on Windows.}
 
 \item{conda}{Path to conda executable (or "auto" to find conda using the
 PATH and other conventional install locations).}
+
+\item{python_version}{The requested Python version. Ignored when attempting
+to install with a Python virtual environment.}
 
 \item{...}{Additional arguments passed to \code{\link[=conda_install]{conda_install()}}
 or \code{\link[=virtualenv_install]{virtualenv_install()}}.}

--- a/man/virtualenv-tools.Rd
+++ b/man/virtualenv-tools.Rd
@@ -14,7 +14,8 @@ virtualenv_list()
 
 virtualenv_create(envname = NULL, python = NULL)
 
-virtualenv_install(envname = NULL, packages, ignore_installed = TRUE)
+virtualenv_install(envname = NULL, packages, ignore_installed = TRUE,
+  ...)
 
 virtualenv_remove(envname = NULL, packages = NULL,
   confirm = interactive())
@@ -41,6 +42,8 @@ the current session will be used.}
 requested packages? (This should normally be \code{TRUE}, so that pre-installed
 packages available in the site libraries are ignored and hence packages
 are installed into the virtual environment.)}
+
+\item{...}{Optional arguments; currently ignored for future expansion.}
 
 \item{confirm}{Boolean; confirm before removing packages or virtual
 environments?}


### PR DESCRIPTION
This PR allows users of `py_install()` and `conda_install()` to request a specific Python version, to be installed in the associated Conda environment. (it currently ignored for virtual environments)

This should allow e.g. `install_tensorflow()` to work with Conda environments with a specific Python version requirement.