### PR TITLE
Prefer miniconda

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,9 @@
   with `tthread::`, to avoid issues with symbol conflicts during
   compilation. (#773)
   
+- Prefer Miniconda installation over system path's conda when looking
+  for conda. (#790)
+  
 ## reticulate 1.16
 
 - TinyThread now calls `Rf_error()` rather than `std::terminate()`

--- a/R/conda.R
+++ b/R/conda.R
@@ -31,8 +31,9 @@
 #' following locations:
 #' 
 #' 1. The location specified by the `reticulate.conda_binary` \R option;
-#' 2. The program `PATH`;
-#' 3. A set of pre-defined locations where Conda is typically installed.
+#' 2. The `miniconda_path()` location if it exists.
+#' 3. The program `PATH`;
+#' 4. A set of pre-defined locations where Conda is typically installed.
 #'
 #' @export
 conda_list <- function(conda = "auto") {
@@ -350,6 +351,10 @@ find_conda <- function() {
   conda <- getOption("reticulate.conda_binary")
   if (!is.null(conda))
     return(conda)
+  
+  # if miniconda is installed, use it
+  if (miniconda_exists())
+    conda <- miniconda_conda()
   
   # if there is a conda executable on the PATH, use it
   conda <- Sys.which("conda")

--- a/R/conda.R
+++ b/R/conda.R
@@ -31,7 +31,7 @@
 #' following locations:
 #' 
 #' 1. The location specified by the `reticulate.conda_binary` \R option;
-#' 2. The `miniconda_path()` location if it exists.
+#' 2. The [miniconda_path()] location (if it exists);
 #' 3. The program `PATH`;
 #' 4. A set of pre-defined locations where Conda is typically installed.
 #'

--- a/R/conda.R
+++ b/R/conda.R
@@ -354,7 +354,7 @@ find_conda <- function() {
   
   # if miniconda is installed, use it
   if (miniconda_exists())
-    conda <- miniconda_conda()
+    return(miniconda_conda())
   
   # if there is a conda executable on the PATH, use it
   conda <- Sys.which("conda")

--- a/man/conda-tools.Rd
+++ b/man/conda-tools.Rd
@@ -90,7 +90,7 @@ Anaconda / Miniconda installation and use that. \code{reticulate} will search th
 following locations:
 \enumerate{
 \item The location specified by the \code{reticulate.conda_binary} \R option;
-\item The \code{miniconda_path()} location if it exists.
+\item The \code{\link[=miniconda_path]{miniconda_path()}} location (if it exists);
 \item The program \code{PATH};
 \item A set of pre-defined locations where Conda is typically installed.
 }

--- a/man/conda-tools.Rd
+++ b/man/conda-tools.Rd
@@ -90,6 +90,7 @@ Anaconda / Miniconda installation and use that. \code{reticulate} will search th
 following locations:
 \enumerate{
 \item The location specified by the \code{reticulate.conda_binary} \R option;
+\item The \code{miniconda_path()} location if it exists.
 \item The program \code{PATH};
 \item A set of pre-defined locations where Conda is typically installed.
 }


### PR DESCRIPTION
This PR makes miniconda prefered (if installed) over system conda installation. Fix #786 