### PR TITLE
Fix incorrect extraction of parameter descriptions

### DIFF
--- a/R/wrapper.R
+++ b/R/wrapper.R
@@ -213,7 +213,8 @@ py_function_custom_scaffold <- function(
 
       # Write docstrings for each parameters
       for(i in 1:length(docs$parameters)) {
-        param_doc <- process_param_doc_fn(docs$sections[i], docs)
+        param_name <- names(docs$parameters)[i]
+        param_doc <- process_param_doc_fn(docs$parameters[[param_name]], docs)
         write_line(paste0("#' @param ", " ", names(docs$parameters)[i], " ", param_doc))
       }
 


### PR DESCRIPTION
This should be extracting from `docs$parameters` instead of `docs$sections`.