### PR TITLE
resolve non-list values for `delay_load` in `import_from_path_delayed`

### DIFF
--- a/R/import.R
+++ b/R/import.R
@@ -175,6 +175,22 @@ import_from_path <- function(module,
 
 import_from_path_delayed <- function(module, path, convert, delay_load) {
   
+  # resolve delay_load
+  # single function, maps to on_load
+  if(is.function(delay_load)){
+    delay_load <- list(on_load = delay_load)
+  }
+  
+  # TRUE translates to an empty list of hooks
+  if(identical(delay_load, TRUE)){
+    delay_load <- list()
+  }
+  
+  # anything else not a list is an error
+  if(!is.list(delay_load)){
+    stop("delay_load should be a boolean, a single function, or a list of functions.")
+  }
+  
   .before_load <- delay_load$before_load %||% function() {}
   .on_load     <- delay_load$on_load %||% function() {}
   .on_error    <- delay_load$on_error %||% function(error) {}

--- a/R/import.R
+++ b/R/import.R
@@ -177,17 +177,17 @@ import_from_path_delayed <- function(module, path, convert, delay_load) {
   
   # resolve delay_load
   # single function, maps to on_load
-  if(is.function(delay_load)){
+  if (is.function(delay_load)) {
     delay_load <- list(on_load = delay_load)
   }
   
   # TRUE translates to an empty list of hooks
-  if(identical(delay_load, TRUE)){
+  if (identical(delay_load, TRUE)) {
     delay_load <- list()
   }
   
   # anything else not a list is an error
-  if(!is.list(delay_load)){
+  if (!is.list(delay_load)) {
     stop("delay_load should be a boolean, a single function, or a list of functions.")
   }
   


### PR DESCRIPTION
resolves the issue reported in #1058, where the (recomended) value of `TRUE` would cause errors. 

The fix is a bit ugly, as reticulate is now resolving single arguments to a list in `import_from_path_delayed`, and spreading that list back out to single arguments in `import` itself. Some refactoring might be in order, but I don't feel confident enough to make more sweeping changes. 

I aimed to cover the documented options for `delay_load` (function, list and boolean), and fail early for other inputs.