### PR TITLE
Fix formals check in `py_iterator()`

### DIFF
--- a/R/generator.R
+++ b/R/generator.R
@@ -65,7 +65,7 @@ py_iterator <- function(fn, completed = NULL) {
   # validation
   if (!is.function(fn))
     stop("fn must be an R function")
-  if (length(formals(fn) != 0))
+  if (length(formals(fn)))
     stop("fn must be an R function with no arguments")
 
   # wrap the function in an error handler

--- a/tests/testthat/test-python-iterators.R
+++ b/tests/testthat/test-python-iterators.R
@@ -92,3 +92,10 @@ test_that("generator functions are always called on the main thread", {
   gen <- py_iterator(sequence_generator(10L))
   expect_equal(test$iterateOnThread(gen), 11L:19L)
 })
+
+test_that("can't supply a function with arguments", {
+  expect_error(
+    py_iterator(function(x) x),
+    "no arguments"
+  )
+})


### PR DESCRIPTION
Fixes a typo in the validation of formals.

```r
py_iterator(function(x) x)
#> Error in formals(fn) != 0 :
#>   comparison (2) is possible only for atomic and list types
```

Becomes

```r
#> Error in reticulate::py_iterator(function(x) x) :
#>   fn must be an R function with no arguments
```