### PR TITLE
insert path to rpytools for embedded R

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -33,7 +33,7 @@ is_python_initialized <- function() {
 ensure_python_initialized <- function(required_module = NULL) {
 
   if (!is_python_initialized()) {
-    
+
     # give delay load modules priority
     use_environment <- NULL
     if (!is.null(.globals$delay_load_module)) {
@@ -48,16 +48,16 @@ ensure_python_initialized <- function(required_module = NULL) {
 
     # remap output streams to R output handlers
     remap_output_streams()
-    
+
     # generate 'R' helper object
     py_inject_r()
-    
+
     # inject hooks
     py_inject_hooks()
-    
+
     # install required packages
     configure_environment()
-    
+
     # notify front-end (if any) that Python has been initialized
     callback <- getOption("reticulate.initialized")
     if (is.function(callback))
@@ -94,16 +94,16 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
 
   # check numpy version and provide a load error message if we don't satisfy it
   numpy_load_error <- tryCatch(
-    
+
     expr = {
       if (is.null(config$numpy) || config$numpy$version < "1.6")
         "installation of Numpy >= 1.6 not found"
       else
         ""
     },
-    
+
     error = function(e) "<unknown>"
-    
+
   )
 
   # if we're a virtual environment then set VIRTUAL_ENV (need to
@@ -115,7 +115,7 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
   # set R_SESSION_INITIALIZED flag (used by rpy2)
   curr_session_env <- Sys.getenv("R_SESSION_INITIALIZED", unset = NA)
   Sys.setenv(R_SESSION_INITIALIZED = sprintf('PID=%s:NAME="reticulate"', Sys.getpid()))
-  
+
   # prefer utf-8 encoding on Windows in RStudio
   if (is_rstudio()) {
     encoding <- Sys.getenv("PYTHONIOENCODING", unset = NA)
@@ -125,10 +125,10 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
 
   # munge PATH for python (needed so libraries can be found in some cases)
   oldpath <- python_munge_path(config$python)
-  
+
   # initialize python
   tryCatch({
-    
+
     # set PYTHONPATH (required to load virtual environments in some cases?)
     oldpythonpath <- Sys.getenv("PYTHONPATH")
     newpythonpath <- Sys.getenv(
@@ -139,13 +139,13 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
         sep = .Platform$path.sep
       )
     )
- 
+
     local({
-      
+
       # set PYTHONPATH while we initialize
       Sys.setenv(PYTHONPATH = newpythonpath)
       on.exit(Sys.setenv(PYTHONPATH = oldpythonpath), add = TRUE)
-      
+
       # initialize Python
       py_initialize(config$python,
                     config$libpython,
@@ -154,11 +154,11 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
                     config$version >= "3.0",
                     interactive(),
                     numpy_load_error)
-      
+
     })
-    
+
     },
-    
+
     error = function(e) {
       Sys.setenv(PATH = oldpath)
       if (is.na(curr_session_env)) {
@@ -168,7 +168,7 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
       }
       stop(e)
     }
-    
+
   )
 
   # set available flag indicating we have py bindings
@@ -176,14 +176,14 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
 
   # ensure modules can be imported from the current working directory
   py_run_string_impl("import sys; sys.path.insert(0, '')")
-  
+
   # register interrupt handler
   initialize_interrupt_handler()
-  
+
   # if this is a conda installation, set QT_QPA_PLATFORM_PLUGIN_PATH
   # https://github.com/rstudio/reticulate/issues/586
   py_set_qt_qpa_platform_plugin_path(config)
-  
+
   # notify the user if the loaded version of Python isn't the same
   # as the requested version of python
   local({
@@ -217,67 +217,67 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
     }
 
   })
-  
+
   # return config
   config
 }
 
 check_forbidden_initialization <- function() {
-  
+
   if (is_python_initialized())
     return(FALSE)
-  
+
   override <- getOption(
     "reticulate.allow.package.initialization",
     default = FALSE
   )
-  
+
   if (identical(override, TRUE))
     return(FALSE)
-  
+
   calls <- sys.calls()
   frames <- sys.frames()
-  
+
   for (i in seq_along(calls)) {
-  
+
     call <- calls[[i]]
     frame <- frames[[i]]
     if (!identical(call[[1]], as.name("runHook")))
       next
-    
+
     bad <-
       identical(call[[2]], ".onLoad") ||
       identical(call[[2]], ".onAttach")
-    
+
     if (!bad)
       next
-    
+
     pkgname <- tryCatch(
         get("pkgname", envir = frame),
         error = function(e) "<unknown>"
       )
-      
+
     fmt <- paste(
       "package '%s' attempted to initialize Python in %s().",
       "Packages should not initialize Python themselves; rather, Python should",
       "be loaded on-demand as requested by the user of the package. Please see",
       "vignette(\"python_dependencies\", package = \"reticulate\") for more details."
     )
-    
+
     msg <- sprintf(fmt, pkgname, call[[2]])
     warning(msg)
-    
+
   }
-  
+
 }
 
 check_forbidden_install <- function(label) {
-  
+
   # escape hatch for users who know, or claim to know, what they're doing
   envvar <- Sys.getenv("_RETICULATE_I_KNOW_WHAT_IM_DOING_", unset = NA)
   if (identical(tolower(envvar), "true"))
     return(FALSE)
-  
+
   # if this is being called as part of R CMD check, then warn
   # (error in future versions)
   if (is_r_cmd_check()) {
@@ -286,47 +286,46 @@ check_forbidden_install <- function(label) {
     warning(msg)
     return(TRUE)
   }
-  
+
   FALSE
-  
+
 }
 
 py_set_qt_qpa_platform_plugin_path <- function(config) {
-  
+
   # only done on Windows since that's where we see all the issues
   if (!is_windows())
     return(FALSE)
-  
+
   # get python homes (note that multiple homes may be specified)
   homes <- strsplit(config$pythonhome, ";", fixed = TRUE)[[1]]
   for (home in homes) {
 
-    # build some candidate paths to the plugins directory    
+    # build some candidate paths to the plugins directory
     candidates <- c(
       file.path(home, "Library/plugins/platforms"),
       file.path(home, "../../Library/plugins/platforms")
     )
-    
+
     # check and see if any of these exist
     paths <- candidates[file.exists(candidates)]
     if (length(paths) == 0)
       next
-    
+
     # we found a path; use it
     path <- normalizePath(paths[[1]], winslash = "/", mustWork = TRUE)
     path <- gsub("/", "\\\\", path, fixed = TRUE)
-    
+
     fmt <- "import os; os.environ['QT_QPA_PLATFORM_PLUGIN_PATH'] = '%s'"
     cmd <- sprintf(fmt, path)
     py_run_string_impl(cmd)
-    
+
     # return TRUE to indicate success
     return(TRUE)
-    
+
   }
-  
+
   # failed to find folder; nothing to do
   FALSE
-  
-}
 
+}

--- a/R/package.R
+++ b/R/package.R
@@ -81,6 +81,9 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
   # find configuration
   config <- py_discover_config(required_module, use_environment)
 
+  # check if R is embedded in an python environment
+  py_embedded <- !is.null(main_process_python_info())
+
   # check for basic python prerequsities
   if (is.null(config)) {
     python_not_found("Installation of Python not found, Python bindings not loaded.")
@@ -173,6 +176,13 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
 
   # set available flag indicating we have py bindings
   config$available <- TRUE
+
+  if (py_embedded) {
+    # we need to insert path to rpytools directly for embedded R
+    py_run_string_impl(paste0("import sys; sys.path.append('",
+                         system.file("python", package = "reticulate"),
+                         "')"))
+  }
 
   # ensure modules can be imported from the current working directory
   py_run_string_impl("import sys; sys.path.insert(0, '')")


### PR DESCRIPTION
it is needed for R embedded in python because the `PYTHONPATH` trick no longer works.

related #208