### PR TITLE
Check for a conda installation before prompting for miniconda

### DIFF
--- a/R/conda.R
+++ b/R/conda.R
@@ -515,7 +515,7 @@ conda_list_packages <- function(envname = NULL, conda = "auto", no_pip = TRUE) {
 }
 
 conda_installed <- function() {
-  condabin <- tryCatch(conda_binary(conda = conda), error = identity)
+  condabin <- tryCatch(conda_binary(), error = identity)
   if (inherits(condabin, "error"))
     return(FALSE)
   else

--- a/R/conda.R
+++ b/R/conda.R
@@ -66,11 +66,22 @@ conda_list <- function(conda = "auto") {
   # strip out anaconda cloud prefix (not valid json)
   if (length(conda_envs) > 0 && grepl("Anaconda Cloud", conda_envs[[1]], fixed = TRUE))
     conda_envs <- conda_envs[-1]
+  
+  # parse conda info
+  info <- fromJSON(conda_envs)
 
   # convert to json
-  conda_envs <- fromJSON(conda_envs)$envs
+  conda_envs <- info$envs
   conda_envs <- Filter(file.exists, conda_envs)
-
+  
+  # normalize and remove duplicates (seems necessary on Windows as Anaconda
+  # may report both short-path and long-path versions of the same environment)
+  conda_envs <- unique(normalizePath(conda_envs))
+  
+  # remove root conda environment as it shouldnnt count as environment and
+  # it is not correct to install packages into it.
+  conda_envs <- conda_envs[!conda_envs == normalizePath(info$root_prefix)]
+  
   # return an empty data.frame when no envs are found
   if (length(conda_envs) == 0L) {
     return(data.frame(
@@ -79,10 +90,6 @@ conda_list <- function(conda = "auto") {
       stringsAsFactors = FALSE)
     )
   }
-
-  # normalize and remove duplicates (seems necessary on Windows as Anaconda
-  # may report both short-path and long-path versions of the same environment)
-  conda_envs <- unique(normalizePath(conda_envs))
 
   # build data frame
   name <- character()

--- a/R/conda.R
+++ b/R/conda.R
@@ -513,3 +513,11 @@ conda_list_packages <- function(envname = NULL, conda = "auto", no_pip = TRUE) {
   )
   
 }
+
+conda_installed <- function() {
+  condabin <- tryCatch(conda_binary(conda = conda), error = identity)
+  if (inherits(condabin, "error"))
+    return(FALSE)
+  else
+    return(TRUE)
+}

--- a/R/config.R
+++ b/R/config.R
@@ -152,6 +152,14 @@ py_discover_config <- function(required_module = NULL, use_environment = NULL) {
     python_versions <- c(python_versions, module_python_envs$python)
   }
   
+  # the user might have a conda installation but no environment.
+  # in this case we should create the r-reticulate env
+  # we use the same python version as we would install with miniconda.
+  if (length(conda_binary()) > 0 && nrow(conda_list()) == 0) {
+    python <- miniconda_python_package()
+    conda_create("r-reticulate", packages = c(python, "numpy"), conda = conda_binary())
+  }
+  
   # look for conda environments
   python_condaenvs <- python_conda_versions()
   r_reticulate_python_envs <- python_condaenvs[python_condaenvs$name == "r-reticulate", ]

--- a/R/config.R
+++ b/R/config.R
@@ -172,7 +172,6 @@ py_discover_config <- function(required_module = NULL, use_environment = NULL) {
     module_python_envs <- python_condaenvs[python_condaenvs$name %in% envnames, ]
     python_versions <- c(python_versions, module_python_envs$python)
   }
-
   
   # look for r-reticulate environment in miniconda
   # if the environment doesn't exist, and the user hasn't requested a separate
@@ -341,6 +340,10 @@ python_conda_versions <- function() {
                   "/miniconda2/envs",
                   "/miniconda3/envs",
                   "/miniconda4/envs",
+                  "~/opt/anaconda/envs",
+                  "~/opt/anaconda2/envs",
+                  "~/opt/anaconda3/envs",
+                  "~/opt/anaconda4/envs",
                   "~")
     
     python_env_binaries <- python_environments(env_dirs)

--- a/R/config.R
+++ b/R/config.R
@@ -152,14 +152,6 @@ py_discover_config <- function(required_module = NULL, use_environment = NULL) {
     python_versions <- c(python_versions, module_python_envs$python)
   }
   
-  # the user might have a conda installation but no environment.
-  # in this case we should create the r-reticulate env
-  # we use the same python version as we would install with miniconda.
-  if (conda_installed() && nrow(conda_list()) == 0) {
-    python <- miniconda_python_package()
-    conda_create("r-reticulate", packages = c(python, "numpy"), conda = conda_binary())
-  }
-  
   # look for conda environments
   python_condaenvs <- python_conda_versions()
   r_reticulate_python_envs <- python_condaenvs[python_condaenvs$name == "r-reticulate", ]
@@ -206,6 +198,20 @@ py_discover_config <- function(required_module = NULL, use_environment = NULL) {
     config <- python_config(miniconda_python, NULL, miniconda_python)
     return(config)
     
+  }
+  
+  # the user might have opted out for miniconda but could still have a 
+  # conda isntallation. In this case, we should the r-reticulate env
+  # we use the same python version as we would install with miniconda.
+  if (conda_installed() && nrow(conda_list()) == 0) {
+    python <- miniconda_python_package()
+    conda_create("r-reticulate", packages = c(python, "numpy"), conda = conda_binary())
+    
+    # gather python conda versions one again as they might exist now that
+    # we created the environment
+    python_condaenvs <- python_conda_versions()
+    r_reticulate_python_envs <- python_condaenvs[python_condaenvs$name == "r-reticulate", ]
+    python_versions <- c(python_versions, r_reticulate_python_envs$python)
   }
   
   # join virtualenv, condaenv environments together

--- a/R/config.R
+++ b/R/config.R
@@ -155,7 +155,7 @@ py_discover_config <- function(required_module = NULL, use_environment = NULL) {
   # the user might have a conda installation but no environment.
   # in this case we should create the r-reticulate env
   # we use the same python version as we would install with miniconda.
-  if (length(conda_binary()) > 0 && nrow(conda_list()) == 0) {
+  if (conda_installed() && nrow(conda_list()) == 0) {
     python <- miniconda_python_package()
     conda_create("r-reticulate", packages = c(python, "numpy"), conda = conda_binary())
   }

--- a/R/python-tools.R
+++ b/R/python-tools.R
@@ -51,6 +51,9 @@ python_info <- function(python) {
       file.exists(file.path(path, "Scripts/activate")) ||
       file.exists(file.path(path, "Scripts/activate.bat"))
 
+    if (is_windows())
+      virtualenv <- virtualenv && (!file.exists("condabin/conda"))
+    
     if (virtualenv) {
       suffix <- if (is_windows()) "Scripts/python.exe" else "bin/python"
       python <- file.path(path, suffix)


### PR DESCRIPTION
This PR adds 3 fixes:

1. On Windows it won't identify the root conda path as a virtualenv by checking if  `!file.exists("condabin/conda")`.

2. It ignores the root conda environment as a possible environment in `conda_list` by checking if it's path is equal to the `root_prefix` returned by `conda info`. This environment is not correctly writable.

3. If users opts out for miniconda, they can still have a fresh conda installation that don't have any environment. (conda is installed, but no environment is available). In this case we create an `r-reticulate` environment.

It fixes #789 