### PR TITLE
do not capture output in repl mode

### DIFF
--- a/R/repl.R
+++ b/R/repl.R
@@ -229,9 +229,7 @@ repl_python <- function(
 
       # submit previous code
       pasted <- paste(previous, collapse = "\n")
-      output <- tryCatch(py_compile_eval(pasted), error = handle_error)
-      if (is.character(output) && nzchar(output))
-        cat(output, sep = "")
+      tryCatch(py_compile_eval(pasted, capture = FALSE), error = handle_error)
 
       # now, handle the newest line of code submitted
       buffer$set(contents)
@@ -246,9 +244,7 @@ repl_python <- function(
     # otherwise, we should have received a code output object
     # so we can just run the code submitted thus far
     buffer$clear()
-    output <- tryCatch(py_compile_eval(code), error = handle_error)
-    if (is.character(output) && nzchar(output))
-      cat(output, sep = "")
+    tryCatch(py_compile_eval(code, capture = FALSE), error = handle_error)
 
   }
 
@@ -302,4 +298,3 @@ repl_python <- function(
 py_repl_active <- function() {
   .globals$py_repl_active
 }
-


### PR DESCRIPTION
The output of the following python code in `repl_python()` will be buffered until the whole block is done.

```py
import time
for i in range(10):
  print(i, flush = True)
  time.sleep(1)
```

It is because `py_compile_eval` has captured the output. This PR adds an option to `py_compile_eval` so that the output is not captured.

Before:
![before](https://user-images.githubusercontent.com/1690993/83500699-f82b4100-a473-11ea-8737-6b0afd28b91d.gif)

After:
![after](https://user-images.githubusercontent.com/1690993/83500716-fe212200-a473-11ea-9874-1173ab4d7383.gif)


related to https://github.com/rstudio/reticulate/issues/739#issuecomment-637374290