### PR TITLE
Enable the convert scope for the self instance.

### DIFF
--- a/R/class.R
+++ b/R/class.R
@@ -59,9 +59,9 @@ PyClass <- function(classname, defs = list(), inherit = NULL) {
       x <- function(...) {
         args <- list(...)
         # enable convertion scope for `self`
-        # the first argument is always `self`.
+        # the first argument is always `self`.and we don't want to convert it.
         assign("convert", TRUE, envir = as.environment(args[[1]])) 
-        do.call(f, lapply(args, py_to_r))
+        do.call(f, append(args[1], lapply(args[-1], py_to_r)))
       }
     }
     x

--- a/R/class.R
+++ b/R/class.R
@@ -57,7 +57,11 @@ PyClass <- function(classname, defs = list(), inherit = NULL) {
     if (inherits(x, "function")) {
       f <- inject_super(x)
       x <- function(...) {
-        do.call(f, lapply(list(...), py_to_r))
+        args <- list(...)
+        # enable convertion scope for `self`
+        # the first argument is always `self`.
+        assign("convert", TRUE, envir = as.environment(args[[1]])) 
+        do.call(f, lapply(args, py_to_r))
       }
     }
     x

--- a/tests/testthat/test-python-class.R
+++ b/tests/testthat/test-python-class.R
@@ -153,7 +153,40 @@ test_that("Can directly access variables from a class", {
   expect_equal(x$add_n(10), 12)
 })
 
-
+test_that("Properties are automatically converted in inherited classes", {
+  skip_if_no_python()
+  
+  bt <- import_builtins(convert = FALSE)
+  p <- py_run_string("
+class Base:
+  def __init__ (self, x):
+    self.x = 1
+", convert = FALSE)
+  
+  Hi <- PyClass("Hi", inherit = p$Base, list(
+    `__init__` = function(self, a, ...) {
+      self$a <- a
+      self$k <- bt$isinstance # Have a python that can't be
+                              # converted to an R type
+      super()$`__init__`(...)
+    },
+    add_2 = function(self) {
+      self$a + 2
+    },
+    get_class = function(self) {
+      class(self$a)
+    },
+    add_n = function(self, n) {
+      self$a + n
+    }
+  ))
+  
+  x <- Hi(a = 2, x = 1)
+  expect_equal(x$add_2(), 4)
+  expect_equal(x$a, 2)
+  expect_equal(x$get_class(), "numeric")
+  expect_equal(x$add_n(10), 12)
+})
 
 
 

--- a/tests/testthat/test-python-class.R
+++ b/tests/testthat/test-python-class.R
@@ -188,6 +188,32 @@ class Base:
   expect_equal(x$add_n(10), 12)
 })
 
+test_that("self is not converted when there's a py_to_r method for it", {
+  skip_if_no_python()
+  
+  bt <- import_builtins(convert = FALSE)
+  
+  Base <- PyClass("Base")
+  
+  Hi <- PyClass("Hi", inherit = Base, list(
+    `__init__` = function(self, a) {
+      self$a <- a
+      NULL
+    },
+    add_2 = function(self) {
+      self$a + 2
+    }
+  ))
+  
+  py_to_r.python.builtin.Base <- function(x) {
+    "base"
+  }
+  
+  x <- Hi(2)
+  expect_equal(x, "base")
+})
+
+
 
 
 


### PR DESCRIPTION
This PR enables the convert scope for the `self` instance, fixing: https://github.com/rstudio/reticulate/pull/655#issuecomment-558236772

**Pending adding tests**