### PR TITLE
restore LD_LIBRARY_PATH on linux

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -577,7 +577,7 @@ python_config <- function(python,
 
   # read output as dcf
   config_connection <- textConnection(config)
-  on.exit(close(config_connection))
+  on.exit(close(config_connection), add = TRUE)
   config <- read.dcf(config_connection, all = TRUE)
 
   # get the full textual version and the numeric version, check for anaconda


### PR DESCRIPTION
added on.exit(add=TRUE) so that this call can coexist with the
other on.exit calls in the same frame.