### PR TITLE
set PYTHONPATH before initializing Python

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 
 ## reticulate 1.17 (UNRELEASED)
 
+- `reticulate` now sets `PYTHONPATH` before loading Python, to ensure modules
+  are looked up in the same locations where a regular Python interpreter would
+  find them on load. This should fix issues where `reticulate` was unable to
+  bind to a Python virtual environment in some cases.
+  
 - `reticulate::virtualenv_create()` gains the `packages` argument, allowing one
   to choose a set of packages to be installed (via `pip install`) after the
   virtual environment has been created.

--- a/R/config.R
+++ b/R/config.R
@@ -540,7 +540,7 @@ python_config <- function(python, required_module, python_versions, forced = NUL
       pattern <- sprintf("^libpython%sd?m?%s", version, ext)
       candidates <- list.files(src, pattern = pattern, full.names = TRUE)
       if (length(candidates)) {
-        libpython <- candidate
+        libpython <- candidates
         break
       }
       

--- a/R/package.R
+++ b/R/package.R
@@ -109,18 +109,34 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
   curr_session_env <- Sys.getenv("R_SESSION_INITIALIZED", unset = NA)
   Sys.setenv(R_SESSION_INITIALIZED = sprintf('PID=%s:NAME="reticulate"', Sys.getpid()))
 
-  # initialize python
+  # munge PATH for python (needed so libraries can be found in some cases)
   oldpath <- python_munge_path(config$python)
-  tryCatch(
-    {
-      py_initialize(config$python,
-                    config$libpython,
-                    config$pythonhome,
-                    config$virtualenv_activate,
-                    config$version >= "3.0",
-                    interactive(),
-                    numpy_load_error)
+  
+  # initialize python
+  tryCatch({
+    
+    # set PYTHONPATH (required to load virtual environments in some cases?)
+    oldpythonpath <- Sys.getenv("PYTHONPATH")
+    newpythonpath <- paste(
+      config$pythonpath,
+      system.file("python", package = "reticulate"),
+      sep = .Platform$path.sep
+    )
+    
+    Sys.setenv(PYTHONPATH = newpythonpath)
+    on.exit(Sys.setenv(PYTHONPATH = oldpythonpath), add = TRUE)
+    
+    # initialize Python
+    py_initialize(config$python,
+                  config$libpython,
+                  config$pythonhome,
+                  config$virtualenv_activate,
+                  config$version >= "3.0",
+                  interactive(),
+                  numpy_load_error)
+    
     },
+    
     error = function(e) {
       Sys.setenv(PATH = oldpath)
       if (is.na(curr_session_env)) {
@@ -130,15 +146,11 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
       }
       stop(e)
     }
+    
   )
 
   # set available flag indicating we have py bindings
   config$available <- TRUE
-
-  # add our python scripts to the search path
-  py_run_string_impl(paste0("import sys; sys.path.append('",
-                       system.file("python", package = "reticulate") ,
-                       "')"))
 
   # ensure modules can be imported from the current working directory
   py_run_string_impl("import sys; sys.path.insert(0, '')")

--- a/R/package.R
+++ b/R/package.R
@@ -117,10 +117,13 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
     
     # set PYTHONPATH (required to load virtual environments in some cases?)
     oldpythonpath <- Sys.getenv("PYTHONPATH")
-    newpythonpath <- paste(
-      config$pythonpath,
-      system.file("python", package = "reticulate"),
-      sep = .Platform$path.sep
+    newpythonpath <- Sys.getenv(
+      "RETICULATE_PYTHONPATH",
+      unset = paste(
+        config$pythonpath,
+        system.file("python", package = "reticulate"),
+        sep = .Platform$path.sep
+      )
     )
     
     Sys.setenv(PYTHONPATH = newpythonpath)

--- a/R/virtualenv.R
+++ b/R/virtualenv.R
@@ -267,7 +267,7 @@ virtualenv_default_python <- function(python = NULL) {
 
   # if the user has supplied a verison of python already, use it
   if (!is.null(python))
-    return(python)
+    return(path.expand(python))
 
   # check for some pre-defined Python sources (prefer Python 3)
   pythons <- c(

--- a/inst/config/config.py
+++ b/inst/config/config.py
@@ -1,7 +1,8 @@
 
-import sys
-import os
 import platform
+import sys
+import sysconfig
+import os
 
 # The 'imp' module is deprecated since Python 3.4, and the use of
 # 'importlib' is recommended instead.
@@ -21,35 +22,40 @@ else:
     origin = spec.origin
     return origin[:origin.rfind('/')]
 
-sys.stdout.write('Version: ' + str(sys.version).replace('\n', ' '))
-sys.stdout.write('\nVersionNumber: ' + str(sys.version_info[0]) + '.' + str(sys.version_info[1]))
+# Get appropriate path-entry separator for platform
+pathsep = ";" if os.name == "nt" else ":"
 
-try:
-  import sysconfig
-  if not platform.system() == 'Windows':
-    sys.stdout.write('\nLIBPL: ' + sysconfig.get_config_vars('LIBPL')[0])
-    sys.stdout.write('\nLIBDIR: ' + sysconfig.get_config_vars('LIBDIR')[0])
-  sys.stdout.write('\nPREFIX: ' + sysconfig.get_config_vars('prefix')[0])
-  sys.stdout.write('\nEXEC_PREFIX: ' + sysconfig.get_config_vars('exec_prefix')[0])
-except Exception:
-  pass
+# Read default configuration values
+config = {
+  "Architecture"     : platform.architecture()[0],
+  "Version"          : str(sys.version).replace("\n", " "),
+  "VersionNumber"    : str(sys.version_info[0]) + "." + str(sys.version_info[1]),
+  "Prefix"           : getattr(sys, "prefix", ""),
+  "ExecPrefix"       : getattr(sys, "exec_prefix", ""),
+  "BaseExecPrefix"   : getattr(sys, "base_exec_prefix", ""),
+  "PythonPath"       : pathsep.join(sys.path[1:]),
+  "LIBPL"            : sysconfig.get_config_var("LIBPL"),
+  "LIBDIR"           : sysconfig.get_config_var("LIBDIR"),
+}
 
-sys.stdout.write("\nArchitecture: "  + platform.architecture()[0])
-
+# Read numpy configuration (if available)
 try:
   import numpy
-  sys.stdout.write('\nNumpyPath: ' + str(numpy.__path__[0]))
-  sys.stdout.write('\nNumpyVersion: ' + str(numpy.__version__))
-except Exception:
+  config["NumpyPath"]    = str(numpy.__path__[0])
+  config["NumpyVersion"] = str(numpy.__version__)
+except:
   pass
 
+# Read required module information (if requested)
+try:
+  required_module = os.environ["RETICULATE_REQUIRED_MODULE"]
+  if required_module is not None and len(required_module) > 0:
+    config["RequiredModule"] = required_module
+    config["RequiredModulePath"] = module_path(required_module)
+except:
+  pass
 
-if "RETICULATE_REQUIRED_MODULE" in os.environ:
-  required_module = os.environ.get("RETICULATE_REQUIRED_MODULE")
-  try:
-    sys.stdout.write('\nRequiredModule: ' + required_module)
-    sys.stdout.write('\nRequiredModulePath: ' + str(module_path(required_module)))
-  except Exception:
-    pass
-
-
+# Write configuration to stdout
+lines = [str(key) + ": " + str(val) for (key, val) in config.items()]
+text = "\n".join(lines)
+sys.stdout.write(text)


### PR DESCRIPTION
This PR fixes a couple issues:

1. In some cases, virtual environments are created only with a copy of the Python interpreter, not the Python shared library. In such a case, we need to use the copy of Python that was used to create the virtual environment, and bind to that shared library instead.

2. In some cases, `reticulate` would fail to initialize Python as certain system modules could not be found. See e.g. https://stackoverflow.com/questions/5694706/py-initialize-fails-unable-to-load-the-file-system-codec. The solution here is to set `PYTHONPATH` based on what the interpreter would use as `sys.path`, so Python can resolve these system modules properly.

