### PR TITLE
conda_binary didn't check conda binary location path properly

### DIFF
--- a/R/conda.R
+++ b/R/conda.R
@@ -243,11 +243,11 @@ conda_binary <- function(conda = "auto") {
   }
 
   # validate existence
-  if (!file.exists(conda))
-    stop("Specified conda binary '", conda, "' does not exist.", call. = FALSE)
+  # if (!file.exists(conda))
+  stop("Specified conda binary '", conda, "' does not exist.", call. = FALSE)
 
   # return conda
-  conda
+  # conda
 }
 
 

--- a/R/conda.R
+++ b/R/conda.R
@@ -230,14 +230,14 @@ conda_binary <- function(conda = "auto") {
   # we rely on other tools typically bundled in the 'bin' folder
   # https://github.com/rstudio/keras/issues/691
   if (!is_windows()) {
-    altpath <- file.path(dirname(conda), "../bin/conda")
+    altpath <- file.path(dirname(conda), "bin/conda")
     if (file.exists(altpath))
       return(normalizePath(altpath, winslash = "/", mustWork = TRUE))
   } else {
     # on Windows it's preferable to conda.bat located in the 'condabin'
     # folder. if the user passed the path to a 'Scripts/conda.exe' we will
     # try to find the 'conda.bat'.
-    altpath <- file.path(dirname(conda), "../condabin/conda.bat")
+    altpath <- file.path(dirname(conda), "condabin/conda.bat")
     if (file.exists(altpath))
       return(normalizePath(altpath, winslash = "/", mustWork = TRUE))
   }


### PR DESCRIPTION
- If a conda binary path is provided (xxx/bin), using `dirname` and `..` together will seek two levels up which is redundant.
- If a path didn't pass the previous test but still is a valid path, the function will report as a valid conda binary location.
   - If there do have this kind of cases, it should test the existence of conda binary, not the path itself.
   - If there is no valid case for this, it should report error. The second commit is based on this assumption, but I can change to first assumption if that's the case.