### PR TITLE
use 'importhook' module for robust module load hooks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,9 @@ Authors@R: c(
   person("Ryan", "Hafen", role = c("ctb", "cph"),
          email = "rhafen@gmail.com"),
   person("Marcus", "Geelnard", role = c("ctb", "cph"),
-         comment = "TinyThread library, http://tinythreadpp.bitsnbites.eu/")
+         comment = "TinyThread library, http://tinythreadpp.bitsnbites.eu/"),
+  person("Brett", "Langdon", role = c("ctb", "cph"),
+         comment = "Author of importhook Python module, https://pypi.org/project/importhook/")
   )
 Description: Interface to 'Python' modules, classes, and functions. When calling
     into 'Python', R data types are automatically converted to their equivalent 'Python'

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,8 @@
 
 - `reticulate` now uses the `importhook` module to hook loaded modules. This
   should allow `reticulate` to more properly detect when certain Python modules
-  are loaded, and take action in response to their load.
+  are loaded, and take action in response to their load. Note that this feature
+  is only supported with Python 3.3 or newer.
 
 - `reticulate::import_from_path()` now accepts the `delay_load` parameter,
   allowing modules which should be loaded from a pre-specified path

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 
 ## reticulate 1.17 (UNRELEASED)
 
+- `reticulate` now uses the `importhook` module to hook loaded modules. This
+  should allow `reticulate` to more properly detect when certain Python modules
+  are loaded, and take action in response to their load.
+
 - `reticulate::import_from_path()` now accepts the `delay_load` parameter,
   allowing modules which should be loaded from a pre-specified path
   to be lazy-loaded.

--- a/R/import.R
+++ b/R/import.R
@@ -105,28 +105,14 @@ import <- function(module, as = NULL, convert = TRUE, delay_load = FALSE) {
   
   # normal case (load immediately)
   if (!delay_load || is_python_initialized()) {
+    
     # ensure that python is initialized (pass top level module as
     # a hint as to which version of python to choose)
     ensure_python_initialized(required_module = module)
     
     # import the module
-    hookName <- paste("reticulate", module, "load", sep = "::")
-    imported <- py_module_import(module, convert = convert)
-    
-    # retrieve load hooks
-    hooks <- getHook(hookName)
-    
-    # remove hooks (we only want to run on first import, and
-    # we need to do this before running the hooks as the load
-    # hooks may want to re-import the module)
-    setHook(hookName, list(), "replace")
-    
-    # run load hooks
-    for (hook in hooks)
-      tryCatch(hook(imported), error = warning)
-    
-    # return imported module
-    imported
+    py_module_import(module, convert = convert)
+
   }
   
   # delay load case (wait until first access)

--- a/inst/python/importhook/LICENSE
+++ b/inst/python/importhook/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Brett Langdon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/inst/python/importhook/__init__.py
+++ b/inst/python/importhook/__init__.py
@@ -1,0 +1,165 @@
+"""
+importhook
+==========
+
+Python module for registering hooks to call when certain modules are imported.
+
+.. code:: python
+
+    import importhook
+
+    # Configure a function to call when `socket` is imported
+    @importhook.on_import('socket')
+    def socket_import(socket):
+        print('Socket module imported')
+
+    # Import the `socket` module
+    import socket
+"""
+import functools
+import importlib
+import sys
+import types
+
+from .logger import logger
+from .meta_paths import HookMetaPaths
+from .registry import registry
+from .utils import get_module_name
+
+__all__ = [
+    'ANY_MODULE',
+    'copy_module',
+    'get_module_name',
+    'logger',
+    'on_import',
+    'registry',
+    'reload_module',
+    'reset_module',
+]
+
+ANY_MODULE = None
+
+# Wrap existing (and future) system meta path finders
+sys.meta_path = HookMetaPaths(sys.meta_path[:])
+
+
+def on_import(module_name, func=None):
+    """
+    Helper function used to register a hook function for a given module
+
+    .. code:: python
+
+        import importhook
+
+        @importhook.on_import('socket')
+        def on_socket_import(socket):
+            print('socket imported')
+
+
+        @importhook.on_import(importhook.ANY_MODULE)
+        def on_any_import(module):
+            print(f'{module.__spec__.name} imported')
+
+
+        def on_httplib_import(httplib):
+            print('httplib imported')
+
+
+        importhook.on_import('httplib', on_httplib_import)
+    """
+    if func is None:
+        @functools.wraps(func)
+        def decorator(func):
+            registry[module_name] = func
+            return func
+        return decorator
+    else:
+        registry[module_name] = func
+
+
+def reset_module(module_name):
+    """
+    Helper function to reset a copied module.
+
+    .. code:: python
+
+        import socket
+        import importhook
+
+        # Copy `socket` module
+        socket = importhook.copy_module(socket)
+
+        # Reset copied `socket` module back to it's original version
+        socket = importhook.reset_module(socket)
+    """
+    if not isinstance(module_name, str):
+        module_name = get_module_name(module_name)
+
+    module = sys.modules.get(module_name)
+    if not module:
+        return None
+
+    if not hasattr(module, '__original_module__'):
+        return module
+
+    sys.modules[module_name] = module.__original_module__
+    return module.__original_module__
+
+
+def copy_module(module, copy_attributes=True, copy_spec=True):
+    """
+    Helper function for copying a python module
+
+    .. code:: python
+
+        import importhook
+
+        @importhook.on_import('socket')
+        def on_socket_import(socket):
+            new_socket = importhook.copy_module(socket)
+            setattr(new_socket, 'get_hostname', lambda: 'hostname')
+            return new_socket
+    """
+    name = get_module_name(module)
+    new_mod = types.ModuleType(name)
+    setattr(new_mod, '__original_module__', module)
+    setattr(new_mod, '__reset_module__', lambda: reset_module(name))
+
+    # Copy all module attributes
+    if copy_attributes:
+        for attr, value in module.__dict__.items():
+            setattr(new_mod, attr, value)
+
+    # Make a copy of the modules spec if one is present
+    if copy_spec and getattr(new_mod, '__spec__', None):
+        spec = type(new_mod.__spec__)(name=name, loader=new_mod.__spec__.loader)
+        for attr, value in new_mod.__spec__.__dict__.items():
+            if attr not in ('name', 'loader'):
+                setattr(spec, attr, value)
+        new_mod.__spec__ = spec
+    return new_mod
+
+
+def reload_module(module_name):
+    """
+    Helper function to reload the specified module
+
+    .. code:: python
+
+        import socket
+        import importhook
+
+        # Reload the `socket` module by passing in module
+        socket = importhook.reload_module(socket)
+
+        # Reload the `socket` module by passing in the name
+        socket = importhook.reload_module('socket')
+    """
+    if not isinstance(module_name, str):
+        module_name = get_module_name(module_name)
+
+    module = sys.modules.get(module_name)
+    if not module:
+        return None
+
+    return importlib.reload(module)

--- a/inst/python/importhook/finder.py
+++ b/inst/python/importhook/finder.py
@@ -1,0 +1,53 @@
+import functools
+
+from .loader import HookLoader
+from .logger import logger
+
+
+def hook_finder(finder):
+    """
+    Helper function to create a new "hooked" subclass of the provided finder class
+
+    This function replaces the `Finder.find_spec` function to ensure that any ModuleSpecs will
+    use an `importmod.HookLoader`
+    """
+    # If this finder has already been 'hooked', then return as-is
+    if hasattr(finder, '__hooked__'):
+        return finder
+
+    # Determine if we were given an instance or a class
+    if isinstance(finder, type):
+        finder_cls = finder
+    else:
+        finder_cls = finder.__class__
+
+    # Determine the class name of the finder
+    finder_name = finder_cls.__name__
+
+    def wrap_find_spec(find_spec):
+        @functools.wraps(find_spec)
+        def wrapper(fullname, path, target=None):
+            logger.debug(f'{finder_name}.find_spec(fullname={fullname}, path={path}, target={target})')
+            spec = find_spec(fullname, path, target=target)
+            if spec is not None:
+                spec.loader = HookLoader(spec.loader)
+            return spec
+        return wrapper
+
+    def wrap_find_loader(find_loader):
+        @functools.wraps(find_loader)
+        def wrapper(fullname, path):
+            logger.debug(f'{finder_name}.find_loader(fullname={fullname}, path={path})')
+            loader = find_loader(fullname, path)
+            return HookLoader(loader)
+        return wrapper
+
+    # Override the functions we care about
+    if hasattr(finder, 'find_spec'):
+        setattr(finder, 'find_spec', wrap_find_spec(finder.find_spec))
+    if hasattr(finder, 'find_loader'):
+        setattr(finder, 'find_loader', wrap_find_loader(finder.find_loader))
+
+    # Make this finder as being 'hooked'
+    setattr(finder, '__hooked__', True)
+    return finder

--- a/inst/python/importhook/finder.py
+++ b/inst/python/importhook/finder.py
@@ -27,7 +27,7 @@ def hook_finder(finder):
     def wrap_find_spec(find_spec):
         @functools.wraps(find_spec)
         def wrapper(fullname, path, target=None):
-            logger.debug(f'{finder_name}.find_spec(fullname={fullname}, path={path}, target={target})')
+            # logger.debug(f'{finder_name}.find_spec(fullname={fullname}, path={path}, target={target})')
             spec = find_spec(fullname, path, target=target)
             if spec is not None:
                 spec.loader = HookLoader(spec.loader)
@@ -37,7 +37,7 @@ def hook_finder(finder):
     def wrap_find_loader(find_loader):
         @functools.wraps(find_loader)
         def wrapper(fullname, path):
-            logger.debug(f'{finder_name}.find_loader(fullname={fullname}, path={path})')
+            # logger.debug(f'{finder_name}.find_loader(fullname={fullname}, path={path})')
             loader = find_loader(fullname, path)
             return HookLoader(loader)
         return wrapper

--- a/inst/python/importhook/loader.py
+++ b/inst/python/importhook/loader.py
@@ -49,14 +49,14 @@ class HookLoader(Loader):
         raise AttributeError
 
     def create_module(self, *args, **kwargs):
-        logger.debug(f'{self.__class__.__name__}.create_module(*args={args}, **kwargs={kwargs})')
+        # logger.debug(f'{self.__class__.__name__}.create_module(*args={args}, **kwargs={kwargs})')
         if not hasattr(self.loader, 'create_module'):
             return None
 
         return self.loader.create_module(*args, **kwargs)
 
     def find_module(self, name, *args, **kwargs):
-        logger.debug(f'{self.__class__.__name__}.find_module(name={name}, *args={args}, **kwargs={kwargs})')
+        # logger.debug(f'{self.__class__.__name__}.find_module(name={name}, *args={args}, **kwargs={kwargs})')
         if not hasattr(self.loader, 'find_module'):
             return None
 
@@ -67,7 +67,7 @@ class HookLoader(Loader):
         return module
 
     def load_module(self, name, *args, **kwargs):
-        logger.debug(f'{self.__class__.__name__}.load_module(name={name}, *args={args}, **kwargs={kwargs})')
+        # logger.debug(f'{self.__class__.__name__}.load_module(name={name}, *args={args}, **kwargs={kwargs})')
         if not hasattr(self.loader, 'load_module'):
             return None
 
@@ -78,7 +78,7 @@ class HookLoader(Loader):
         return module
 
     def exec_module(self, module, *args, **kwargs):
-        logger.debug(f'{self.__class__.__name__}.exec_module(module={module}, *args={args}, **kwargs={kwargs})')
+        # logger.debug(f'{self.__class__.__name__}.exec_module(module={module}, *args={args}, **kwargs={kwargs})')
         if not hasattr(self.loader, 'exec_module'):
             return None
 

--- a/inst/python/importhook/loader.py
+++ b/inst/python/importhook/loader.py
@@ -1,0 +1,90 @@
+from importlib.abc import Loader
+import sys
+
+from .logger import logger
+from .registry import registry
+from .utils import get_module_name
+
+
+def call_module_hooks(module):
+    name = get_module_name(module)
+
+    # If we have a hook in the registry, then call it now
+    if name in registry:
+        mod = registry[name](module)
+        if mod is not None:
+            module = mod
+
+    # If we have a global hook in the registry, then call it now
+    if None in registry:
+        mod = registry[None](module)
+        if mod is not None:
+            module = mod
+
+    sys.modules[name] = module
+
+
+class HookLoader(Loader):
+    """
+    Custom `importlib.abc.Loader` which ensures we call any registered hooks when a module is loaded.
+    """
+    __slots__ = ['loader']
+
+    def __init__(self, loader):
+        self.loader = loader
+
+    def __getattribute__(self, name):
+        # If they are requesting the "loader" attribute, return it right away
+        loader = super(HookLoader, self).__getattribute__('loader')
+        if name == 'loader':
+            return loader
+
+        # Pass through attributes/methods only if they exist on the underlying loader
+        if hasattr(loader, name):
+            try:
+                return super(HookLoader, self).__getattribute__(name)
+            except AttributeError:
+                return getattr(loader, name)
+
+        raise AttributeError
+
+    def create_module(self, *args, **kwargs):
+        logger.debug(f'{self.__class__.__name__}.create_module(*args={args}, **kwargs={kwargs})')
+        if not hasattr(self.loader, 'create_module'):
+            return None
+
+        return self.loader.create_module(*args, **kwargs)
+
+    def find_module(self, name, *args, **kwargs):
+        logger.debug(f'{self.__class__.__name__}.find_module(name={name}, *args={args}, **kwargs={kwargs})')
+        if not hasattr(self.loader, 'find_module'):
+            return None
+
+        module = self.loader.find_module(name=name, *args, **kwargs)
+        if module is None:
+            return None
+        call_module_hooks(module)
+        return module
+
+    def load_module(self, name, *args, **kwargs):
+        logger.debug(f'{self.__class__.__name__}.load_module(name={name}, *args={args}, **kwargs={kwargs})')
+        if not hasattr(self.loader, 'load_module'):
+            return None
+
+        module = self.loader.load_module(name, *args, **kwargs)
+        if module is None:
+            return None
+        call_module_hooks(module)
+        return module
+
+    def exec_module(self, module, *args, **kwargs):
+        logger.debug(f'{self.__class__.__name__}.exec_module(module={module}, *args={args}, **kwargs={kwargs})')
+        if not hasattr(self.loader, 'exec_module'):
+            return None
+
+        mod = self.loader.exec_module(module, *args, **kwargs)
+        if mod is not None:
+            module = mod
+
+        call_module_hooks(module)
+        return module

--- a/inst/python/importhook/logger.py
+++ b/inst/python/importhook/logger.py
@@ -1,0 +1,4 @@
+import logging
+
+# Logger used by `importmod`
+logger = logging.getLogger(__name__)

--- a/inst/python/importhook/meta_paths.py
+++ b/inst/python/importhook/meta_paths.py
@@ -1,0 +1,15 @@
+from .finder import hook_finder
+
+
+class HookMetaPaths(list):
+    """
+    Custom list that will ensure any items added are wrapped as a "hooked" finder
+
+    This class is made to replace `sys.meta_paths`
+    """
+
+    def __init__(self, finders):
+        super(HookMetaPaths, self).__init__([hook_finder(f) for f in finders])
+
+    def __setitem__(self, key, val):
+        super(HookMetaPaths, self).__setitem__(key, hook_finder(val))

--- a/inst/python/importhook/registry.py
+++ b/inst/python/importhook/registry.py
@@ -1,0 +1,45 @@
+import sys
+
+from .logger import logger
+
+
+class Hooks(set):
+    """Custom set that is used to maintain and call a list of hooks"""
+    def __call__(self, module):
+        for hook in self:
+            logger.debug(f'Calling hook {hook.__module__}:{hook.__name__}({module})')
+            mod = hook(module)
+            # If they modified the module, then use that instead
+            if mod is not None:
+                module = mod
+        return module
+
+
+class HookRegistry(dict):
+    """
+    Class used as the registry for import hooks
+    """
+
+    def __setitem__(self, key, hook):
+        module_name = key or 'ANY_MODULE'
+        logger.debug(f'Registering hook {hook.__module__}:{hook.__name__} for {module_name}')
+
+        # Ensure we have a key for this module and it's value is a `Hooks` set
+        if key not in self:
+            super(HookRegistry, self).__setitem__(key, Hooks())
+
+        # Add our hook to the registry
+        self[key].add(hook)
+
+        # Call hook for a module which has already been loaded
+        if key is not None and key in sys.modules:
+            module = sys.modules[key]
+            logger.debug(f'Calling hook {hook.__module__}:{hook.__name__}({module})')
+
+            module = hook(sys.modules[key])
+            if module is not None:
+                sys.modules[key] = module
+
+
+# Create our global registry
+registry = HookRegistry()

--- a/inst/python/importhook/registry.py
+++ b/inst/python/importhook/registry.py
@@ -7,7 +7,7 @@ class Hooks(set):
     """Custom set that is used to maintain and call a list of hooks"""
     def __call__(self, module):
         for hook in self:
-            logger.debug(f'Calling hook {hook.__module__}:{hook.__name__}({module})')
+            # logger.debug(f'Calling hook {hook.__module__}:{hook.__name__}({module})')
             mod = hook(module)
             # If they modified the module, then use that instead
             if mod is not None:
@@ -22,7 +22,7 @@ class HookRegistry(dict):
 
     def __setitem__(self, key, hook):
         module_name = key or 'ANY_MODULE'
-        logger.debug(f'Registering hook {hook.__module__}:{hook.__name__} for {module_name}')
+        # logger.debug(f'Registering hook {hook.__module__}:{hook.__name__} for {module_name}')
 
         # Ensure we have a key for this module and it's value is a `Hooks` set
         if key not in self:
@@ -34,7 +34,7 @@ class HookRegistry(dict):
         # Call hook for a module which has already been loaded
         if key is not None and key in sys.modules:
             module = sys.modules[key]
-            logger.debug(f'Calling hook {hook.__module__}:{hook.__name__}({module})')
+            # logger.debug(f'Calling hook {hook.__module__}:{hook.__name__}({module})')
 
             module = hook(sys.modules[key])
             if module is not None:

--- a/inst/python/importhook/tests/test_meta_paths.py
+++ b/inst/python/importhook/tests/test_meta_paths.py
@@ -1,0 +1,15 @@
+from importhook import HookMetaPaths
+
+
+class DummyFinder:
+    pass
+
+
+def test_hook_meta_paths_setitem():
+    finder1 = DummyFinder()
+    finder2 = DummyFinder()
+    paths = HookMetaPaths([finder1, finder2])
+    finder3 = DummyFinder()
+    paths[0] = finder3
+    assert paths == [finder3, finder2]
+    assert finder3.__hooked__ is True

--- a/inst/python/importhook/utils.py
+++ b/inst/python/importhook/utils.py
@@ -1,0 +1,5 @@
+def get_module_name(module):
+    """Helper function to get a module's name"""
+    if hasattr(module, '__spec__'):
+        return module.__spec__.name
+    return module.__name__

--- a/inst/python/rpytools/loader.py
+++ b/inst/python/rpytools/loader.py
@@ -1,0 +1,17 @@
+
+_callback = None
+
+def on_import(module):
+  global _callback
+  _callback(module)
+  
+def initialize(callback):
+  
+  # save our default callback
+  global _callback
+  _callback = callback
+  
+  # define our import hook
+  import importhook
+  importhook.on_import(importhook.ANY_MODULE, on_import)
+  

--- a/tests/testthat/helper-init.R
+++ b/tests/testthat/helper-init.R
@@ -4,21 +4,14 @@ test_that <- function(desc, code) {
   # don't run tests on CRAN
   testthat::skip_on_cran()
   
-  # delegate to test_that
+  # delegate to testthat
   call <- sys.call()
   call[[1L]] <- quote(testthat::test_that)
   eval(call, envir = parent.frame())
   
 }
 
-py_tests_initialize <- function() {
-  
-  # prefer Python 3 if available
-  if (is.na(Sys.getenv("RETICULATE_PYTHON", unset = NA))) {
-    python <- Sys.which("python3")
-    if (nzchar(python))
-      use_python(python, required = TRUE)
-  }
+context <- function(label) {
   
   # import some modules used by the tests
   if (py_available(initialize = TRUE)) {
@@ -30,9 +23,24 @@ py_tests_initialize <- function() {
       builtins = import_builtins(convert = FALSE)
     )
     
-    envir <- globalenv()
-    list2env(modules, envir = envir)
+    list2env(modules, envir = parent.frame())
     
+  }
+  
+  # delegate to testthat
+  call <- sys.call()
+  call[[1L]] <- quote(testthat::context)
+  eval(call, envir = parent.frame())
+  
+}
+
+py_tests_initialize <- function() {
+  
+  # prefer Python 3 if available
+  if (is.na(Sys.getenv("RETICULATE_PYTHON", unset = NA))) {
+    python <- Sys.which("python3")
+    if (nzchar(python))
+      use_python(python, required = TRUE)
   }
   
 }

--- a/tests/testthat/helper-init.R
+++ b/tests/testthat/helper-init.R
@@ -13,6 +13,17 @@ test_that <- function(desc, code) {
 
 context <- function(label) {
   
+  # prefer Python 3 if available
+  if (!py_available(initialize = FALSE)) {
+    
+    if (is.na(Sys.getenv("RETICULATE_PYTHON", unset = NA))) {
+      python <- Sys.which("python3")
+      if (nzchar(python))
+        use_python(python, required = TRUE)
+    }
+    
+  }
+  
   # import some modules used by the tests
   if (py_available(initialize = TRUE)) {
     
@@ -31,16 +42,5 @@ context <- function(label) {
   call <- sys.call()
   call[[1L]] <- quote(testthat::context)
   eval(call, envir = parent.frame())
-  
-}
-
-py_tests_initialize <- function() {
-  
-  # prefer Python 3 if available
-  if (is.na(Sys.getenv("RETICULATE_PYTHON", unset = NA))) {
-    python <- Sys.which("python3")
-    if (nzchar(python))
-      use_python(python, required = TRUE)
-  }
   
 }

--- a/tests/testthat/helper-init.R
+++ b/tests/testthat/helper-init.R
@@ -1,4 +1,13 @@
 
+# prefer Python 3 if available
+if (!py_available(initialize = FALSE) &&
+    is.na(Sys.getenv("RETICULATE_PYTHON", unset = NA)))
+{
+  python <- Sys.which("python3")
+  if (nzchar(python))
+    use_python(python, required = TRUE)
+}
+
 test_that <- function(desc, code) {
 
   # don't run tests on CRAN
@@ -12,17 +21,6 @@ test_that <- function(desc, code) {
 }
 
 context <- function(label) {
-  
-  # prefer Python 3 if available
-  if (!py_available(initialize = FALSE)) {
-    
-    if (is.na(Sys.getenv("RETICULATE_PYTHON", unset = NA))) {
-      python <- Sys.which("python3")
-      if (nzchar(python))
-        use_python(python, required = TRUE)
-    }
-    
-  }
   
   # import some modules used by the tests
   if (py_available(initialize = TRUE)) {

--- a/tests/testthat/resources/.gitignore
+++ b/tests/testthat/resources/.gitignore
@@ -1,6 +1,5 @@
 *.md
 *.html
 *.pdf
-
+*_files
 figure/
-example_files/

--- a/tests/testthat/test-aaa.R
+++ b/tests/testthat/test-aaa.R
@@ -1,4 +1,0 @@
-
-context("Setup")
-
-py_tests_initialize()

--- a/tests/testthat/test-python-knitr-engine.R
+++ b/tests/testthat/test-python-knitr-engine.R
@@ -6,7 +6,7 @@ test_that("An R Markdown document can be rendered using reticulate", {
   skip_if_no_python()
   skip_if_not_installed("rmarkdown")
 
-  modules <- c("numpy", "matplotlib")
+  modules <- c("numpy", "matplotlib", "pandas")
   for (module in modules) {
     if (!py_module_available(module)) {
       fmt <- "module '%s' not available; skipping"


### PR DESCRIPTION
This PR fixes an issue where modules imported recursively in response to other modules being loaded would not have R load hooks fired.