### PR TITLE
Switch to conda activate command

### DIFF
--- a/R/conda.R
+++ b/R/conda.R
@@ -182,14 +182,13 @@ conda_install <- function(envname = NULL,
 
   if (pip) {
     # use pip package manager
-    condaenv_bin <- function(bin) path.expand(file.path(dirname(conda), bin))
-    cmd <- sprintf("%s%s %s && pip install --upgrade %s %s%s",
-                   ifelse(is_windows(), "", ifelse(is_osx(), "source ", "/bin/bash -c \"source ")),
-                   shQuote(path.expand(condaenv_bin("activate"))),
+    cmd <- sprintf("%s %s && pip install --upgrade %s %s%s",
+                   ifelse(is_windows(), paste(conda, "activate"),
+                          sprintf("bash -c \"eval $(%s shell.bash hook) && conda activate", conda)),
                    envname,
                    ifelse(pip_ignore_installed, "--ignore-installed", ""),
                    paste(shQuote(packages), collapse = " "),
-                   ifelse(is_windows(), "", ifelse(is_osx(), "", "\"")))
+                   ifelse(is_windows(), "", "\""))
     result <- system(cmd)
 
   } else {


### PR DESCRIPTION
Based on #522, here is a pull request for the switch from the `source activate` to the `conda activate` command. Should work with Conda >= 4.6. Tested on Fedora 29 and Windows 10. Unfortunately, I do not have a macOS installation for testing.

Not sure if you want to merge this, but feel free to take a look and propose some changes.