### PR TITLE
ensure configure_environment() is noop if using 'system' Python

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 
 ## reticulate 1.15 (UNDER DEVELOPMENT)
 
+- `reticulate::configure_environment()` now only allows environment
+  configuration within interactive R sessions, and ensures that the
+  version of Python that has been initialized by Python is indeed
+  associated with a virtual environment or Conda environment.
+
 - `reticulate` now automatically flushes output written to Python's
   stdout / stderr, as a top-level task added by `addTaskCallback()`.
   This behavior is controlled with the `options(reticulate.autoflush)`

--- a/R/package.R
+++ b/R/package.R
@@ -56,7 +56,7 @@ ensure_python_initialized <- function(required_module = NULL) {
     py_inject_hooks()
     
     # install required packages
-    if (should_configure()) configure_environment()
+    configure_environment()
 
   }
 }
@@ -173,22 +173,4 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
 
   # return config
   config
-}
-
-
-should_configure <- function() {
-  
-  # allow users to opt out
-  configure_ok <- Sys.getenv("RETICULATE_AUTOCONFIGURE", unset = "TRUE")
-  if (configure_ok %in% c("FALSE", "False", "0"))
-    return(FALSE)
-  
-  # only done if we're using miniconda for now
-  config <- py_config()
-  python <- config$python
-  home <- miniconda_path()
-  is_miniconda <- substring(config$python, 1, nchar(home)) == home
-  
-  is_miniconda
-  
 }

--- a/R/python-packages.R
+++ b/R/python-packages.R
@@ -35,16 +35,29 @@
 #' @param package The name of a package to configure. When `NULL`, `reticulate`
 #'   will instead look at all loaded packages and discover their associated
 #'   Python requirements.
-#'   
+#'
+#' @param force Boolean; force configuration of the Python environment? Note
+#'   that `configure_environment()` is a no-op within non-interactive \R
+#'   sessions. Use this if you require automatic environment configuration, e.g.
+#'   when testing a package on a continuous integration service.
+#'
 #' @export
-configure_environment <- function(package = NULL) {
+configure_environment <- function(package = NULL, force = FALSE) {
   
+  # no-op when Python has not yet been initialized
   if (!is_python_initialized())
     return(FALSE)
   
-  # allow users to opt out
-  configure_ok <- Sys.getenv("RETICULATE_AUTOCONFIGURE", unset = "TRUE")
-  if (configure_ok %in% c("FALSE", "False", "0"))
+  # allow opt-out through envvar
+  auto <- Sys.getenv("RETICULATE_AUTOCONFIGURE", unset = "TRUE")
+  if (auto %in% c("FALSE", "False", "0"))
+    return(FALSE)
+  
+  # disallow in non-interactive R sessions unless forced
+  # (even if force is set, do not allow unless user has explicitly
+  # promised they're not on CRAN)
+  ok <- interactive() || (force && identical(Sys.getenv("NOT_CRAN"), "true"))
+  if (!ok)
     return(FALSE)
   
   # disallow environment configuration when not using a Python environment

--- a/R/python-packages.R
+++ b/R/python-packages.R
@@ -35,11 +35,23 @@
 #' @param package The name of a package to configure. When `NULL`, `reticulate`
 #'   will instead look at all loaded packages and discover their associated
 #'   Python requirements.
-#'
+#'   
 #' @export
 configure_environment <- function(package = NULL) {
   
   if (!is_python_initialized())
+    return(FALSE)
+  
+  # allow users to opt out
+  configure_ok <- Sys.getenv("RETICULATE_AUTOCONFIGURE", unset = "TRUE")
+  if (configure_ok %in% c("FALSE", "False", "0"))
+    return(FALSE)
+  
+  # disallow environment configuration when not using a Python environment
+  config <- py_config()
+  root <- dirname(dirname(config$python))
+  ok <- is_virtualenv(root) || is_condaenv(root)
+  if (!ok)
     return(FALSE)
   
   # find Python requirements  

--- a/man/configure_environment.Rd
+++ b/man/configure_environment.Rd
@@ -4,12 +4,17 @@
 \alias{configure_environment}
 \title{Configure a Python Environment}
 \usage{
-configure_environment(package = NULL)
+configure_environment(package = NULL, force = FALSE)
 }
 \arguments{
 \item{package}{The name of a package to configure. When \code{NULL}, \code{reticulate}
 will instead look at all loaded packages and discover their associated
 Python requirements.}
+
+\item{force}{Boolean; force configuration of the Python environment? Note
+that \code{configure_environment()} is a no-op within non-interactive \R
+sessions. Use this if you require automatic environment configuration, e.g.
+when testing a package on a continuous integration service.}
 }
 \description{
 Configure a Python environment, satisfying the Python dependencies of any


### PR DESCRIPTION
Otherwise, packages configuring Python with e.g.

```
.onLoad <- function(libname, pkgname) {
  reticulate::configure_environment(pkgname)
}
```

could inadvertently attempt to configure a system copy of Python.