### PR TITLE
Use knitr::engine_output() instead of knitr:::wrap()

### DIFF
--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -453,11 +453,7 @@ eng_python_synchronize_before <- function() {
 eng_python_synchronize_after <- function() {}
 
 eng_python_wrap <- function(outputs, options) {
-  # TODO: development version of knitr supplies new 'engine_output()'
-  # interface -- use that when it's on CRAN
-  # https://github.com/yihui/knitr/commit/71bfd8796d485ed7bb9db0920acdf02464b3df9a
-  wrap <- yoink("knitr", "wrap")
-  wrap(outputs, options)
+  knitr::engine_output(options, out = outputs)
 }
 
 eng_python_validate_options <- function(options) {


### PR DESCRIPTION
Fix #993: `engine_output()` has been exported in knitr a couple of years ago, so no need to use the internal `knitr:::wrap()`.