### PR TITLE
Point to proper vignette that details package developer tips

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -239,7 +239,7 @@ check_forbidden_initialization <- function() {
       "package '%s' attempted to initialize Python in %s().",
       "Packages should not initialize Python themselves; rather, Python should",
       "be loaded on-demand as requested by the user of the package. Please see",
-      "vignette(\"python_packages\", package = \"reticulate\") for more details."
+      "vignette(\"python_dependencies\", package = \"reticulate\") for more details."
     )
     
     msg <- sprintf(fmt, pkgname, call[[2]])


### PR DESCRIPTION
Previous error message erroneously pointed to the wrong vignette.  The `python_packages` vignette is about installing packages whereas the `python_dependencies` is the right resource for package developers who depend on reticulate functionality.