### PR TITLE
Add python_dependencies vignette to header menu

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -26,6 +26,8 @@ navbar:
           href: articles/arrays.html
         - text: "Using reticulate in an R Package"
           href: articles/package.html
+        - text: "Managing an R Package’s Python Dependencies"
+          href: articles/python_dependencies.html
         - text: "---"
         - text: "Tools"
         - text: "RStudio IDE Tools for reticulate"

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -26,7 +26,7 @@ navbar:
           href: articles/arrays.html
         - text: "Using reticulate in an R Package"
           href: articles/package.html
-        - text: "Managing an R Package’s Python Dependencies"
+        - text: "Managing an R Package's Python Dependencies"
           href: articles/python_dependencies.html
         - text: "---"
         - text: "Tools"


### PR DESCRIPTION
I noticed that this existed but was not in the menu