### PR TITLE
check if keywords are NULL before trying to do anything

### DIFF
--- a/src/python.cpp
+++ b/src/python.cpp
@@ -1250,6 +1250,7 @@ extern "C" PyObject* call_r_function(PyObject *self, PyObject* args, PyObject* k
   // the first argument is always the capsule containing the R function to call
   PyObject* capsule = PyTuple_GetItem(args, 0);
   RObject rFunction = r_object_from_capsule(capsule);
+
   bool convert = (bool)PyCapsule_GetContext(capsule);
 
   // convert remainder of positional arguments to R list
@@ -1268,15 +1269,18 @@ extern "C" PyObject* call_r_function(PyObject *self, PyObject* args, PyObject* k
 
   // get keyword arguments
   List rKeywords;
-  if (convert) {
-    rKeywords = ::py_to_r(keywords, convert);
-  } else {
-    PyObject *key, *value;
-    Py_ssize_t pos = 0;
-    while (PyDict_Next(keywords, &pos, &key, &value)) {
-      PyObjectPtr str(PyObject_Str(key));
-      Py_IncRef(value);
-      rKeywords[as_std_string(str)] = py_ref(value, convert);
+
+  if (keywords != NULL) {
+    if (convert) {
+      rKeywords = ::py_to_r(keywords, convert);
+    } else {
+      PyObject *key, *value;
+      Py_ssize_t pos = 0;
+      while (PyDict_Next(keywords, &pos, &key, &value)) {
+        PyObjectPtr str(PyObject_Str(key));
+        Py_IncRef(value);
+        rKeywords[as_std_string(str)] = py_ref(value, convert);
+      }
     }
   }
 


### PR DESCRIPTION
@kevinushey I am getting some random crashes with TF nightly and this fixes it. 

I am not really sure why this happens, but can be related on how the TF autograph creates and calls functions that we define.

I once proposed this fix: https://github.com/rstudio/reticulate/pull/520 but I think this one is more precise.

The easiest way to reproduce the segfault is to install TF nightly and run :

```
tfdatasets::dataset_map(tfdatasets::tensors_dataset(1:10), function(x) x)
```

Although the error happens whenever you pass R functions to TensorFlow.

