### PR TITLE
Update link to Travis build

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![CRAN\_Status\_Badge](https://www.r-pkg.org/badges/version/reticulate)](https://cran.r-project.org/package=reticulate)
 [![Travis-CI Build
-Status](https://travis-ci.org/rstudio/reticulate.svg?branch=master)](https://travis-ci.org/rstudio/reticulate)
+Status](https://travis-ci.org/rstudio/reticulate.svg?branch=master)](https://travis-ci.com/github/rstudio/reticulate)
 [![Appveyor Build
 Status](https://ci.appveyor.com/api/projects/status/github/rstudio/reticulate?svg=true)](https://ci.appveyor.com/project/rstudio/reticulate)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -349,7 +349,7 @@
 <h2>Dev status</h2>
 <ul class="list-unstyled">
 <li><a href="https://cran.r-project.org/package=reticulate"><img src="https://www.r-pkg.org/badges/version/reticulate" alt="CRAN_Status_Badge"></a></li>
-<li><a href="https://travis-ci.org/rstudio/reticulate"><img src="https://travis-ci.org/rstudio/reticulate.svg?branch=master" alt="Travis-CI Build Status"></a></li>
+<li><a href="https://travis-ci.com/github/rstudio/reticulate"><img src="https://travis-ci.org/rstudio/reticulate.svg?branch=master" alt="Travis-CI Build Status"></a></li>
 <li><a href="https://ci.appveyor.com/project/rstudio/reticulate"><img src="https://ci.appveyor.com/api/projects/status/github/rstudio/reticulate?svg=true" alt="Appveyor Build Status"></a></li>
 </ul>
 </div>

--- a/index.Rmd
+++ b/index.Rmd
@@ -10,7 +10,7 @@ knitr::opts_chunk$set(echo = TRUE)
 # R Interface to Python
 
 [![CRAN\_Status\_Badge](https://www.r-pkg.org/badges/version/reticulate)](https://cran.r-project.org/package=reticulate)
-[![Travis-CI Build Status](https://travis-ci.org/rstudio/reticulate.svg?branch=master)](https://travis-ci.org/rstudio/reticulate) [![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/github/rstudio/reticulate?svg=true)](https://ci.appveyor.com/project/rstudio/reticulate)  
+[![Travis-CI Build Status](https://travis-ci.org/rstudio/reticulate.svg?branch=master)](https://travis-ci.com/github/rstudio/reticulate) [![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/github/rstudio/reticulate?svg=true)](https://ci.appveyor.com/project/rstudio/reticulate)  
 
 The **reticulate** package provides a comprehensive set of tools for interoperability between Python and R. The package includes facilities for:
 


### PR DESCRIPTION
It has been moved to travis-ci.com instead of travis-ci.org.