### PR TITLE
allow packages to declare specific versions of dependencies

### DIFF
--- a/R/conda.R
+++ b/R/conda.R
@@ -189,25 +189,25 @@ conda_install <- function(envname = NULL,
     }
   }
 
-  if (pip) {
-    # use pip
-    pip_install(python, packages, ignore_installed = pip_ignore_installed)
-  } else {
-    # use conda
-    args <- conda_args("install", envname)
-    if (forge)
-      args <- c(args, "-c", "conda-forge")
-    args <- c(args, python_package, packages)
-    result <- system2(conda, shQuote(args))
-  }
-
+  # delegate to pip if requested
+  if (pip)
+    return(pip_install(python, packages))
+    
+  # otherwise, use conda
+  args <- conda_args("install", envname)
+  if (forge)
+    args <- c(args, "-c", "conda-forge")
+  args <- c(args, python_package, packages)
+  result <- system2(conda, shQuote(args))
+  
   # check for errors
   if (result != 0L) {
-    stop("Error ", result, " occurred installing packages into conda environment ",
-         envname, call. = FALSE)
+    fmt <- "one or more Python packages failed to install [error code %i]"
+    stopf(fmt, result)
   }
 
-  invisible(NULL)
+  
+  invisible(packages)
 }
 
 

--- a/R/conda.R
+++ b/R/conda.R
@@ -190,7 +190,7 @@ conda_install <- function(envname = NULL,
   }
 
   if (pip) {
-    # use pip package manager
+    # use pip
     pip_install(python, packages, ignore_installed = pip_ignore_installed)
   } else {
     # use conda

--- a/R/conda.R
+++ b/R/conda.R
@@ -156,7 +156,7 @@ conda_install <- function(envname = NULL,
                           packages,
                           forge = TRUE,
                           pip = FALSE,
-                          pip_ignore_installed = TRUE,
+                          pip_ignore_installed = FALSE,
                           conda = "auto",
                           python_version = NULL,
                           ...)
@@ -191,16 +191,7 @@ conda_install <- function(envname = NULL,
 
   if (pip) {
     # use pip package manager
-    condaenv_bin <- function(bin) path.expand(file.path(dirname(conda), bin))
-    cmd <- sprintf("%s%s %s && pip install --upgrade %s %s%s",
-                   ifelse(is_windows(), "", ifelse(is_osx(), "source ", "/bin/bash -c \"source ")),
-                   shQuote(path.expand(condaenv_bin("activate"))),
-                   envname,
-                   ifelse(pip_ignore_installed, "--ignore-installed", ""),
-                   paste(shQuote(packages), collapse = " "),
-                   ifelse(is_windows(), "", ifelse(is_osx(), "", "\"")))
-    result <- system(cmd)
-
+    pip_install(python, packages, ignore_installed = pip_ignore_installed)
   } else {
     # use conda
     args <- conda_args("install", envname)
@@ -410,9 +401,11 @@ conda_list_packages <- function(envname = NULL, conda = "auto", no_pip = TRUE) {
   }
   
   parsed <- jsonlite::fromJSON(output)
+  
   data.frame(
-    package = parsed$name,
-    version = parsed$version,
+    package     = parsed$name,
+    version     = parsed$version,
+    requirement = paste(parsed$name, parsed$version, sep = "="),
     stringsAsFactors = FALSE
   )
   

--- a/R/miniconda.R
+++ b/R/miniconda.R
@@ -176,7 +176,8 @@ miniconda_conda <- function(path = miniconda_path()) {
   file.path(path, exe)
 }
 
-miniconda_envpath <- function(env, path = miniconda_path()) {
+miniconda_envpath <- function(env = NULL, path = miniconda_path()) {
+  env <- env %||% Sys.getenv("RETICULATE_MINICONDA_ENVNAME", unset = "r-reticulate")
   file.path(path, "envs", env)
 }
 
@@ -263,7 +264,7 @@ miniconda_python_envpath <- function() {
   
   Sys.getenv(
     "RETICULATE_MINICONDA_PYTHON_ENVPATH",
-    unset = miniconda_envpath("r-reticulate")
+    unset = miniconda_envpath()
   )
   
 }

--- a/R/pip.R
+++ b/R/pip.R
@@ -14,7 +14,7 @@ pip_version <- function(python) {
 }
 
 
-pip_install <- function(python, packages, ignore_installed = TRUE) {
+pip_install <- function(python, packages, ignore_installed = FALSE) {
 
   # construct command line arguments
   args <- c("-m", "pip", "install", "--upgrade")
@@ -57,8 +57,9 @@ pip_freeze <- function(python) {
   packages <- vapply(splat, `[[`, 1L, FUN.VALUE = character(1))
   versions <- vapply(splat, `[[`, 2L, FUN.VALUE = character(1))
   data.frame(
-    package = packages,
-    version = versions,
+    package     = packages,
+    version     = versions,
+    requirement = paste(packages, versions, sep = "=="),
     stringsAsFactors = FALSE
   )
   

--- a/R/python-packages.R
+++ b/R/python-packages.R
@@ -51,6 +51,9 @@ configure_environment <- function(package = NULL) {
     use.names = FALSE
   )
   
+  # split into packages to be installed with pip vs. conda
+  # we'll diff the requested packages against the currently-installed
+  # packages and only install packages which truly need to be updated
   pip_installed_packages <- NULL
   conda_installed_packages <- NULL
   
@@ -112,11 +115,20 @@ configure_environment <- function(package = NULL) {
     
   }
   
-  if (length(pip_packages))
+  if (length(pip_packages) || length(conda_packages)) {
+    
+    fmt <- "Configuring package '%s': please wait ..."
+    messagef(fmt, package)
+    
+    if (length(pip_packages))
       py_install(pip_packages, pip = TRUE)
     
-  if (length(conda_packages))
-    py_install(conda_packages, pip = FALSE)
+    if (length(conda_packages))
+      py_install(conda_packages, pip = FALSE)
+    
+    message("Done!")
+    
+  }
   
   TRUE
 }

--- a/R/python-packages.R
+++ b/R/python-packages.R
@@ -77,7 +77,7 @@ configure_environment <- function(package = NULL) {
       
       # check to see if we satisfy this requirement already
       satisfied <-
-        requirement %in% pip_installed_packages$requirement %||%
+        requirement %in% pip_installed_packages$requirement ||
         requirement %in% pip_installed_packages$package
       
       if (satisfied)
@@ -103,7 +103,7 @@ configure_environment <- function(package = NULL) {
       
       # check to see if we satisfy this requirement already
       satisfied <-
-        requirement %in% conda_installed_packages$requirement %||%
+        requirement %in% conda_installed_packages$requirement ||
         requirement %in% conda_installed_packages$package
       
       if (satisfied)

--- a/R/utils.R
+++ b/R/utils.R
@@ -218,3 +218,10 @@ canonical_path <- function(path) {
   }
   
 }
+
+enumerate <- function(x, f, ...) {
+  n <- names(x)
+  lapply(seq_along(x), function(i) {
+    f(n[[i]], x[[i]], ...)
+  })
+}

--- a/R/virtualenv.R
+++ b/R/virtualenv.R
@@ -96,7 +96,7 @@ virtualenv_create <- function(envname = NULL, python = NULL) {
 #' @export
 virtualenv_install <- function(envname = NULL,
                                packages,
-                               ignore_installed = TRUE,
+                               ignore_installed = FALSE,
                                ...)
 {
   # create virtual environment on demand

--- a/man/conda-tools.Rd
+++ b/man/conda-tools.Rd
@@ -22,7 +22,7 @@ conda_install(
   packages,
   forge = TRUE,
   pip = FALSE,
-  pip_ignore_installed = TRUE,
+  pip_ignore_installed = FALSE,
   conda = "auto",
   python_version = NULL,
   ...

--- a/man/configure_environment.Rd
+++ b/man/configure_environment.Rd
@@ -4,12 +4,14 @@
 \alias{configure_environment}
 \title{Configure a Python Environment}
 \usage{
-configure_environment(package = NULL)
+configure_environment(package = NULL, force = TRUE)
 }
 \arguments{
 \item{package}{The name of a package to configure. When \code{NULL}, \code{reticulate}
 will instead look at all loaded packages and discover their associated
 Python requirements.}
+
+\item{force}{Boolean; force configuration of the associated environment?}
 }
 \description{
 Configure a Python environment, satisfying the Python dependencies of any

--- a/man/py_function_custom_scaffold.Rd
+++ b/man/py_function_custom_scaffold.Rd
@@ -16,7 +16,7 @@ py_function_custom_scaffold(
 )
 }
 \arguments{
-\item{python_function}{Fully qualfied name of Python function or class
+\item{python_function}{Fully qualified name of Python function or class
 constructor (e.g. \code{tf$layers$average_pooling1d})}
 
 \item{r_function}{Name of R function to generate (defaults to name of Python

--- a/man/py_function_wrapper.Rd
+++ b/man/py_function_wrapper.Rd
@@ -10,7 +10,7 @@ py_function_wrapper(python_function, r_prefix = NULL, r_function = NULL)
 py_function_docs(python_function)
 }
 \arguments{
-\item{python_function}{Fully qualfied name of Python function or class
+\item{python_function}{Fully qualified name of Python function or class
 constructor (e.g. \code{tf$layers$average_pooling1d})}
 
 \item{r_prefix}{Prefix to add to generated R function name}

--- a/man/virtualenv-tools.Rd
+++ b/man/virtualenv-tools.Rd
@@ -14,7 +14,7 @@ virtualenv_list()
 
 virtualenv_create(envname = NULL, python = NULL)
 
-virtualenv_install(envname = NULL, packages, ignore_installed = TRUE, ...)
+virtualenv_install(envname = NULL, packages, ignore_installed = FALSE, ...)
 
 virtualenv_remove(envname = NULL, packages = NULL, confirm = interactive())
 

--- a/vignettes/python_dependencies.Rmd
+++ b/vignettes/python_dependencies.Rmd
@@ -75,7 +75,7 @@ Version: 1.0.0
 Description: Provides an R interface to the Python package scipy.
 reticulate@R: list(
   packages = list(
-    c(package = "scipy")
+    list(package = "scipy")
   )
 )
 < ... other fields ...>

--- a/vignettes/python_dependencies.Rmd
+++ b/vignettes/python_dependencies.Rmd
@@ -77,7 +77,7 @@ reticulate@R: list(
   packages = list(
     list(package = "scipy")
   )
-)
+  )
 < ... other fields ...>
 ```
 
@@ -111,9 +111,9 @@ library(rscipy)
 
 If the user has no compatible version of Python available on their system, they
 will be prompted to install Miniconda. If they do have Python already, then the
-required Python packages (in this case `scypy`) will be installed in the
-standard shared environment for R sessions (typically a virtualenv or condaenv
-named "r-reticulate").
+required Python packages (in this case `scipy`) will be installed in the
+standard shared environment for R sessions (typically a virtual environment, or
+a Conda environment named "r-reticulate").
 
 In effect, users have to pay a one-time, mostly-automated initialization cost in
 order to use your package, and then things will then work as any other R package
@@ -141,7 +141,7 @@ The goal of these mechanisms is to allow easy interoperability between R
 packages that have Python dependencies, as well as to minimize specialized
 version/configuration steps for end-users. To that end, `reticulate` will (by
 default) track an older version of Python than the current release, giving
-Python packages time to adapt as is required.Python 2 will not be supported.
+Python packages time to adapt as is required. Python 2 will not be supported.
 
 Tools for breaking these rules are not yet implemented, but will be provided as
 the need arises.
@@ -152,18 +152,21 @@ Declared Python package dependencies should have the following format:
 
 - **package**: The name of the Python package.
 
+- **version**: The version of the package that should be installed.
+  When left unspecified, the latest-available version will be installed.
+
 - **pip**: Whether this package should be retrieved from the
   [PyPI](https://pypi.org) with `pip`, or (if `FALSE`) from the Anaconda
   repositories.
 
 For example, we could change the `reticulate@R` directive from above to specify
-that `scipy` be installed from PyPI:
+that `scipy [1.3.0]` be installed from PyPI (with `pip`):
 
 ```
 reticulate@R: list(
   packages = list(
-    c(package = "scipy", pip = TRUE)
+    list(package = "scipy", version = "1.3.0", pip = TRUE)
   )
-)
+  )
 ```
 

--- a/vignettes/python_dependencies.Rmd
+++ b/vignettes/python_dependencies.Rmd
@@ -73,10 +73,11 @@ Package: rscipy
 Title: An R Interface to scipy
 Version: 1.0.0
 Description: Provides an R interface to the Python package scipy.
-reticulate@R: list(
-  packages = list(
-    list(package = "scipy")
-  )
+reticulate@R:
+  list(
+    packages = list(
+      list(package = "scipy")
+    )
   )
 < ... other fields ...>
 ```
@@ -163,10 +164,11 @@ For example, we could change the `reticulate@R` directive from above to specify
 that `scipy [1.3.0]` be installed from PyPI (with `pip`):
 
 ```
-reticulate@R: list(
-  packages = list(
-    list(package = "scipy", version = "1.3.0", pip = TRUE)
-  )
+reticulate@R:
+  list(
+    packages = list(
+      list(package = "scipy", version = "1.3.0", pip = TRUE)
+    )
   )
 ```
 

--- a/vignettes/python_dependencies.Rmd
+++ b/vignettes/python_dependencies.Rmd
@@ -79,7 +79,7 @@ reticulate@R:
       list(package = "scipy")
     )
   )
-< ... other fields ...>
+< ... other fields ... >
 ```
 
 ### Installation 
@@ -153,8 +153,13 @@ Declared Python package dependencies should have the following format:
 
 - **package**: The name of the Python package.
 
-- **version**: The version of the package that should be installed.
-  When left unspecified, the latest-available version will be installed.
+- **version**: The version of the package that should be installed. When left
+  unspecified, the latest-available version will be installed. This should only
+  be set in exceptional cases -- for example, if the most recently-released
+  version of a Python package breaks compatibility with your package (or other
+  Python packages) in a fundamental way. If multiple R packages request
+  different versions of a particular Python package, `reticulate` will signal a
+  warning.
 
 - **pip**: Whether this package should be retrieved from the
   [PyPI](https://pypi.org) with `pip`, or (if `FALSE`) from the Anaconda


### PR DESCRIPTION
This PR makes it possible for R packages to declare specific versions of Python dependencies. R packages can hence declare e.g.

```
reticulate@R:
    list(
      packages = list(
        list(package = "scipy", version = "1.3.0")
      )
    )
```

to indicate that the package depends on `scipy [1.3.0]`.

---

- [x] Should we do any sort of (primitive) dependency resolution?
- [x] What should we do if multiple loaded R packages declare conflicting requirements (e.g. a different package requires `scipy [1.2.1]`?