### PR TITLE
Add poetry project awareness

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -199,6 +199,15 @@ py_discover_config <- function(required_module = NULL, use_environment = NULL) {
     
   }
   
+  # if we're working within a project that containers a pyproject.toml, then
+  # check if that project uses poetry as a tool.
+  # if so, use the copy of Python associated with the poetry project
+  if (is_poetry_project()) {
+    python <- poetry_python()
+    config = python_config(python, required_module, forced = "poetry")
+    return(config)
+  } 
+  
   # if we're working within a project that contains a Pipfile, then
   # use the copy of Python associated with that pipenv
   pipfile <- pipenv_pipfile_path()

--- a/R/poetry.R
+++ b/R/poetry.R
@@ -1,0 +1,55 @@
+error_no_toml_parser = function(e) {
+  stop("Please install 'RcppTOML' to parse the a poetry pyproject.toml", call. = FALSE)
+}
+
+pyproject_parser = function() {
+  # From: https://github.com/rstudio/blogdown/blob/main/R/utils.R#L343
+  tryCatch(getFromNamespace('parseTOML', 'RcppTOML'), error = error_no_toml_parser)
+}
+  
+pyproject_path <- function() {
+  # check option
+  pyproject <- getOption("reticulate.poetry.pyproject")
+  if (!is.null(pyproject))
+    return(pyproject)
+  
+  # try default
+  tryCatch(here::here("pyproject.toml"), error = function(e) "")
+}
+
+is_poetry_project <- function() {
+  path = pyproject_path()
+  
+  # If there is no pyproject.toml, it is not a poetry project
+  if (!file.exists(path)) return(FALSE)
+  
+  # read the pyproject.toml
+  parser = pyproject_parser()
+  toml = parser(path, fromFile = TRUE)
+  
+  # If poetry is listed as a pyproject, it is a poetry project
+  "poetry" %in% names(toml[["tool"]])
+}
+
+poetry_python <- function() {
+  
+  # validate that poetry is available on the PATH
+  if (!nzchar(Sys.which("poetry")))
+    stop("'poetry' is not available")
+  
+  # move to root directory
+  root <- here::here()
+  owd <- setwd(root)
+  on.exit(setwd(owd), add = TRUE)
+  
+  # ask poetry what the environment path is
+  envpath <- system("poetry env info --path", intern = TRUE)
+  status <- attr(envpath, "status") %||% 0L
+  if (status != 0L) {
+    fmt <- "'poetry env info --path' had status %i"
+    stopf(fmt, status)
+  }
+  
+  # get path to python
+  virtualenv_python(envpath)
+}

--- a/tests/testthat/test-python-poetry.R
+++ b/tests/testthat/test-python-poetry.R
@@ -1,0 +1,36 @@
+context("poetry")
+
+test_that("reticulate uses the poetry-configured version of Python", {
+  
+  if (!nzchar(Sys.which("poetry")))
+    skip("poetry is not installed")
+  
+  # move to temporary directory
+  project <- tempfile("poetry-")
+  dir.create(project)
+  on.exit(unlink(project), add = TRUE)
+  
+  owd <- setwd(project)
+  on.exit(setwd(owd), add = TRUE)
+  
+  # initialize a poetry project
+  system("poetry init --no-interaction --quiet", ignore.stdout = TRUE, ignore.stderr = TRUE)
+  # make the venv in the project folder to ensure it is cleaned up on exit
+  cat(c("[virtualenvs]", "in-project = true"), file = "poetry.toml", sep = "\n")
+  system("poetry env use python --quiet", ignore.stdout = TRUE, ignore.stderr = TRUE)
+  
+  # ask for virtualenv path
+  expected <- system("poetry env info --path", intern = TRUE)
+  expected <- paste0(expected, "/bin/python")
+  
+  # try running reticulate in child process
+  fmt <- "R --vanilla -s -e '%s'"
+  cmd <- sprintf(fmt, "writeLines(reticulate::py_config()$python)")
+  actual <- system(cmd, intern = TRUE)
+  
+  expect_equal(
+    normalizePath(expected),
+    normalizePath(actual)
+  )
+  
+})


### PR DESCRIPTION
Hi!

Took a stab at using `poetry` as the venv provider after following the conversation in #1006. 
I have used the method shown to use Pipenv as the venv provider from [this commit](https://github.com/rstudio/reticulate/commit/3675ff51f5478554bf2b7572a4325496f3ef67c4).

![Screenshot from 2021-10-24 12-21-29](https://user-images.githubusercontent.com/9381608/138592150-875f94ed-dd7b-424c-93e9-5e69dd098c4d.png)

The environment seems to respect the provided venv. 

To detect a poetry environment, I check whether there is a `pyproject.toml` which declares `poetry` as one of the tools, as the `pyproject.toml` is the only file `poetry init` initially creates.

```
> poetry init --no-interaction --quiet
> cat pyproject.toml 
[tool.poetry]
name = "myproject"
version = "0.1.0"
description = ""
authors = ["Akhil <...>"]

[tool.poetry.dependencies]
python = "^3.8"

[tool.poetry.dev-dependencies]

[build-system]
requires = ["poetry-core>=1.0.0"]
build-backend = "poetry.core.masonry.api"
```

I dynamically register the `TOML` parser (as done in `blogdown`) as it doesn't seem like it should be a package dependency, but rather just warn the user if it doesn't exist and they want to use `poetry`. Hope this is ok.

Strange note - when I run `reticulate::py_config()` in a terminal R session, I do not have to unset `RETICULATE_PYTHON`, but I do in Rstudio. I wonder if this is the same with the `pipenv` implementation?

Thanks for the great package :)
