### PR TITLE
Allow specifying channel in conda_create

### DIFF
--- a/R/conda.R
+++ b/R/conda.R
@@ -486,6 +486,7 @@ conda_list_packages <- function(envname = NULL, conda = "auto", no_pip = TRUE) {
     package     = parsed$name,
     version     = parsed$version,
     requirement = paste(parsed$name, parsed$version, sep = "="),
+    channel     = parsed$channel,
     stringsAsFactors = FALSE
   )
   

--- a/R/conda.R
+++ b/R/conda.R
@@ -103,8 +103,18 @@ conda_list <- function(conda = "auto") {
 }
 
 
-
+#' @param forge Boolean; include the [Conda Forge](https://conda-forge.org/)
+#'   repository?
+#'
+#' @param channel An optional character vector of Conda channels to include.
+#'   When specified, the `forge` argument is ignored. If you need to
+#'   specify multiple channels, including the Conda Forge, you can use
+#'   `c("conda-forge", <other channels>)`.
+#'
 #' @rdname conda-tools
+#'
+#' @keywords internal
+#'
 #' @export
 conda_create <- function(envname = NULL,
                          packages = "python",

--- a/R/conda.R
+++ b/R/conda.R
@@ -106,7 +106,11 @@ conda_list <- function(conda = "auto") {
 
 #' @rdname conda-tools
 #' @export
-conda_create <- function(envname = NULL, packages = "python", conda = "auto") {
+conda_create <- function(envname = NULL,
+                         packages = "python",
+                         forge = TRUE,
+                         channel = character(),
+                         conda = "auto") {
 
   # resolve conda binary
   conda <- conda_binary(conda)
@@ -116,6 +120,16 @@ conda_create <- function(envname = NULL, packages = "python", conda = "auto") {
 
   # create the environment
   args <- conda_args("create", envname, packages)
+
+  # add user-requested channels
+  channels <- if (length(channel))
+    channel
+  else if (forge)
+    "conda-forge"
+
+  for (ch in channels)
+    args <- c(args, "-c", ch)
+
   result <- system2(conda, shQuote(args))
   if (result != 0L) {
     stop("Error ", result, " occurred creating conda environment ", envname,

--- a/man/conda-tools.Rd
+++ b/man/conda-tools.Rd
@@ -13,7 +13,13 @@
 \usage{
 conda_list(conda = "auto")
 
-conda_create(envname = NULL, packages = "python", conda = "auto")
+conda_create(
+  envname = NULL,
+  packages = "python",
+  forge = TRUE,
+  channel = character(),
+  conda = "auto"
+)
 
 conda_remove(envname, packages = NULL, conda = "auto")
 

--- a/tests/testthat/test-python-envs.R
+++ b/tests/testthat/test-python-envs.R
@@ -17,6 +17,14 @@ test_that("conda utility functions work as expected", {
   conda_remove('reticulate-testthat')
   expect_false('reticulate-testthat' %in% conda_list()$name)
 
+  conda_create('reticulate-testthat', forge = TRUE)
+  expect_true(all(grepl("conda-forge", conda_list_packages("reticulate-testthat")$channel)))
+  conda_remove('reticulate-testthat')
+
+  conda_create('reticulate-testthat', channel = c("anaconda"))
+  expect_true(all(grepl("anaconda", conda_list_packages("reticulate-testthat")$channel)))
+  conda_remove('reticulate-testthat')
+
 })
 
 test_that("virtualenv utility functions work as expected", {

--- a/tests/testthat/test-python-envs.R
+++ b/tests/testthat/test-python-envs.R
@@ -30,7 +30,10 @@ test_that("conda utility functions work as expected", {
 test_that("virtualenv utility functions work as expected", {
   skip_if_no_test_environments()
 
-  virtualenv_remove('reticulate-testthat', confirm = FALSE)
+  expect_error(
+    virtualenv_remove('reticulate-testthat', confirm = FALSE),
+    'Virtual environment \'reticulate-testthat\' does not exist.'
+  )
 
   virtualenv_create('reticulate-testthat')
   virtualenv_remove('reticulate-testthat', confirm = FALSE)


### PR DESCRIPTION
This PR adds the arguments `forge` and `channel` to `conda_create` analogously to how they work in `conda_install`.

This is a tiny PR, but adding these arguments will change behavior for two reasons:
- I set the default value for `conda` to `TRUE` just like for `conda_install`. Previously, it would just use whatever the user had configured conda to do (see `conda config --show-sources`)
- I'm squeezing the `forge` and `channel` arguments in before the `conda` argument just like for `conda_install`.

I also added a tiny test for this. But to make the test meaningful I need to access the channel of installed packages somehow (ideally without activating the conda environment). So I amended `conda_list_packages` to also return a column with the `channel` just like you see when you run `conda list` in the command line.

Closes #751