### PR TITLE
Make `reticulate::configure_environment()` work with the default miniconda installation

### DIFF
--- a/R/pip.R
+++ b/R/pip.R
@@ -59,7 +59,7 @@ pip_freeze <- function(python) {
   
   args <- c("-m", "pip", "freeze")
   output <- system2(python, args, stdout = TRUE)
-  splat <- strsplit(output, "==", fixed = TRUE)
+  splat <- strsplit(output, "==| @ ")
   packages <- vapply(splat, `[[`, 1L, FUN.VALUE = character(1))
   versions <- vapply(splat, `[[`, 2L, FUN.VALUE = character(1))
   data.frame(


### PR DESCRIPTION
# Problem
On my machine, `reticulate::configure_environment()` crashes when invoked for the default miniconda installed by reticulate.  The cause of the problem is that the `pip freeze` command (which is called by `pip_freeze()` in the course of working out which packages need to be installed) is expected to list every installed package with a name and a version number separated by `==`, e.g.:

```
scipy==1.4.1
```

However, the `numpy` package in the default miniconda installation (on my machine) does not adhere to this format:

```
> py_config()
python:         /home/kale/.local/share/r-miniconda/envs/r-reticulate/bin/python
libpython:      /home/kale/.local/share/r-miniconda/envs/r-reticulate/lib/libpython3.6m.so
pythonhome:     /home/kale/.local/share/r-miniconda/envs/r-reticulate:/home/kale/.local/share/r-miniconda/envs/r-reticulate
version:        3.6.10 | packaged by conda-forge | (default, Apr 24 2020, 16:44:11)  [GCC 7.3.0]
numpy:          /home/kale/.local/share/r-miniconda/envs/r-reticulate/lib/python3.6/site-packages/numpy
numpy_version:  1.18.4
```

```
$ /home/kale/.local/share/r-miniconda/envs/r-reticulate/bin/python -m pip freeze
certifi==2020.4.5.1
numpy @ file:///home/conda/feedstock_root/build_artifacts/numpy_1588605080954/work
```

Note that the `numpy` line has ` @ ` rather than `==`.  When `pip_freeze()` attempt to parse this line, it attempts to access the substring after `==` and in doing so generates a "subscript out of bounds" error.

I don't know why exactly the miniconda installed by reticulate doesn't have a "normal" version specifier.  The `file:///home/conda/...` path doesn't actually exist on my machine.  Maybe something recently changed about how numpy is packaged by conda.  Maybe this is somehow related to my operating system (Arch linux).  Maybe it's relevant that the `@` syntax was only added to `pip` in version 19.1, which was released a little over a year ago.  In any case, though, it seems prudent to support this syntax.

# Solution
This PR offers the simplest solution to this problem, which is to allow `==` or `@` to delimit the package name from its version number.  This is really only a half-way solution though, because `pip freeze` can still produce all kinds of output that will not be parsed correctly.  Editable packages are an example that comes immediately to mind, but the [requirement file format](https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format) details many more potential problems.  Furthermore, the "version number" after the `@` sign would not be useful for making version comparisons (although I don't think reticulate does any sophisticated version-checking at the moment). 

A more robust approach might be to run `pip show <pkgname>` for each dependency that might need to be installed, e.g.:
```
$ /home/kale/.local/share/r-miniconda/envs/r-reticulate/bin/python -m pip show numpy
Name: numpy
Version: 1.18.4
Summary: NumPy is the fundamental package for array computing with Python.
Home-page: https://www.numpy.org
Author: Travis E. Oliphant et al.
Author-email: None
License: BSD
Location: /home/kale/.local/share/r-miniconda/envs/r-reticulate/lib/python3.6/site-packages
Requires: 
Required-by: pandas, matplotlib
```
This would produce consistent output no matter how the package is installed.   Alternatively, the return code itself (0 if the package is installed, 1 if not) might be enough, although this doesn't take the version number into account:
```
$ /home/kale/.local/share/r-miniconda/envs/r-reticulate/bin/python -m pip show numpy -qq; echo $?
0
$ /home/kale/.local/share/r-miniconda/envs/r-reticulate/bin/python -m pip show not-installed -qq; echo $?
1
```
The downside to this approach is that it requires an invocation of `pip` for each dependency, which might cause a noticeable lag (since python programs have notoriously slow startup times).  It's also a little outside what I would feel comfortable implementing, since I have almost no experience with R (I'm just trying to make a wrapper for one of my python packages).

Another approach might be to construct a `requirements.txt` file from the dependencies listed in the DESCRIPTION files, then to just call `pip install -r requirements.txt`.  That would let `pip` take care of getting all the right things installed, although again, probably at the expense of greater overhead.