### PR TITLE
initialize before py_install

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -79,15 +79,24 @@ py_install <- function(packages,
   # then install into that same environment
   if (is.null(envname)) {
     
-   config <- py_discover_config()
+    python <- if (is_python_initialized())
+      .globals$py_config$python
+    else if (length(.globals$required_python_version))
+      .globals$required_python_version[[1]]
+    else if (length(p <- py_discover_config()$python))
+      p
+    else
+      NULL
     
-   python <- config$python
-   info <- python_info(python)
-   envname <- info$root
-   method <- info$type
-   if (method == "conda")
-     conda <- conda_binary(info$root)
-   }
+    if (!is.null(python)) {
+      info <- python_info(python)
+      envname <- info$root
+      method <- info$type
+      if (method == "conda")
+        conda <- conda_binary(info$root)
+    }
+    
+  }
   
   # resolve 'auto' method
   method <- match.arg(method)

--- a/R/install.R
+++ b/R/install.R
@@ -79,9 +79,9 @@ py_install <- function(packages,
   # then install into that same environment
   if (is.null(envname)) {
     
-   ensure_python_initialized()
+   config <- py_discover_config()
     
-   python <- .globals$py_config$python
+   python <- config$python
    info <- python_info(python)
    envname <- info$root
    method <- info$type

--- a/R/install.R
+++ b/R/install.R
@@ -79,22 +79,15 @@ py_install <- function(packages,
   # then install into that same environment
   if (is.null(envname)) {
     
-    python <- if (is_python_initialized())
-      .globals$py_config$python
-    else if (length(.globals$required_python_version))
-      .globals$required_python_version[[1]]
-    else
-      NULL
+   ensure_python_initialized()
     
-    if (!is.null(python)) {
-      info <- python_info(python)
-      envname <- info$root
-      method <- info$type
-      if (method == "conda")
-        conda <- conda_binary(info$root)
-    }
-    
-  }
+   python <- .globals$py_config$python
+   info <- python_info(python)
+   envname <- info$root
+   method <- info$type
+   if (method == "conda")
+     conda <- conda_binary(info$root)
+   }
   
   # resolve 'auto' method
   method <- match.arg(method)


### PR DESCRIPTION
The reason for this change is described below. However, I'm not sure if there are any unintended consequences in other usage scenarios, so this PR is kind of tentative :-)

Reason:
When you have RETICULATE_AUTOCONFIGURE set to`0`, but execute (or have other packages execute) `py_install()` right at the start of a session - meaning that `is_python_initialized()` yields `FALSE` - `reticulate` will try installing into an env called `r-reticulate`, even though `py_config()` would have correctly discovered the one you specified by `. ~myenv/bin/activate` before starting RStudio.

This PR makes sure Python is always initialized  before `py_install` is called.