### PR TITLE
add conda_run2()

### DIFF
--- a/R/pip.R
+++ b/R/pip.R
@@ -22,7 +22,6 @@ pip_version <- function(python) {
 pip_install <- function(python, packages, pip_options = character(), ignore_installed = FALSE,
                         conda = "auto", envname = NULL) {
 
-
   # construct command line arguments
   args <- c("-m", "pip", "install", "--upgrade")
   if (ignore_installed)
@@ -44,7 +43,7 @@ pip_install <- function(python, packages, pip_options = character(), ignore_inst
   result <- if (is.null(conda) || identical(conda, FALSE))
     system2(python, args)
   else
-    conda_run(python, args, conda = conda, envname = envname)
+    conda_run2(python, args, conda = conda, envname = envname)
 
 
   if (result != 0L) {


### PR DESCRIPTION
Manually implements the equivalent of `conda run`, as a workaround for https://github.com/conda/conda/issues/10972
Partially reverts https://github.com/rstudio/reticulate/pull/1053
Restores `keras::install_keras()` failing tests: https://github.com/rstudio/keras/actions/runs/1317897279