### PR TITLE
WIP: Python 3.9 compatibility

### DIFF
--- a/src/libpython.cpp
+++ b/src/libpython.cpp
@@ -201,7 +201,6 @@ bool LibPython::loadSymbols(bool python3, std::string* pError)
   LOAD_PYTHON_SYMBOL(PyByteArray_AsString)
   LOAD_PYTHON_SYMBOL(PyCallable_Check)
   LOAD_PYTHON_SYMBOL(PyRun_StringFlags)
-  LOAD_PYTHON_SYMBOL(Py_CompileString)
   LOAD_PYTHON_SYMBOL(PyEval_EvalCode)
   LOAD_PYTHON_SYMBOL(PyModule_GetDict)
   LOAD_PYTHON_SYMBOL(PyImport_AddModule)
@@ -245,7 +244,7 @@ bool LibPython::loadSymbols(bool python3, std::string* pError)
   LOAD_PYTHON_SYMBOL(PyObject_CallMethod)
   LOAD_PYTHON_SYMBOL(PySequence_GetItem)
   LOAD_PYTHON_SYMBOL(PyObject_IsTrue)
-
+  
   // PyUnicode_AsEncodedString may have several different names depending on the Python
   // version and the UCS build type
   std::vector<std::string> names;
@@ -278,6 +277,7 @@ bool LibPython::loadSymbols(bool python3, std::string* pError)
     LOAD_PYTHON_SYMBOL(PyUnicode_FromString)
     LOAD_PYTHON_SYMBOL_AS(PyLong_AsLong, PyInt_AsLong)
     LOAD_PYTHON_SYMBOL_AS(PyLong_FromLong, PyInt_FromLong)
+    LOAD_PYTHON_SYMBOL(Py_CompileStringExFlags)
   } else {
     if (is64bit) {
       LOAD_PYTHON_SYMBOL_AS(Py_InitModule4_64, Py_InitModule4)
@@ -293,13 +293,14 @@ bool LibPython::loadSymbols(bool python3, std::string* pError)
     LOAD_PYTHON_SYMBOL(PyInt_AsLong)
     LOAD_PYTHON_SYMBOL(PyInt_FromLong)
     LOAD_PYTHON_SYMBOL(PyCObject_AsVoidPtr)
+    LOAD_PYTHON_SYMBOL(Py_CompileString)
   }
   LOAD_PYTHON_SYMBOL(PyCapsule_New)
   LOAD_PYTHON_SYMBOL(PyCapsule_GetPointer)
   LOAD_PYTHON_SYMBOL(PyCapsule_SetContext)
   LOAD_PYTHON_SYMBOL(PyCapsule_GetContext)
   LOAD_PYTHON_SYMBOL(Py_BuildValue)
-
+  
   return true;
 }
 

--- a/src/libpython.h
+++ b/src/libpython.h
@@ -114,6 +114,10 @@ typedef struct PyModuleDef{
   freefunc m_free;
 } PyModuleDef;
 
+typedef struct PyCompilerFlags{
+  int cf_flags;  
+  int cf_feature_version; 
+} PyCompilerFlags;
 
 LIBPYTHON_EXTERN PyTypeObject* PyFunction_Type;
 LIBPYTHON_EXTERN PyTypeObject* PyModule_Type;
@@ -310,7 +314,9 @@ LIBPYTHON_EXTERN void (*PySys_WriteStderr)(const char *format, ...);
 LIBPYTHON_EXTERN PyObject* (*PyObject_CallMethod)(PyObject *o, const char *name, const char *format, ...);
 LIBPYTHON_EXTERN PyObject* (*PySequence_GetItem)(PyObject *o, Py_ssize_t i);
 LIBPYTHON_EXTERN int (*PyObject_IsTrue)(PyObject *o);
-  
+
+LIBPYTHON_EXTERN PyObject* (*Py_CompileStringExFlags)(const char *str, const char *filename, int start, PyCompilerFlags *flags, int optimize);
+
 #define PyObject_TypeCheck(o, tp) ((PyTypeObject*)Py_TYPE(o) == (tp)) || PyType_IsSubtype((PyTypeObject*)Py_TYPE(o), (tp))
 
 #define PyType_Check(o) PyObject_TypeCheck(o, PyType_Type)
@@ -690,5 +696,4 @@ LIBPYTHON_EXTERN PyThreadState* (*PyThreadState_Next)(PyThreadState*);
 } // namespace libpython
 
 #endif
-
 

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -2187,12 +2187,12 @@ SEXP py_run_file_impl(const std::string& file,
 SEXP py_eval_impl(const std::string& code, bool convert = true) {
 
   // compile the code
-  // TBD: find a check that works
   PyObjectPtr compiledCode;
-  if (FALSE)
-    compiledCode(Py_CompileString(code.c_str(), "reticulate_eval", Py_eval_input));
+  if (Py_CompileStringExFlags != nullptr) 
+    compiledCode.assign(Py_CompileStringExFlags(code.c_str(), "reticulate_eval", Py_eval_input, NULL, 0));
   else 
-    compiledCode(Py_CompileStringExFlags(code.c_str(), "reticulate_eval", Py_eval_input, NULL, 0));
+    compiledCode.assign(Py_CompileString(code.c_str(), "reticulate_eval", Py_eval_input));
+  
   
   if (compiledCode.is_null())
     stop(py_fetch_error());

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -2187,10 +2187,16 @@ SEXP py_run_file_impl(const std::string& file,
 SEXP py_eval_impl(const std::string& code, bool convert = true) {
 
   // compile the code
-  PyObjectPtr compiledCode(Py_CompileString(code.c_str(), "reticulate_eval", Py_eval_input));
+  // TBD: find a check that works
+  PyObjectPtr compiledCode;
+  if (FALSE)
+    compiledCode(Py_CompileString(code.c_str(), "reticulate_eval", Py_eval_input));
+  else 
+    compiledCode(Py_CompileStringExFlags(code.c_str(), "reticulate_eval", Py_eval_input, NULL, 0));
+  
   if (compiledCode.is_null())
     stop(py_fetch_error());
-
+  
   // execute the code
   PyObject* main = PyImport_AddModule("__main__");
   PyObject* dict = PyModule_GetDict(main);

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -2188,7 +2188,7 @@ SEXP py_eval_impl(const std::string& code, bool convert = true) {
 
   // compile the code
   PyObjectPtr compiledCode;
-  if (Py_CompileStringExFlags != nullptr) 
+  if (Py_CompileStringExFlags != NULL) 
     compiledCode.assign(Py_CompileStringExFlags(code.c_str(), "reticulate_eval", Py_eval_input, NULL, 0));
   else 
     compiledCode.assign(Py_CompileString(code.c_str(), "reticulate_eval", Py_eval_input));


### PR DESCRIPTION
This is just the first step reg. `Py_CompileString`, Python is successfully loaded for Python 3.9 (including 3.8 ... 3.2 - `Py_CompileStringExFlags` was added in 3.2)  as well as Python 2.7 now. 

But I haven't yet found a way to use the adequate function in `py_eval_impl`:

dummy code:

```
  if (FALSE)
    compiledCode(Py_CompileString(code.c_str(), "reticulate_eval", Py_eval_input));
  else 
    compiledCode(Py_CompileStringExFlags(code.c_str(), "reticulate_eval", Py_eval_input, NULL, 0));
```

I was searching for  a way to check if a function exists in cpython, but haven't found one yet... (tried e.g. to see if the module dict from `main` has a key with that name)

Just copying the macro from 

https://github.com/python/cpython/blob/da6ce58dd5ac109485af45878fca6bfd265b43e9/Include/pythonrun.h#L99-L103

is not an option because only one of them will be loaded, depending on Python version...

Would you have an idea what to do here Kevin? Thanks!

