### PR TITLE
fix #706 handling of lineno with decorators

### DIFF
--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -93,7 +93,11 @@ eng_python <- function(options) {
 
   # iterate over top-level nodes and extract line numbers
   lines <- vapply(parsed$body, function(node) {
-    node$lineno
+    if(py_has_attr(node, 'decorator_list') && length(node$decorator_list)) {
+      node$decorator_list[[1]]$lineno
+    } else {
+      node$lineno
+    }
   }, integer(1))
 
   # it's possible for multiple statements to live on the


### PR DESCRIPTION
This is my attempt to fix issue [#706](https://github.com/rstudio/reticulate/issues/706).

For functions with decorators, Python 3.8 updated `lineno` to point to the `lineno` of the `def`, rather than the `lineno` of the first decorator (see [this PR](https://github.com/python/cpython/pull/9731)).

I updated the code that extracts line numbers to use the first decorator's `lineno` if available, and otherwise the node's `lineno`. Unsure if this is the best approach, so I appreciate any feedback, but it appears to work.