### PR TITLE
.DollarNames(x, pattern) obeys its contract

### DIFF
--- a/R/python.R
+++ b/R/python.R
@@ -440,9 +440,15 @@ as.environment.python.builtin.object <- function(x) {
     }
   }
 
+  idx <- grepl(pattern, names)
+  names <- names[idx]
+  types <- types[idx]
+
   if (length(names) > 0) {
     # set types
-    attr(names, "types") <- types
+    oidx <- order(names)
+    names <- names[oidx]
+    attr(names, "types") <- types[oidx]
 
     # specify a help_handler
     attr(names, "helpHandler") <- "reticulate:::help_handler"


### PR DESCRIPTION
- returns completions matching pattern, allowing tab completion in
  vanilla R

Previously:
```
> import("numpy") -> numpy
> str(.DollarNames(numpy, "a"))
 chr [1:587] "abs" "absolute" "absolute_import" "add" "add_docstring" ...
 - attr(*, "types")= int [1:587] 6 6 4 6 6 6 6 5 6 6 ...
 - attr(*, "helpHandler")= chr "reticulate:::help_handler"
> numpy$a<tab>
> numpy$a
```
After PR, in vanilla R
```
> numpy$array2string numpy$array_equiv  numpy$array_split
> str(.DollarNames(numpy, "a"))
 chr [1:264] "abs" "absolute" "absolute_import" "add" "add_docstring" ...
 - attr(*, "types")= int [1:264] 6 6 4 6 6 6 6 6 6 6 ...
 - attr(*, "helpHandler")= chr "reticulate:::help_handler"
> numpy$a<tab>
numpy$abs               numpy$apply_over_axes   numpy$array_equal
numpy$absolute          numpy$arange            numpy$array_equiv
...
> numpy$a
```