### PR TITLE
invalid 'path' argument when no environments are found by conda -info

### DIFF
--- a/R/conda.R
+++ b/R/conda.R
@@ -59,6 +59,15 @@ conda_list <- function(conda = "auto") {
   # convert to json
   conda_envs <- fromJSON(conda_envs)$envs
 
+  # return an empty data.frame when no envs are found
+  if (length(conda_envs) == 0L) {
+    return(data.frame(
+      name = character(),
+      python = character(),
+      stringsAsFactors = FALSE)
+    )
+  }
+
   # normalize and remove duplicates (seems necessary on Windows as Anaconda
   # may report both short-path and long-path versions of the same environment)
   conda_envs <- Filter(file.exists, conda_envs)

--- a/R/conda.R
+++ b/R/conda.R
@@ -58,6 +58,7 @@ conda_list <- function(conda = "auto") {
 
   # convert to json
   conda_envs <- fromJSON(conda_envs)$envs
+  conda_envs <- Filter(file.exists, conda_envs)
 
   # return an empty data.frame when no envs are found
   if (length(conda_envs) == 0L) {
@@ -70,7 +71,6 @@ conda_list <- function(conda = "auto") {
 
   # normalize and remove duplicates (seems necessary on Windows as Anaconda
   # may report both short-path and long-path versions of the same environment)
-  conda_envs <- Filter(file.exists, conda_envs)
   conda_envs <- unique(normalizePath(conda_envs))
 
   # build data frame


### PR DESCRIPTION
Older versions of Conda can return an empty list of environments which causes an error when calling `normalizePath`. Eg. `normalizePath(list())`.

This happens mostly in AppVeyor, since multiple versions of conda are installed by default.
