### PR TITLE
Bugfix/not creating env

### DIFF
--- a/R/conda.R
+++ b/R/conda.R
@@ -168,17 +168,19 @@ conda_install <- function(envname = NULL,
   envname <- condaenv_resolve(envname)
 
   # honor request for specific Python
-  python_package <- NULL
+  python_package <- "python"
   if (!is.null(python_version))
-    python_package <- paste("python", python_version, sep = "=")
+    python_package <- paste(python_package, python_version, sep = "=")
 
   # check if the environment exists, and create it on demand if needed.
   # if the environment does already exist, but a version of Python was
   # requested, attempt to install that in the existing environment
   # (effectively re-creating it if the Python version differs)
-  python <- tryCatch(conda_python(envname = envname, conda = conda), error = identity)
+  python <- tryCatch(conda_python(envname = envname, conda = conda), error = identity)  
+  
   if (inherits(python, "error") || !file.exists(python)) {
     conda_create(envname, packages = python_package, conda = conda)
+    python <- conda_python(envname = envname, conda = conda)
   } else if (!is.null(python_package)) {
     args <- conda_args("install", envname, python_package)
     status <- system2(conda, shQuote(args))

--- a/R/install.R
+++ b/R/install.R
@@ -2,7 +2,7 @@
 py_install_method_detect <- function(envname, conda = "auto") {
 
   # try to find an existing virtualenv
-  if (virtualenv_exists(envname))
+  if (!is_windows() && virtualenv_exists(envname))
     return("virtualenv")
   
   # check and prompt for miniconda
@@ -15,13 +15,16 @@ py_install_method_detect <- function(envname, conda = "auto") {
 
   # check to see if virtualenv or venv is available
   python <- virtualenv_default_python()
-  if (python_has_module(python, "virtualenv") || python_has_module(python, "venv"))
+  if (!is_windows() && (python_has_module(python, "virtualenv") || python_has_module(python, "venv")))
     return("virtualenv")
 
   # check to see if conda is available
   conda <- tryCatch(conda_binary(conda = conda), error = identity)
   if (!inherits(conda, "error"))
     return("conda")
+  
+  if (is_windows())
+    stop("No conda installation detected.", call. = FALSE)
 
   # default to virtualenv
   "virtualenv"

--- a/R/virtualenv.R
+++ b/R/virtualenv.R
@@ -250,7 +250,7 @@ virtualenv_default_python <- function(python = NULL) {
       next
 
     # get list of required modules
-    version <- tryCatch(python_version(python), error = identity)
+    suppressWarnings({version <- tryCatch(python_version(python), error = identity)})
     if (inherits(version, "error"))
       next
 


### PR DESCRIPTION
With the dev version of reticulate on Windows with a working version of Anaconda installed. If I try installing a package say numpy I see:

```
> reticulate::py_install("numpy")
Error: Installing Python packages into a virtualenv is not supported on Windows
In addition: Warning messages:
1: In system2(python, args, stdout = TRUE, stderr = FALSE) :
  running command '"C:\Users\dfalbel\AppData\Local\MICROS~1\WINDOW~1\python3.exe" -E -c "import platform; print(platform.python_version())"' had status 9009
2: In system2(python, args, stdout = TRUE, stderr = FALSE) :
  running command '"C:\Users\dfalbel\AppData\Local\MICROS~1\WINDOW~1\python.exe" -E -c "import platform; print(platform.python_version())"' had status 9009
```

If I force conda with method=conda:

```
> reticulate::py_install("numpy", method = "conda", pip = TRUE)
Collecting package metadata (current_repodata.json): ...working... done
Solving environment: ...working... done


==> WARNING: A newer version of conda exists. <==
  current version: 4.7.10
  latest version: 4.7.12

Please update conda by running

    $ conda update -n base -c defaults conda



## Package Plan ##

  environment location: C:\Users\dfalbel\ANACON~1\envs\r-reticulate



Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done
#
# To activate this environment, use
#
#     $ conda activate r-reticulate
#
# To deactivate an active environment, use
#
#     $ conda deactivate

Error: Error installing package(s): "numpy"
```

This PR fixes both issues.