### PR TITLE
inject PATHs when using pip in condaenv

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 ## reticulate 1.23  (UNRELEASED)
 
+- Fixed an issue that caused `reticulate::conda_install(pip = TRUE)`
+  to fail on windows. (#1053, @t-kalinowski)
+
 ## reticulate 1.22
 
 - Fixed a regression that caused `reticulate::conda_install(pip = TRUE)`

--- a/R/conda.R
+++ b/R/conda.R
@@ -392,7 +392,7 @@ numeric_conda_version <- function(conda = "auto", version_string = conda_version
   # substitute rc|beta|alpha|whatever suffix with .
   v <- sub("[A-Za-z]+", ".", v) 
   
-  if(endsWith(v, "."))
+  if (grepl("\\.$", v))
     v <- paste0(v, "9000")
   
   numeric_version(v)

--- a/R/conda.R
+++ b/R/conda.R
@@ -589,7 +589,7 @@ conda_run <- function(cmd, args = c(), conda = "auto", envname = NULL,
   conda <- conda_binary(conda)
   envname <- condaenv_resolve(envname)
 
-  if(numeric_conda_version(conda) < "4.9")
+  if (numeric_conda_version(conda) < "4.9")
     stopf(
 "`conda_run()` requires conda version >= 4.9.
 Run `miniconda_update('%s')` to update conda.", conda)

--- a/R/conda.R
+++ b/R/conda.R
@@ -376,9 +376,25 @@ conda_version <- function(conda = "auto") {
 }
 
 
-numeric_conda_version <- function(conda = "auto") {
-  v <- conda_version(conda)
-  v <- sub("(conda) ([0-9.]+)", "\\2", v)
+numeric_conda_version <- function(conda = "auto", version_string = conda_version(conda)) {
+  # some plausible version strings: 
+  # "conda 4.6.0"                 
+  # "conda 4.6.0b0"               
+  # "conda 4.6.0rc1"              
+  # "conda 4.6.0rc1.post3+64bde06"
+  v <- version_string 
+  v <- sub("^conda ", "", v) # drop hardcoded prefix
+  
+  # https://github.com/conda/conda/blob/c1579681d1468af3d1b4af3083bed33f8391e861/conda/_vendor/auxlib/packaging.py#L142
+  # if dev version string: "{0}.post{1}+{2}".format(version, post_commit, hash)
+  v <- sub("\\.post(\\d)\\+.+$", ".\\1", v)
+
+  # substitute rc|beta|alpha|whatever suffix with .
+  v <- sub("[A-Za-z]+", ".", v) 
+  
+  if(endsWith(v, "."))
+    v <- paste0(v, "9000")
+  
   numeric_version(v)
 }
 

--- a/R/conda.R
+++ b/R/conda.R
@@ -286,15 +286,28 @@ conda_install <- function(envname = NULL,
     }
   }
 
+  
   # delegate to pip if requested
   if (pip) {
+    conda_env_PATH_additions <- normalizePath(file.path(dirname(python), c(
+      "",
+      "Library/mingw-w64/bin",
+      "Library/usr/bin",
+      "Library/bin",
+      "Scripts",
+      "bin")
+      ), mustWork = FALSE)
     
-    result <- pip_install(
-      python = python,
-      packages = packages,
-      pip_options = pip_options,
-      ignore_installed = pip_ignore_installed
-    )
+    withr::with_path(conda_env_PATH_additions, {
+      
+      result <- pip_install(
+        python = python,
+        packages = packages,
+        pip_options = pip_options,
+        ignore_installed = pip_ignore_installed
+      )
+      
+    })
     
     return(result)
     

--- a/R/conda.R
+++ b/R/conda.R
@@ -595,7 +595,7 @@ conda_run <- function(cmd, args = c(), conda = "auto", envname = NULL,
 Run `miniconda_update('%s')` to update conda.", conda)
 
   if(grepl("[/\\]", envname))
-    in_env <- c("--prefix", envname)
+    in_env <- c("--prefix", shQuote(normalizePath(envname)))
   else
     in_env <- c("--name", envname)
 

--- a/R/config.R
+++ b/R/config.R
@@ -496,6 +496,16 @@ python_munge_path <- function(python) {
   python_home <- dirname(python)
   python_dirs <- c(normalizePath(python_home))
   
+  # fix rpath for anaconda libmkl
+  if (is_osx()) {
+    libmkl <- file.path(python_home, "../lib/libmkl_intel_thread.dylib")
+    if (file.exists(libmkl)) {
+      libmkl <- normalizePath(libmkl)
+      args <- c("-add_rpath", shQuote(dirname(libmkl)), libmkl)
+      system2("install_name_tool", args, stdout = FALSE, stderr = FALSE)
+    }
+  }
+  
   info <- python_info(python)
   
   if(info$type == "conda" &&
@@ -530,15 +540,6 @@ python_munge_path <- function(python) {
       python_dirs <- c(python_dirs, normalizePath(python_library_bin))
   }
   
-  # fix rpath for anaconda libmkl
-  if (is_osx()) {
-    libmkl <- file.path(python_home, "../lib/libmkl_intel_thread.dylib")
-    if (file.exists(libmkl)) {
-      libmkl <- normalizePath(libmkl)
-      args <- c("-add_rpath", shQuote(dirname(libmkl)), libmkl)
-      system2("install_name_tool", args, stdout = FALSE, stderr = FALSE)
-    }
-  }
 
   path_prepend(python_dirs)
 

--- a/R/config.R
+++ b/R/config.R
@@ -495,6 +495,22 @@ python_munge_path <- function(python) {
   # https://github.com/rstudio/reticulate/issues/367
   python_home <- dirname(python)
   python_dirs <- c(normalizePath(python_home))
+  
+  info <- python_info(python)
+  
+  if(info$type == "conda" &&
+     numeric_conda_version(info$conda) >= "4.9") {
+    
+    new_path <- conda_run("python",
+      c("-c", shQuote("import os; print(os.environ['PATH'])")),
+      conda = info$conda, envname = info$root,
+      stdout = TRUE)
+    
+    old_path <- Sys.getenv("PATH")
+    Sys.setenv("PATH" = new_path)
+    return(old_path)
+  }
+  
   if (is_windows()) {
 
     # include the Scripts path, as well

--- a/R/pip.R
+++ b/R/pip.R
@@ -35,13 +35,13 @@ pip_install <- function(python, packages, pip_options = character(), ignore_inst
   args <- c(args, packages)
 
   # figure out if we should go though conda_run()
-  if(conda == "auto") {
+  if (conda == "auto") {
     info <- python_info(python)
     if(info$type != "conda" || numeric_conda_version(info$conda) < "4.9")
       conda <- NULL
   }
 
-  result <- if(is.null(conda) || isFALSE(conda))
+  result <- if (is.null(conda) || isFALSE(conda))
     system2(python, args)
   else
     conda_run(python, args, conda = conda, envname = envname)


### PR DESCRIPTION

when attempting to run `tensorflow::install_tensorflow()` in RStudio on Windows, this error message can pop up:
```
WARNING: pip is configured with locations that require TLS/SSL, however the ssl module in Python is not available.
WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/tensorflow/
WARNING: Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/tensorflow/
WARNING: Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/tensorflow/
WARNING: Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/tensorflow/
WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError("Can't connect to HTTPS URL because the SSL module is not available.")': /simple/tensorflow/
Could not fetch URL https://pypi.org/simple/tensorflow/: There was a problem confirming the ssl certificate: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /simple/tensorflow/ (Caused by SSLError("Can't connect to HTTPS URL because the SSL module is not available.")) - skipping
ERROR: Could not find a version that satisfies the requirement tensorflow==2.6.* (from versions: none)
ERROR: No matching distribution found for tensorflow==2.6.*
WARNING: pip is configured with locations that require TLS/SSL, however the ssl module in Python is not available.
Could not fetch URL https://pypi.org/simple/pip/: There was a problem confirming the ssl certificate: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /simple/pip/ (Caused by SSLError("Can't connect to HTTPS URL because the SSL module is not available.")) - skipping
 Error: Error installing package(s): "\"tensorflow==2.6.*\"" 
```

This fixes the issue by prefixing the PATH variable so the correct
"openssl.exe" executable is found. e.g.: 
`"C:\Users\kalin\AppData\Local\r-miniconda\envs\r-reticulate\Library\bin\openssl.exe" `
instead of 
`"C:\rtools40\usr\bin\openssl.exe"`


related: 
https://github.com/conda/conda/issues/6064
https://github.com/conda/conda/issues/8273

https://github.com/rstudio/reticulate/commit/5339495343d277fa30380502b5ac77b2cdd41d8c
https://github.com/rstudio/reticulate/issues/1052
