### PR TITLE
Fix multiple inheritance

### DIFF
--- a/R/class.R
+++ b/R/class.R
@@ -2,19 +2,35 @@ inject_super <- function(fun) {
   # for each function `fun` we need to place a `super` function in its
   # search path, and this `super` function must be able to access
   # the `self` argument passed to `fun`.
-  
+
   e <- new.env(parent = environment(fun))
   
   e$super <- function() {
     bt <- reticulate::import_builtins()
     # self is an argument passed to fun
-    self <- get("self", envir = parent.frame(), inherits = FALSE) 
-    bt$super(self$`__class__`, self)
+    self <- get("self", envir = parent.frame(), inherits = FALSE)
+    class_ <- get("__class__", envir = e, inherits = FALSE)
+    bt$super(class_, self)
   }
-  
+
   environment(fun) <- e # so fun can access `super`
-  
+
   fun
+}
+
+#' Enable the convertion scope so `self` fields can be accessed
+#' without the need to call `py_to_r`.
+#' 
+#' @param f a method/function of a Python class
+#' 
+enable_convert_scope <- function(f) {
+  function(...) {
+    args <- list(...)
+    # enable convertion scope for `self`
+    # the first argument is always `self`.and we don't want to convert it.
+    assign("convert", TRUE, envir = as.environment(args[[1]])) 
+    do.call(f, append(args[1], lapply(args[-1], py_to_r)))
+  }
 }
 
 #' Create a python class
@@ -56,20 +72,25 @@ PyClass <- function(classname, defs = list(), inherit = NULL) {
   defs <- lapply(defs, function(x) {
     if (inherits(x, "function")) {
       f <- inject_super(x)
-      x <- function(...) {
-        args <- list(...)
-        # enable convertion scope for `self`
-        # the first argument is always `self`.and we don't want to convert it.
-        assign("convert", TRUE, envir = as.environment(args[[1]])) 
-        do.call(f, append(args[1], lapply(args[-1], py_to_r)))
-      }
+      x <- enable_convert_scope(f)
+      attr(x, "__env__") <- environment(f)
     }
     x
   })
   
-  bt$type(
+  type <- bt$type(
     classname, inherit, 
     do.call(reticulate::dict, defs)
   )
+  
+  # we add a reference to the type here. so it can be acessed without needing
+  # to find the type from self.
+  lapply(defs, function(x) {
+    if(!is.null(e <- attr(x, "__env__"))) {
+      e$`__class__` <- type
+    }
+  })
+  
+  type
 }
 

--- a/R/class.R
+++ b/R/class.R
@@ -18,19 +18,8 @@ inject_super <- function(fun) {
   fun
 }
 
-#' Enable the convertion scope so `self` fields can be accessed
-#' without the need to call `py_to_r`.
-#' 
-#' @param f a method/function of a Python class
-#' 
 enable_convert_scope <- function(f) {
-  function(...) {
-    args <- list(...)
-    # enable convertion scope for `self`
-    # the first argument is always `self`.and we don't want to convert it.
-    assign("convert", TRUE, envir = as.environment(args[[1]])) 
-    do.call(f, append(args[1], lapply(args[-1], py_to_r)))
-  }
+  
 }
 
 #' Create a python class
@@ -72,7 +61,13 @@ PyClass <- function(classname, defs = list(), inherit = NULL) {
   defs <- lapply(defs, function(x) {
     if (inherits(x, "function")) {
       f <- inject_super(x)
-      x <- enable_convert_scope(f)
+      x <- function(...) {
+        args <- list(...)
+        # enable convertion scope for `self`
+        # the first argument is always `self`.and we don't want to convert it.
+        assign("convert", TRUE, envir = as.environment(args[[1]])) 
+        do.call(f, append(args[1], lapply(args[-1], py_to_r)))
+      }
       attr(x, "__env__") <- environment(f)
     }
     x

--- a/tests/testthat/test-python-class.R
+++ b/tests/testthat/test-python-class.R
@@ -214,7 +214,32 @@ test_that("self is not converted when there's a py_to_r method for it", {
   rm(py_to_r.python.builtin.Base, envir = .GlobalEnv)
 })
 
-
+test_that("can call super from an ingerited class", {
+  
+  Base1 <- PyClass("Base1", list(`__init__` = function(self, a) {
+    self$a <- a
+  }))
+  
+  Base2 <- PyClass("Base2", list(`__init__` = function(self, a, b) {
+    self$b <- b
+    super()$`__init__`(a)
+  }), inherit = Base1)
+  
+  Inhe <- PyClass("Inhe", inherit = Base2, list(
+    `__init__` = function(self, a, b, c) {
+      self$c <- c
+      super()$`__init__`(a, b)
+      NULL
+    }
+  ))
+  
+  x <- Inhe(10, 20, 30)
+  
+  
+  expect_equal(x$a, 10)
+  expect_equal(x$b, 20)
+  expect_equal(x$c, 30)
+})
 
 
 


### PR DESCRIPTION
This fixes a bug when creating a third level of inheritance with classes created from R. 
The problem is this line:

https://github.com/rstudio/reticulate/compare/master...dfalbel:fix-inheritance?expand=1#diff-9603c58bdf50909f0162edee456f1ef6L12

Turns out this is a common bug in python, see: https://stackoverflow.com/a/17509938/3297472

I also added a test that shows the bug if you run with the current reticulate version.