### PR TITLE
Properly resolve dlls on windows so that pip doesn't complain about S…

### DIFF
--- a/R/conda.R
+++ b/R/conda.R
@@ -400,6 +400,32 @@ conda_python <- function(envname = NULL, conda = "auto") {
     stop("conda environment ", envname, " not found")
 }
 
+conda_dll_paths <- function(envname = NULL, conda = "auto") {
+  
+  # resolve envname
+  envname <- condaenv_resolve(envname)
+  
+  # for fully-qualified paths, we return empty string
+  if (grepl("[/\\\\]", envname)) {
+      return("")
+  }
+  
+  # otherwise, list conda environments and try to find it
+  conda_envs <- conda_list(conda = conda)
+  env <- subset(conda_envs, conda_envs$name == envname)
+  if (nrow(env) > 0) {
+    prefix <- dirname(env$python[[1]])
+    dll_paths <- c(
+        normalizePath(file.path(prefix, "Library/mingw-w64/bin"), winslash="\\", mustWork = FALSE),
+        normalizePath(file.path(prefix, "Library/usr/bin"), winslash="\\", mustWork = FALSE),
+        normalizePath(file.path(prefix, "Library/bin"), winslash="\\", mustWork = FALSE),
+        normalizePath(file.path(prefix, "Scripts"), winslash="\\", mustWork = FALSE),
+        normalizePath(file.path(prefix, "bin"), winslash="\\", mustWork = FALSE)
+    )
+    paste(dll_paths, collapse = ";")
+  } else
+    stop("conda environment ", envname, " not found")
+}
 
 
 find_conda <- function() {

--- a/R/pip.R
+++ b/R/pip.R
@@ -28,8 +28,19 @@ pip_install <- function(python, packages, pip_options = character(), ignore_inst
   args <- c(args, pip_options)
   args <- c(args, packages)
 
+  # if windows, add conda paths to ensure SSL dlls get picked up
+  old_path <- Sys.getenv("PATH")
+  dll_paths <- conda_dll_paths()
+  if (is_windows() && (dll_paths != ""))
+    Sys.setenv(PATH = paste(dll_paths, old_path, sep = ";"))
+  
   # run it
   result <- system2(python, args)
+  
+  ## Set old path back
+  if (is_windows() && (dll_paths != ""))
+    Sys.setenv(PATH = old_path)
+
   if (result != 0L) {
     pkglist <- paste(shQuote(packages), collapse = ", ")
     msg <- paste("Error installing package(s):", pkglist)


### PR DESCRIPTION
…SL not being found.

`conda_install` with the `pip = TRUE` option doesn't properly set paths, so errors shown in the reprex below occur. This patch adds the appropriate paths to `pip_install()` function to fix the problem.

```
R version 4.1.0 (2021-05-18) -- "Camp Pontanezen"
Copyright (C) 2021 The R Foundation for Statistical Computing
Platform: x86_64-w64-mingw32/x64 (64-bit)

R is free software and comes with ABSOLUTELY NO WARRANTY.
You are welcome to redistribute it under certain conditions.
Type 'license()' or 'licence()' for distribution details.

  Natural language support but running in an English locale

R is a collaborative project with many contributors.
Type 'contributors()' for more information and
'citation()' on how to cite R or R packages in publications.

Type 'demo()' for some demos, 'help()' for on-line help, or
'help.start()' for an HTML browser interface to help.
Type 'q()' to quit R.

> setwd('c:/Users/naras/')
> library(reticulate)
> conda_install("r-reticulate", packages="lifelines", pip = TRUE)
WARNING: pip is configured with locations that require TLS/SSL, however the ssl module in Python is not available.
WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/lifelines/
WARNING: Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/lifelines/
WARNING: Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/lifelines/
WARNING: Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/lifelines/
WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/lifelines/
Could not fetch URL https://pypi.org/simple/lifelines/: There was a problem confirming the ssl certificate: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /simple/lifelines/ (Caused by SSLError("Can't connect to HTTPS URL because the SSL module is not available.")) - skipping
ERROR: Could not find a version that satisfies the requirement lifelines (from versions: none)
ERROR: No matching distribution found for lifelines
Error: Error installing package(s): "lifelines"
> sessionInfo()
R version 4.1.0 (2021-05-18)
Platform: x86_64-w64-mingw32/x64 (64-bit)
Running under: Windows 10 x64 (build 19042)

Matrix products: default

locale:
[1] LC_COLLATE=English_United States.1252
[2] LC_CTYPE=English_United States.1252
[3] LC_MONETARY=English_United States.1252
[4] LC_NUMERIC=C
[5] LC_TIME=English_United States.1252

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base

other attached packages:
[1] reticulate_1.20

loaded via a namespace (and not attached):
[1] compiler_4.1.0  Matrix_1.3-3    tools_4.1.0     rappdirs_0.3.3
[5] Rcpp_1.0.6      grid_4.1.0      jsonlite_1.7.2  png_0.1-7
[9] lattice_0.20-44
> q()

Process R finished at Fri Jul 16 13:10:43 2021
```