### PR TITLE
miniconda installer url uses x86_64 and not x86-64

### DIFF
--- a/R/miniconda.R
+++ b/R/miniconda.R
@@ -121,6 +121,9 @@ miniconda_installer_arch <- function() {
   info <- as.list(Sys.info())
   if (info$machine == "i386")
     return("x86")
+  # miniconda url use x86_64 not x86-64 for Windows
+  if (info$machine == "x86-64")
+    return("x86_64")
   
   # otherwise, use arch as-is
   info$machine


### PR DESCRIPTION
This follows a regression after https://github.com/rstudio/reticulate/commit/9cf3178d344c6ed61e9648127038c020f1228a60

Miniconda urls are not using `-` but `_`: https://repo.anaconda.com/miniconda/

It was first reported by @topepo from https://github.com/tidymodels/parsnip/runs/2726912897?check_suite_focus=true#step:9:41

I can reproduce on Windows with last dev version 
````r
> install_miniconda(force = TRUE)
* Downloading "https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86-64.exe" ...
trying URL 'https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86-64.exe'
Error in download.file(url, destfile = installer, mode = "wb") : 
  cannot open URL 'https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86-64.exe'
In addition: Warning message:
In download.file(url, destfile = installer, mode = "wb") :
  cannot open URL 'https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86-64.exe': HTTP status was '404 Not Found'
Run `rlang::last_error()` to see where the error occurred.
````

I did not add a NEWS bullet as it was a regression from a really recent commit. 