### PR TITLE
initial work on python dependency discovery + install

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -51,6 +51,9 @@ ensure_python_initialized <- function(required_module = NULL) {
 
     # remap output streams to R output handlers
     remap_output_streams()
+    
+    # install required packages
+    configure_environment()
 
   }
 }

--- a/R/python-packages.R
+++ b/R/python-packages.R
@@ -1,0 +1,68 @@
+
+configure_environment <- function() {
+  
+  # only done if we're using miniconda for now
+  config <- py_config()
+  home <- miniconda_path()
+  if (substring(config$python, 1, nchar(home)) != home)
+    return(FALSE)
+  
+  # find package requirements
+  pkgreqs <- python_package_requirements()
+  reqs <- unlist(pkgreqs, recursive = FALSE, use.names = FALSE)
+  packages <- vapply(reqs, `[[`, "package", FUN.VALUE = character(1))
+  pip <- vapply(reqs, function(req) req[["pip"]] %||% FALSE, FUN.VALUE = logical(1))
+  
+  # list installed modules
+  modules <- python_modules(python = config$python)
+  
+  # install them if necessary
+  # TODO: we should compare requested versions and upgrade as needed
+  pip_packages <- setdiff(packages[pip], modules$module)
+  nonpip_packages <- setdiff(packages[!pip], modules$module)
+  
+  if (length(pip_packages) || length(nonpip_packages)) {
+    
+    message("One or more Python packages need to be installed -- please wait ...")
+    
+    if (length(pip_packages))
+      py_install(pip_packages, pip = TRUE)
+    
+    if (length(nonpip_packages))
+      py_install(nonpip_packages, pip = FALSE)
+    
+    message("Done!")
+    
+  }
+  
+  
+  TRUE
+}
+
+python_package_requirements <- function() {
+  
+  packages <- loadedNamespaces()
+  names(packages) <- packages
+  reqs <- lapply(packages, function(package) {
+    tryCatch(
+      python_package_requirements_find(package),
+      error = function(e) { warning(e); NULL }
+    )
+  })
+  
+  Filter(Negate(is.null), reqs)
+  
+}
+
+python_package_requirements_find <- function(package) {
+  
+  descpath <- system.file("DESCRIPTION", package = package)
+  desc <- read.dcf(descpath, all = TRUE)
+  
+  entry <- desc[["reticulate@R"]]
+  if (is.null(entry))
+    return(NULL)
+  
+  eval(parse(text = entry), envir = baseenv())
+  
+}

--- a/R/python-tools.R
+++ b/R/python-tools.R
@@ -36,6 +36,15 @@ python_module_version <- function(python, module) {
   numeric_version(output)
 }
 
+python_modules <- function(python) {
+  args <- c("-m", "pip", "freeze")
+  output <- system2(python, args, stdout = TRUE)
+  splat <- strsplit(output, "==", fixed = TRUE)
+  modules <- vapply(splat, `[[`, 1L, FUN.VALUE = character(1))
+  versions <- vapply(splat, `[[`, 2L, FUN.VALUE = character(1))
+  data.frame(module = modules, version = versions, stringsAsFactors = FALSE)
+}
+
 # given the path to a Python binary, try to ascertain its type
 python_info <- function(python) {
   


### PR DESCRIPTION
NOTE: not yet ready for merge; putting this up as a PR just to further facilitate discussion.

---

This PR intends to make it possible for R packages to declare their reticulate Python requirements, and to have `reticulate` automatically discover and install those declared dependencies when using a Miniconda environment.

The intention is that users will be able to run R packages that act as wrappers to Python packages with minimal overhead; that is, they will not need to worry about Python environment management, as `reticulate` will take care of that automagically.

R packages can declare the packages they require with a new field in the DESCRIPTION file. For example, a package wrapping TensorFlow might use:

```
reticulate@R: list(
    list(package = "tensorflow", pip = TRUE),
    list(package = "keras", pip = TRUE)
    )
```

When `reticulate` initializes Python, it will look at the set of loaded packages, find these declared Python dependencies, and then install the required dependencies.

Some open questions:

1. What about version requirements? Do we want to think about this now, or leave it for later?
2. How do we avoid package versions getting stale? Should we prompt for upgrades? Should we try to "live at head" when possible?

For what it's worth, one thing that might make our lives easier: for version requirements, we can delegate that responsibility to `pip` / `conda` as appropriate; e.g. we could use

```
pip install -r requirements.txt
```

where `requirements.txt` is generated based on the declared Python requirements. We may need to do some collapsing of version requirements but that's at least simpler than other problems.

A similar facility exists for `conda` with e.g.

```
conda env update -f packages.yml
``` 