### PR TITLE
WIP: py_convert_pandas_df

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -201,6 +201,10 @@ py_eval_impl <- function(code, convert = TRUE) {
     .Call(`_reticulate_py_eval_impl`, code, convert)
 }
 
+py_convert_pandas_df <- function(obj) {
+    .Call(`_reticulate_py_convert_pandas_df`, obj)
+}
+
 readline <- function(prompt) {
     .Call(`_reticulate_readline`, prompt)
 }

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -201,8 +201,12 @@ py_eval_impl <- function(code, convert = TRUE) {
     .Call(`_reticulate_py_eval_impl`, code, convert)
 }
 
-py_convert_pandas_df <- function(obj) {
-    .Call(`_reticulate_py_convert_pandas_df`, obj)
+py_convert_pandas_series <- function(series) {
+    .Call(`_reticulate_py_convert_pandas_series`, series)
+}
+
+py_convert_pandas_df <- function(df) {
+    .Call(`_reticulate_py_convert_pandas_df`, df)
 }
 
 readline <- function(prompt) {

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -294,6 +294,7 @@ py_to_r.pandas.core.frame.DataFrame <- function(x) {
 
   # extract numpy arrays associated with each column
   columns <- x$columns$values
+  
   # delegate to c++
   converted <- py_convert_pandas_df(x)
   names(converted) <- py_to_r(x$columns$format())

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -294,10 +294,8 @@ py_to_r.pandas.core.frame.DataFrame <- function(x) {
 
   # extract numpy arrays associated with each column
   columns <- x$columns$values
-  converted <- lapply(seq_along(columns) - 1L, function(i) {
-    column <- columns[[i]]
-    py_to_r(py_get_item(x, column)$values)
-  })
+  # delegate to c++
+  converted <- py_convert_pandas_df(x)
   names(converted) <- py_to_r(x$columns$format())
 
   # clean up converted objects

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -498,6 +498,17 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// py_convert_pandas_df
+SEXP py_convert_pandas_df(PyObjectRef obj);
+RcppExport SEXP _reticulate_py_convert_pandas_df(SEXP objSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< PyObjectRef >::type obj(objSEXP);
+    rcpp_result_gen = Rcpp::wrap(py_convert_pandas_df(obj));
+    return rcpp_result_gen;
+END_RCPP
+}
 // readline
 SEXP readline(const std::string& prompt);
 RcppExport SEXP _reticulate_readline(SEXP promptSEXP) {
@@ -554,6 +565,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_reticulate_py_run_string_impl", (DL_FUNC) &_reticulate_py_run_string_impl, 3},
     {"_reticulate_py_run_file_impl", (DL_FUNC) &_reticulate_py_run_file_impl, 3},
     {"_reticulate_py_eval_impl", (DL_FUNC) &_reticulate_py_eval_impl, 2},
+    {"_reticulate_py_convert_pandas_df", (DL_FUNC) &_reticulate_py_convert_pandas_df, 1},
     {"_reticulate_readline", (DL_FUNC) &_reticulate_readline, 1},
     {NULL, NULL, 0}
 };

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -498,14 +498,25 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
-// py_convert_pandas_df
-SEXP py_convert_pandas_df(PyObjectRef obj);
-RcppExport SEXP _reticulate_py_convert_pandas_df(SEXP objSEXP) {
+// py_convert_pandas_series
+SEXP py_convert_pandas_series(PyObjectRef series);
+RcppExport SEXP _reticulate_py_convert_pandas_series(SEXP seriesSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< PyObjectRef >::type obj(objSEXP);
-    rcpp_result_gen = Rcpp::wrap(py_convert_pandas_df(obj));
+    Rcpp::traits::input_parameter< PyObjectRef >::type series(seriesSEXP);
+    rcpp_result_gen = Rcpp::wrap(py_convert_pandas_series(series));
+    return rcpp_result_gen;
+END_RCPP
+}
+// py_convert_pandas_df
+SEXP py_convert_pandas_df(PyObjectRef df);
+RcppExport SEXP _reticulate_py_convert_pandas_df(SEXP dfSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< PyObjectRef >::type df(dfSEXP);
+    rcpp_result_gen = Rcpp::wrap(py_convert_pandas_df(df));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -565,6 +576,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_reticulate_py_run_string_impl", (DL_FUNC) &_reticulate_py_run_string_impl, 3},
     {"_reticulate_py_run_file_impl", (DL_FUNC) &_reticulate_py_run_file_impl, 3},
     {"_reticulate_py_eval_impl", (DL_FUNC) &_reticulate_py_eval_impl, 2},
+    {"_reticulate_py_convert_pandas_series", (DL_FUNC) &_reticulate_py_convert_pandas_series, 1},
     {"_reticulate_py_convert_pandas_df", (DL_FUNC) &_reticulate_py_convert_pandas_df, 1},
     {"_reticulate_readline", (DL_FUNC) &_reticulate_readline, 1},
     {NULL, NULL, 0}

--- a/src/libpython.cpp
+++ b/src/libpython.cpp
@@ -244,6 +244,7 @@ bool LibPython::loadSymbols(bool python3, std::string* pError)
   LOAD_PYTHON_SYMBOL(PyThreadState_Next)
   LOAD_PYTHON_SYMBOL(PyObject_CallMethod)
   LOAD_PYTHON_SYMBOL(PySequence_GetItem)
+  LOAD_PYTHON_SYMBOL(PyObject_IsTrue)
 
   // PyUnicode_AsEncodedString may have several different names depending on the Python
   // version and the UCS build type

--- a/src/libpython.cpp
+++ b/src/libpython.cpp
@@ -242,6 +242,8 @@ bool LibPython::loadSymbols(bool python3, std::string* pError)
   LOAD_PYTHON_SYMBOL(PyGILState_Ensure)
   LOAD_PYTHON_SYMBOL(PyGILState_Release)
   LOAD_PYTHON_SYMBOL(PyThreadState_Next)
+  LOAD_PYTHON_SYMBOL(PyObject_CallMethod)
+  LOAD_PYTHON_SYMBOL(PySequence_GetItem)
 
   // PyUnicode_AsEncodedString may have several different names depending on the Python
   // version and the UCS build type

--- a/src/libpython.h
+++ b/src/libpython.h
@@ -307,6 +307,9 @@ LIBPYTHON_EXTERN void (*PySys_SetArgv_v3)(int, wchar_t **);
 
 LIBPYTHON_EXTERN void (*PySys_WriteStderr)(const char *format, ...);
 
+LIBPYTHON_EXTERN PyObject* (*PyObject_CallMethod)(PyObject *o, const char *name, const char *format, ...);
+LIBPYTHON_EXTERN PyObject* (*PySequence_GetItem)(PyObject *o, Py_ssize_t i);
+  
 #define PyObject_TypeCheck(o, tp) ((PyTypeObject*)Py_TYPE(o) == (tp)) || PyType_IsSubtype((PyTypeObject*)Py_TYPE(o), (tp))
 
 #define PyType_Check(o) PyObject_TypeCheck(o, PyType_Type)

--- a/src/libpython.h
+++ b/src/libpython.h
@@ -309,6 +309,7 @@ LIBPYTHON_EXTERN void (*PySys_WriteStderr)(const char *format, ...);
 
 LIBPYTHON_EXTERN PyObject* (*PyObject_CallMethod)(PyObject *o, const char *name, const char *format, ...);
 LIBPYTHON_EXTERN PyObject* (*PySequence_GetItem)(PyObject *o, Py_ssize_t i);
+LIBPYTHON_EXTERN int (*PyObject_IsTrue)(PyObject *o);
   
 #define PyObject_TypeCheck(o, tp) ((PyTypeObject*)Py_TYPE(o) == (tp)) || PyType_IsSubtype((PyTypeObject*)Py_TYPE(o), (tp))
 

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -2295,8 +2295,12 @@ SEXP py_convert_pandas_df(PyObjectRef df) {
     // access Series in slot 1
     PyObjectPtr series(PySequence_GetItem(tuple, 1));
     Py_IncRef(series);
+    
+    // delegate to py_convert_pandas_series
     PyObjectRef series_ref(series, df.convert());
+    
     RObject R_obj = py_convert_pandas_series(series_ref);
+    
     Py_DecRef(series);
     
     list.push_back(R_obj);

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -2215,6 +2215,7 @@ SEXP py_convert_pandas_series(PyObjectRef series) {
   PyObjectPtr dtype(PyObject_GetAttrString(series, "dtype"));
   PyObjectPtr name(PyObject_GetAttrString(dtype, "name"));
   
+  
   // as well as values
   PyObjectPtr values(PyObject_GetAttrString(series, "values"));
   
@@ -2292,7 +2293,7 @@ SEXP py_convert_pandas_df(PyObjectRef df) {
     // access Series in slot 1
     PyObjectPtr series(PySequence_GetItem(tuple, 1));
     // delegate to py_convert_pandas_series
-    PyObjectRef series_ref(series, df.convert());
+    PyObjectRef series_ref(series.detach(), df.convert());
     RObject R_obj = py_convert_pandas_series(series_ref);
 
     list.push_back(R_obj);

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -2248,11 +2248,8 @@ SEXP py_convert_pandas_series(PyObjectRef series) {
     }
     
     // populate character vector to hold levels
-    n = Rf_xlength(R_levels);
-    CharacterVector factor_levels(n);
-    for (int i = 0; i < n; ++i) {
-      factor_levels[i] = STRING_ELT(R_levels, i);
-    }
+    CharacterVector factor_levels(R_levels);
+    factor_levels.attr("dim") = R_NilValue;
     
     factor.attr("class") = "factor";
     factor.attr("levels") = factor_levels;
@@ -2294,15 +2291,10 @@ SEXP py_convert_pandas_df(PyObjectRef df) {
     
     // access Series in slot 1
     PyObjectPtr series(PySequence_GetItem(tuple, 1));
-    Py_IncRef(series);
-    
     // delegate to py_convert_pandas_series
     PyObjectRef series_ref(series, df.convert());
-    
     RObject R_obj = py_convert_pandas_series(series_ref);
-    
-    Py_DecRef(series);
-    
+
     list.push_back(R_obj);
   }
 

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -2240,7 +2240,7 @@ SEXP py_convert_pandas_series(PyObjectRef series) {
     
     // populate integer vector to hold factor values
     int* codes_int = INTEGER(R_values);
-    int n = Rf_length(R_values);
+    int n = Rf_xlength(R_values);
     IntegerVector factor(n);
     // values need to start at 1
     for (int i = 0; i < n; ++i) {
@@ -2248,7 +2248,7 @@ SEXP py_convert_pandas_series(PyObjectRef series) {
     }
     
     // populate character vector to hold levels
-    n = Rf_length(R_levels);
+    n = Rf_xlength(R_levels);
     CharacterVector factor_levels(n);
     for (int i = 0; i < n; ++i) {
       factor_levels[i] = STRING_ELT(R_levels, i);
@@ -2276,7 +2276,7 @@ SEXP py_convert_pandas_df(PyObjectRef df) {
   
   // pd.DataFrame.items() returns an Iterator over (column name, Series) pairs
   PyObjectPtr items(PyObject_CallMethod(df, "items", NULL));
-  if (! PyObject_HasAttrString(items, "__next__"))
+  if (! (PyObject_HasAttrString(items, "__next__") || PyObject_HasAttrString(items, "next")))
     stop("Cannot iterate over object");
 
   std::vector<RObject> list;
@@ -2306,9 +2306,7 @@ SEXP py_convert_pandas_df(PyObjectRef df) {
     list.push_back(R_obj);
   }
 
-  List rList(list.size());
-  for (size_t i = 0; i < list.size(); i++)
-    rList[i] = list[i];
+  List rList(list.begin(), list.end());
   return rList;
 
 }

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -2209,10 +2209,73 @@ SEXP py_eval_impl(const std::string& code, bool convert = true) {
 }
 
 // [[Rcpp::export]]
-SEXP py_convert_pandas_df(PyObjectRef obj) {
+SEXP py_convert_pandas_series(PyObjectRef series) {
+  
+  // extract dtype
+  PyObjectPtr dtype(PyObject_GetAttrString(series, "dtype"));
+  PyObjectPtr name(PyObject_GetAttrString(dtype, "name"));
+  
+  // as well as values
+  PyObjectPtr values(PyObject_GetAttrString(series, "values"));
+  
+  RObject R_obj;
+  
+  // special treatment for pd.Categorical
+  if (as_std_string(name) == "category") {
+    
+    // get actual values and convert to R
+    PyObjectPtr cat(PyObject_GetAttrString(series, "cat"));
+    PyObjectPtr codes(PyObject_GetAttrString(cat, "codes"));
+    PyObjectPtr code_values(PyObject_GetAttrString(codes, "values"));
+    RObject R_values = py_to_r(code_values, true);
+    
+    // get levels and convert to R
+    PyObjectPtr categories(PyObject_GetAttrString(dtype, "categories"));
+    PyObjectPtr category_values(PyObject_GetAttrString(categories, "values"));
+    RObject R_levels = py_to_r(category_values, true);
+    
+    // get "ordered" attribute
+    PyObjectPtr ordered(PyObject_GetAttrString(dtype, "ordered"));
+    //RObject ordered = py_to_r(ordered_, true);
+    
+    // populate integer vector to hold factor values
+    int* codes_int = INTEGER(R_values);
+    int n = Rf_length(R_values);
+    IntegerVector factor(n);
+    // values need to start at 1
+    for (int i = 0; i < n; ++i) {
+      factor[i] = codes_int[i] + 1;
+    }
+    
+    // populate character vector to hold levels
+    n = Rf_length(R_levels);
+    CharacterVector factor_levels(n);
+    for (int i = 0; i < n; ++i) {
+      factor_levels[i] = STRING_ELT(R_levels, i);
+    }
+    
+    factor.attr("class") = "factor";
+    factor.attr("levels") = factor_levels;
+    if (PyObject_IsTrue(ordered)) factor.attr("ordered") = true;
+    
+    R_obj = factor;
+    
+    // default case
+  } else {
+    
+    R_obj = py_to_r(values, series.convert());
+    
+  }
+  
+  return R_obj;
+  
+}
+
+// [[Rcpp::export]]
+SEXP py_convert_pandas_df(PyObjectRef df) {
   
   // pd.DataFrame.items() returns an Iterator over (column name, Series) pairs
-  PyObjectPtr items(PyObject_CallMethod(obj, "items", NULL));
+  PyObjectPtr items(PyObject_CallMethod(df, "items", NULL));
   if (! PyObject_HasAttrString(items, "__next__"))
     stop("Cannot iterate over object");
 
@@ -2231,62 +2294,10 @@ SEXP py_convert_pandas_df(PyObjectRef obj) {
     
     // access Series in slot 1
     PyObjectPtr series(PySequence_GetItem(tuple, 1));
-    
-    // and extract dtype
-    PyObjectPtr dtype(PyObject_GetAttrString(series, "dtype"));
-    PyObjectPtr name(PyObject_GetAttrString(dtype, "name"));
-    
-    // as well as values
-    PyObjectPtr values(PyObject_GetAttrString(series, "values"));
-    
-    RObject R_obj;
-
-    // special treatment for pd.Categorical
-    if (as_std_string(name) == "category") {
-      
-      // get actual values and convert to R
-      PyObjectPtr cat(PyObject_GetAttrString(series, "cat"));
-      PyObjectPtr codes(PyObject_GetAttrString(cat, "codes"));
-      PyObjectPtr code_values(PyObject_GetAttrString(codes, "values"));
-      RObject R_values = py_to_r(code_values, true);
-      
-      // get levels and convert to R
-      PyObjectPtr categories(PyObject_GetAttrString(dtype, "categories"));
-      PyObjectPtr category_values(PyObject_GetAttrString(categories, "values"));
-      RObject R_levels = py_to_r(category_values, true);
-      
-      // get "ordered" attribute
-      PyObjectPtr ordered(PyObject_GetAttrString(dtype, "ordered"));
-      //RObject ordered = py_to_r(ordered_, true);
-   
-      // populate integer vector to hold factor values
-      int* codes_int = INTEGER(R_values);
-      int n = Rf_length(R_values);
-      IntegerVector factor(n);
-      // values need to start at 1
-      for (int i = 0; i < n; ++i) {
-        factor[i] = codes_int[i] + 1;
-      }
-      
-      // populate character vector to hold levels
-      n = Rf_length(R_levels);
-      CharacterVector factor_levels(n);
-      for (int i = 0; i < n; ++i) {
-        factor_levels[i] = STRING_ELT(R_levels, i);
-      }
-
-      factor.attr("class") = "factor";
-      factor.attr("levels") = factor_levels;
-      if (PyObject_IsTrue(ordered)) factor.attr("ordered") = true;
-      
-      R_obj = factor;
-    
-    // default case
-    } else {
-      
-      R_obj = py_to_r(values, obj.convert());
-      
-    }
+    Py_IncRef(series);
+    PyObjectRef series_ref(series, df.convert());
+    RObject R_obj = py_convert_pandas_series(series_ref);
+    Py_DecRef(series);
     
     list.push_back(R_obj);
   }

--- a/tests/testthat/test-python-pandas.R
+++ b/tests/testthat/test-python-pandas.R
@@ -125,3 +125,27 @@ test_that("single-row data.frames with rownames can be converted", {
   expect_equal(c(before), c(after))
 
 })
+
+test_that("Time zones are respected if available", {
+  skip_if_no_pandas()
+  
+  pd <- import("pandas", convert = FALSE)
+  
+  before <- pd$DataFrame(list('TZ' = pd$Series(
+    c(
+      pd$Timestamp('20130102003020', tz = 'US/Pacific'),
+      pd$Timestamp('20130102003020', tz = 'CET'),
+      pd$Timestamp('20130102003020', tz = 'UTC'),
+      pd$Timestamp('20130102003020', tz = 'Hongkong')
+    )
+  )))
+  
+  converted <- py_to_r(before)
+  after <- r_to_py(converted)
+  
+  # check if both are the same in *local* timezone
+  expect_equal(py_to_r(before), py_to_r(after))
+  
+})
+
+


### PR DESCRIPTION
Purpose: Convert `pandas` dataframes on c++ level instead of in R, to reduce number of round trips.

This is just to show the general approach; in this initial version, the only "non-automatic" data type (meaning, the only one for whom calling `py_to_r` will not be sufficient) is `pd.Categorical`. More data types will need specific handling.

I could also imagine that we'd want to split out these individual functions, and/or add them as branches to `py_to_r`?

Thanks for taking a look :-)

