### PR TITLE
don't force as this would apply to non-miniconda-envs as well

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -56,7 +56,7 @@ ensure_python_initialized <- function(required_module = NULL) {
     py_inject_hooks()
     
     # install required packages
-    configure_environment()
+    if (should_configure()) configure_environment()
 
   }
 }
@@ -176,4 +176,18 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
 }
 
 
-
+should_configure <- function() {
+  
+  # allow users to opt out
+  configure_ok <- Sys.getenv("RETICULATE_AUTOCONFIGURE", unset = "TRUE")
+  configure_ok <- if (configure_ok %in% c("FALSE", "False", "0")) FALSE else TRUE
+  
+  # only done if we're using miniconda for now
+  config <- py_config()
+  python <- config$python
+  home <- miniconda_path()
+  is_miniconda <- substring(config$python, 1, nchar(home)) == home
+  
+  configure_ok && is_miniconda
+  
+}

--- a/R/package.R
+++ b/R/package.R
@@ -180,7 +180,8 @@ should_configure <- function() {
   
   # allow users to opt out
   configure_ok <- Sys.getenv("RETICULATE_AUTOCONFIGURE", unset = "TRUE")
-  configure_ok <- if (configure_ok %in% c("FALSE", "False", "0")) FALSE else TRUE
+  if (configure_ok %in% c("FALSE", "False", "0"))
+    return(FALSE)
   
   # only done if we're using miniconda for now
   config <- py_config()
@@ -188,6 +189,6 @@ should_configure <- function() {
   home <- miniconda_path()
   is_miniconda <- substring(config$python, 1, nchar(home)) == home
   
-  configure_ok && is_miniconda
+  is_miniconda
   
 }

--- a/R/python-packages.R
+++ b/R/python-packages.R
@@ -39,7 +39,7 @@
 #' @param force Boolean; force configuration of the associated environment?
 #'
 #' @export
-configure_environment <- function(package = NULL, force = TRUE) {
+configure_environment <- function(package = NULL, force = FALSE) {
   
   if (!is_python_initialized())
     return(FALSE)

--- a/R/python-packages.R
+++ b/R/python-packages.R
@@ -36,26 +36,12 @@
 #'   will instead look at all loaded packages and discover their associated
 #'   Python requirements.
 #'
-#' @param force Boolean; force configuration of the associated environment?
-#'
 #' @export
-configure_environment <- function(package = NULL, force = FALSE) {
+configure_environment <- function(package = NULL) {
   
   if (!is_python_initialized())
     return(FALSE)
   
-  # allow users to opt out
-  enabled <- Sys.getenv("RETICULATE_AUTOCONFIGURE", unset = "TRUE")
-  if (enabled %in% c("FALSE", "False", "0"))
-    return(FALSE)
-  
-  # only done if we're using miniconda for now
-  config <- py_config()
-  python <- config$python
-  home <- miniconda_path()
-  if (!force && substring(config$python, 1, nchar(home)) != home)
-    return(FALSE)
-
   # find Python requirements  
   reqs <- python_package_requirements(package)
   if (length(reqs) == 0)


### PR DESCRIPTION
I am not totally sure what we want to do here... (long-term)

On the one hand, in the recent blog post we say 

> Currently, automatic Python environment configuration will only happen when using the aforementioned reticulate Miniconda installation.

On the other hand, we do have an escape hatch in place already (RETICULATE_AUTOCONFIGURE) so we could as well leave the default as is... and remove the comment 

https://github.com/rstudio/reticulate/blob/c403546661ee7f8273ff505a8cd4f4ec6e2bfa8e/R/python-packages.R#L4

instead (and update the blog post I guess)...

Sorry I didn't "really" check this out before (though I could have, as I'm in the have-to-opt-out situation for virtualenv all the time...)


