### PR TITLE
Allow conda to be installed from customized place

### DIFF
--- a/R/miniconda.R
+++ b/R/miniconda.R
@@ -92,6 +92,11 @@ install_miniconda_preflight <- function(path, force) {
 
 miniconda_installer_url <- function(version = "3") {
   
+  url <- getOption("reticulate.miniconda.url", default = NULL)
+  if( !is.null(url) ){
+    return( url )
+  }
+  
   base <- "https://repo.anaconda.com/miniconda"
   
   info <- as.list(Sys.info())


### PR DESCRIPTION
Added options `reticulate.miniconda.url` to allow users to specify where to download miniconda, to install conda from intranet, conda-forge or personal repos. 

This quick fix solves #1012 #1019.



