### PR TITLE
suppress output with semicolon (fix #717)

### DIFF
--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -142,11 +142,15 @@ eng_python <- function(options) {
     # save last value
     last_value <- py_last_value()
 
+    # use trailing semicolon to suppress output of return value
+    suppress <- grepl(";\\s*$", snippet)
+    compile_mode <- if(suppress) "exec" else "single"
+
     # run code and capture output
     captured <- if (capture_errors)
-      tryCatch(py_compile_eval(snippet), error = identity)
+      tryCatch(py_compile_eval(snippet, compile_mode), error = identity)
     else
-      py_compile_eval(snippet)
+      py_compile_eval(snippet, compile_mode)
 
     # handle matplotlib output
     captured <- eng_python_matplotlib_handle_output(captured, last_value, i == length(ranges))

--- a/R/utils.R
+++ b/R/utils.R
@@ -97,7 +97,7 @@ new_stack <- function() {
 
 }
 
-py_compile_eval <- function(code) {
+py_compile_eval <- function(code, compile_mode="single") {
 
   builtins <- import_builtins(convert = TRUE)
   sys <- import("sys", convert = TRUE)
@@ -116,9 +116,9 @@ py_compile_eval <- function(code) {
   # newline follows the code to be submitted
   code <- sub("\\s*$", "\n", code)
 
-  # compile and eval the code -- using 'single' here ensures that Python
-  # auto-prints statements as they are evaluated
-  compiled <- builtins$compile(code, '<string>', 'single')
+  # compile and eval the code -- use 'single' to auto-print statements
+  # as they are evaluated, or 'exec' to avoid auto-print
+  compiled <- builtins$compile(code, '<string>', compile_mode)
   output <- py_capture_output(builtins$eval(compiled, globals, locals))
 
   # save the value that was produced


### PR DESCRIPTION
I've implemented the functionality described in [#717](https://github.com/rstudio/reticulate/issues/717). Adding a trailing semicolon stops return values from being output.