### PR TITLE
Autocomplete functions: Get formals from Python function signatures!

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -34,6 +34,10 @@ py_is_callable <- function(x) {
     .Call(`_reticulate_py_is_callable`, x)
 }
 
+py_get_formals <- function(func, convert) {
+    .Call(`_reticulate_py_get_formals`, func, convert)
+}
+
 r_to_py_impl <- function(object, convert) {
     .Call(`_reticulate_r_to_py_impl`, object, convert)
 }

--- a/R/python.R
+++ b/R/python.R
@@ -1225,6 +1225,7 @@ py_callable_as_function <- function(callable, convert) {
   f <- function(...) {
     # Cannot use list(...), as we replace the formals() later.
     call <- sys.call()
+    cat('Call: '); print(call)
     call[[1]] <- as.name('list')
     dots <- py_resolve_dots(eval(call))
     result <- py_call_impl(callable, dots$args, dots$keywords)
@@ -1239,9 +1240,8 @@ py_callable_as_function <- function(callable, convert) {
       result
     }
   }
-  if (length(attr(f, "formals")) > 0)
-    formals(f) <- attr(f, "formals")
-  attr(f, "formals") <- NULL
+  formals(f) <- py_get_formals(callable, convert)
+  cat('Formals: ', paste(names(formals(f)), '=', formals(f), collapse = ', '), '\n')
   f
 }
 

--- a/R/python.R
+++ b/R/python.R
@@ -1226,7 +1226,7 @@ py_callable_as_function <- function(callable, convert) {
     # Cannot use list(...), as we replace the formals() later.
     call <- sys.call()
     call[[1]] <- as.name('list')
-    dots <- py_resolve_dots(eval(call))
+    dots <- py_resolve_dots(eval.parent(call))
     result <- py_call_impl(callable, dots$args, dots$keywords)
     if (convert) {
       result <- py_to_r(result)
@@ -1239,7 +1239,9 @@ py_callable_as_function <- function(callable, convert) {
       result
     }
   }
-  formals(f) <- py_get_formals(callable, convert)
+  sig <- py_get_formals(callable, convert)
+  if (!is.null(sig))
+    formals(f) <- sig
   f
 }
 

--- a/R/python.R
+++ b/R/python.R
@@ -1222,8 +1222,11 @@ py_eval <- function(code, convert = TRUE) {
 }
 
 py_callable_as_function <- function(callable, convert) {
-  function(...) {
-    dots <- py_resolve_dots(list(...))
+  f <- function(...) {
+    # Cannot use list(...), as we replace the formals() later.
+    call <- sys.call()
+    call[[1]] <- as.name('list')
+    dots <- py_resolve_dots(eval(call))
     result <- py_call_impl(callable, dots$args, dots$keywords)
     if (convert) {
       result <- py_to_r(result)
@@ -1236,6 +1239,9 @@ py_callable_as_function <- function(callable, convert) {
       result
     }
   }
+  formals(f) <- attr(f, "formals")
+  attr(f, "formals") <- NULL
+  f
 }
 
 py_resolve_dots <- function(dots) {

--- a/R/python.R
+++ b/R/python.R
@@ -1239,7 +1239,8 @@ py_callable_as_function <- function(callable, convert) {
       result
     }
   }
-  formals(f) <- attr(f, "formals")
+  if (length(attr(f, "formals")) > 0)
+    formals(f) <- attr(f, "formals")
   attr(f, "formals") <- NULL
   f
 }

--- a/R/python.R
+++ b/R/python.R
@@ -1239,9 +1239,12 @@ py_callable_as_function <- function(callable, convert) {
       result
     }
   }
-  sig <- py_get_formals(callable, convert)
-  if (!is.null(sig))
-    formals(f) <- sig
+  attr(f, 'get_formals_error') <- tryCatch({
+    sig <- py_get_formals(callable, convert)
+    if (!is.null(sig))
+      formals(f) <- sig
+    NULL
+  }, error = function(e) e)
   f
 }
 

--- a/R/python.R
+++ b/R/python.R
@@ -1225,7 +1225,6 @@ py_callable_as_function <- function(callable, convert) {
   f <- function(...) {
     # Cannot use list(...), as we replace the formals() later.
     call <- sys.call()
-    cat('Call: '); print(call)
     call[[1]] <- as.name('list')
     dots <- py_resolve_dots(eval(call))
     result <- py_call_impl(callable, dots$args, dots$keywords)
@@ -1241,7 +1240,6 @@ py_callable_as_function <- function(callable, convert) {
     }
   }
   formals(f) <- py_get_formals(callable, convert)
-  cat('Formals: ', paste(names(formals(f)), '=', formals(f), collapse = ', '), '\n')
   f
 }
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -68,6 +68,18 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// py_get_formals
+SEXP py_get_formals(PyObjectRef func, bool convert);
+RcppExport SEXP _reticulate_py_get_formals(SEXP funcSEXP, SEXP convertSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< PyObjectRef >::type func(funcSEXP);
+    Rcpp::traits::input_parameter< bool >::type convert(convertSEXP);
+    rcpp_result_gen = Rcpp::wrap(py_get_formals(func, convert));
+    return rcpp_result_gen;
+END_RCPP
+}
 // r_to_py_impl
 PyObjectRef r_to_py_impl(RObject object, bool convert);
 RcppExport SEXP _reticulate_r_to_py_impl(SEXP objectSEXP, SEXP convertSEXP) {
@@ -505,6 +517,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_reticulate_py_last_error", (DL_FUNC) &_reticulate_py_last_error, 0},
     {"_reticulate_py_clear_last_error", (DL_FUNC) &_reticulate_py_clear_last_error, 0},
     {"_reticulate_py_is_callable", (DL_FUNC) &_reticulate_py_is_callable, 1},
+    {"_reticulate_py_get_formals", (DL_FUNC) &_reticulate_py_get_formals, 2},
     {"_reticulate_r_to_py_impl", (DL_FUNC) &_reticulate_r_to_py_impl, 2},
     {"_reticulate_py_activate_virtualenv", (DL_FUNC) &_reticulate_py_activate_virtualenv, 1},
     {"_reticulate_py_initialize", (DL_FUNC) &_reticulate_py_initialize, 7},

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -978,14 +978,14 @@ SEXP py_get_formals(PyObjectRef func, bool convert) {
   if (kw_only.is_null()) stop(py_fetch_error());
 
   Rcpp::Pairlist formals;
-  PyObject* param;
+  PyObjectPtr param;
   bool var_encountered = false;
-  while ((param = PyIter_Next(param_iter.get()))) {
-    PyObjectPtr param_name(PyObject_GetAttrString(param, "name"));
+  while (param.assign(PyIter_Next(param_iter.get())), !param.is_null()) {
+    PyObjectPtr param_name(PyObject_GetAttrString(param.get(), "name"));
     if (param_name.is_null()) stop(py_fetch_error());
-    PyObjectPtr param_kind(PyObject_GetAttrString(param, "kind"));
+    PyObjectPtr param_kind(PyObject_GetAttrString(param.get(), "kind"));
     if (param_kind.is_null()) stop(py_fetch_error());
-    PyObjectPtr param_default(PyObject_GetAttrString(param, "default"));
+    PyObjectPtr param_default(PyObject_GetAttrString(param.get(), "default"));
     if (param_default.is_null()) stop(py_fetch_error());
 
     // If we encounter our first kw_only param
@@ -1016,7 +1016,6 @@ SEXP py_get_formals(PyObjectRef func, bool convert) {
       // variables, calls, ... are stored as `symbol` or `language`.
       formals << Named(as_utf8_r_string(param_name.get()), R_NilValue);
     }
-    Py_DECREF(param);
   }
 
   return formals;

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -973,9 +973,11 @@ SEXP py_get_formals(PyObjectRef func, bool convert) {
   if (kw_only.is_null()) stop(py_fetch_error());
 
   Rcpp::Pairlist formals;
-  PyObjectPtr param;
   bool var_encountered = false;
-  while (param.assign(PyIter_Next(param_iter.get())), !param.is_null()) {
+  while (true) {
+    PyObjectPtr param(PyIter_Next(param_iter.get()));
+    if (param.is_null()) break;
+
     PyObjectPtr param_name(PyObject_GetAttrString(param.get(), "name"));
     if (param_name.is_null()) stop(py_fetch_error());
     PyObjectPtr param_kind(PyObject_GetAttrString(param.get(), "kind"));

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -949,12 +949,7 @@ SEXP py_get_formals(PyObjectRef func, bool convert) {
   PyObjectPtr get_signature(PyObject_GetAttrString(inspect.get(), "signature"));
   if (get_signature.is_null()) stop(py_fetch_error());
   PyObjectPtr signature(PyObject_CallFunctionObjArgs(get_signature.get(), func.get(), NULL));
-  // if we could not get a signature, return an empty one
-  if (signature.is_null() || PyErr_Occurred()) {
-    // TODO: restrict to ValueError
-    if (PyErr_Occurred()) PyErr_Clear();
-    return R_NilValue;
-  }
+  if (signature.is_null()) stop(py_fetch_error());
   PyObjectPtr param_dict(PyObject_GetAttrString(signature.get(), "parameters"));
   if (param_dict.is_null()) stop(py_fetch_error());
 

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -917,9 +917,11 @@ SEXP py_to_r(PyObject* x, bool convert) {
     if (formals.size() > 0) {
       // No Rcpp API to set formals, so do it in R.
       f.attr("formals") = formals;
+      Rcpp::Function str = Rcpp::Environment::global_env()["str"];
+      Rcpp::Rcout << "Setting formals:"; str(formals);
     }
 
-    Rcpp::Rcout << "returning function: " << f << "\n";
+    Rcpp::Rcout << "returning function\n";
 
     // return the R function
     return f;

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -978,7 +978,8 @@ SEXP py_get_formals(PyObjectRef func, bool convert) {
     PyObjectPtr param_default(PyObject_GetAttrString(param, "default"));
     if (param_default.is_null()) stop(py_fetch_error());
 
-    const SEXP param_r = (param_default == empty_param) ? R_MissingArg : py_to_r(param_default.get(), convert);
+    //Here we could convert python objects to R language objects instead of R_NilValue
+    const SEXP param_r = (param_default == empty_param) ? R_MissingArg : R_NilValue;
     formals << Named(as_utf8_r_string(param_name.get()), param_r);
   }
 

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -1016,6 +1016,7 @@ SEXP py_get_formals(PyObjectRef func, bool convert) {
       // variables, calls, ... are stored as `symbol` or `language`.
       formals << Named(as_utf8_r_string(param_name.get()), R_NilValue);
     }
+    Py_DECREF(param);
   }
 
   return formals;

--- a/tests/testthat/test-python-function.R
+++ b/tests/testthat/test-python-function.R
@@ -67,3 +67,14 @@ test_that("The inspect.Parameter signature converts properly", {
     default = NULL, annotation = NULL
   ))
 })
+
+test_that("Parameters are not matched by prefix", {
+  f_r <- function(long = NULL, ...) list(long, list(...))
+  f_py <- py_eval('lambda long=None, **kw: (long, kw)')
+  expect_identical(formals(f_r), formals(f_py))
+
+  # Normal R functions match partially:
+  expect_identical(f_r(l = 2L), list(2L, list()))
+  # Python functions behave as expected:
+  expect_identical(f_py(l = 2L), list(NULL, list(l = 2L)))
+})

--- a/tests/testthat/test-python-function.R
+++ b/tests/testthat/test-python-function.R
@@ -49,6 +49,15 @@ test_that("Python signatures convert properly", {
   expect_formals('a, *args, b=1, **kw', alist(a = , ... = , b = NULL))
 })
 
+test_that("Errors from e.g. builtins are not propagated", {
+  print <- import_builtins()$print
+  expect_formals(formals(print), alist(... = ))
+  expect_match(
+    attr(print, 'get_formals_error')$message,
+    "ValueError: no signature found for builtin <built-in function print>"
+  )
+})
+
 test_that("The inspect.Parameter signature converts properly", {
   # Parameter.empty usually signifies no default parameter,
   # but for args 3 and 4 here, it *is* the default parameter.


### PR DESCRIPTION
I’m not very experienced in Rcpp *or* Python’s C API, but I’m there I think!

This PR converts signatures in a compatible way.

1. Defaults are all set to `NULL` for the time being. This can be improved in a further PR, but isn’t super important, as it doesn’t matter for autocompletion (as R and RStudio autocomplete `paramname = ` for you and therefore ignore that information).
2. `...` in R replaces `*args` and `**kw` at once, so the first occurrence of either is replaced by `...` in the formals.
3. R doesn’t support positional-only parameters such as x and y here. So e.g. the suggestions for `pow` will be wrong:

    ```r
    > builtins$pow(<tab>
          | x =    
          | y =    
          | z =    
    > pow(x = 2, y = 2)
    Error in py_call_impl(callable, dots$args, dots$keywords):
      TypeError: pow() takes no keyword arguments
    Traceback:

    1. pow(x = 2, y = 2)
    ```

Fixes #553 