### PR TITLE
Add bit64 support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,6 +34,7 @@ Imports:
     graphics,
     jsonlite,
     Rcpp (>= 0.12.7),
+    bit64,
     Matrix,
     methods
 Suggests:

--- a/tests/testthat/test-python-numpy.R
+++ b/tests/testthat/test-python-numpy.R
@@ -29,10 +29,22 @@ test_that("Character arrays are handled correctly", {
   expect_equal(a1, py_to_r(r_to_py(a1)))
 })
 
+
+test_that("Long integer types are converted to bit64", {
+  skip_if_no_numpy()
+  np <- import("numpy", convert = FALSE)
+  dtypes <- c(np$int64, np$long)
+  require(bit64)
+  lapply(dtypes, function(dtype) {
+    a1 <- np$array(c(as.integer64("12345"), as.integer64("1567447722123456786")), dtype = dtype)
+    expect_equal(class(py_to_r(a1)), "integer64")
+  })
+})
+
 test_that("Long integer types are converted to R numeric", {
   skip_if_no_numpy()
   np <- import("numpy", convert = FALSE)
-  dtypes <- c(np$int64, np$uint32, np$uint64, np$long, np$longlong)
+  dtypes <- c(np$uint32, np$uint64, np$longlong)
   lapply(dtypes, function(dtype) {
     a1 <- np$array(c(1L:30L), dtype = dtype)
     expect_equal(class(as.vector(py_to_r(a1))), "numeric")

--- a/tests/testthat/test-python-pandas.R
+++ b/tests/testthat/test-python-pandas.R
@@ -125,3 +125,10 @@ test_that("single-row data.frames with rownames can be converted", {
   expect_equal(c(before), c(after))
 
 })
+
+test_that("Large ints are handled correctly", {
+  skip_if_no_pandas()
+  require(bit64)
+  A <- data.frame(val=c(as.integer64("1567447722123456785"), as.integer64("1567447722123456786")))
+  expect_equal(A, py_to_r(r_to_py(A)))
+})


### PR DESCRIPTION
Allow for 64bit integers to be passed between Py <-> R using the bit64 package, inspired by https://gallery.rcpp.org/articles/creating-integer64-and-nanotime-vectors/

