### PR TITLE
Streamline ways to invoke `pip --ignore-installed` in `py_install()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,6 +50,6 @@ Suggests:
     rmarkdown,
     testthat
 LinkingTo: Rcpp
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr

--- a/R/install.R
+++ b/R/install.R
@@ -59,6 +59,15 @@ py_install_method_detect <- function(envname, conda = "auto") {
 #' @param ... Additional arguments passed to [conda_install()]
 #'   or [virtualenv_install()].
 #'
+#' @param pip_ignore_installed,ignore_installed Boolean; whether pip should
+#'   ignore previously installed versions of the requested packages. Setting
+#'   this to `TRUE` causes pip to install the latest versions of all
+#'   dependencies into the requested environment. This ensure that no
+#'   dependencies are satisfied by a package that exists either in the site
+#'   library or was previously installed from a different--potentially
+#'   incompatible--distribution channel. (`ignore_installed` is an alias for
+#'   `pip_ignore_installed`, `pip_ignore_installed` takes precedence).
+#'
 #' @details On Linux and OS X the "virtualenv" method will be used by default
 #'   ("conda" will be used if virtualenv isn't available). On Windows, the
 #'   "conda" method is always used.
@@ -72,7 +81,10 @@ py_install <- function(packages,
                        conda = "auto",
                        python_version = NULL,
                        pip = FALSE,
-                       ...)
+                       ...,
+                       pip_ignore_installed = ignore_installed,
+                       ignore_installed = FALSE
+                       )
 {
   check_forbidden_install("Python packages")
   
@@ -115,6 +127,7 @@ py_install <- function(packages,
     virtualenv = virtualenv_install(
       envname = envname,
       packages = packages,
+      ignore_installed = pip_ignore_installed,
       ...
     ),
     
@@ -124,6 +137,7 @@ py_install <- function(packages,
       conda = conda,
       python_version = python_version,
       pip = pip,
+      pip_ignore_installed = pip_ignore_installed,
       ...
     ),
     

--- a/man/py_install.Rd
+++ b/man/py_install.Rd
@@ -11,7 +11,9 @@ py_install(
   conda = "auto",
   python_version = NULL,
   pip = FALSE,
-  ...
+  ...,
+  pip_ignore_installed = ignore_installed,
+  ignore_installed = FALSE
 )
 }
 \arguments{
@@ -40,6 +42,15 @@ from the Conda repositories.}
 
 \item{...}{Additional arguments passed to \code{\link[=conda_install]{conda_install()}}
 or \code{\link[=virtualenv_install]{virtualenv_install()}}.}
+
+\item{pip_ignore_installed, ignore_installed}{Boolean; whether pip should
+ignore previously installed versions of the requested packages. Setting
+this to \code{TRUE} causes pip to install the latest versions of all
+dependencies into the requested environment. This ensure that no
+dependencies are satisfied by a package that exists either in the site
+library or was previously installed from a different--potentially
+incompatible--distribution channel. (\code{ignore_installed} is an alias for
+\code{pip_ignore_installed}, \code{pip_ignore_installed} takes precedence).}
 }
 \description{
 Install Python packages into a virtual environment or Conda environment.


### PR DESCRIPTION
in `py_install()`, respect both `pip_ignore_installed` and `ignore_installed`, in both conda and virtualenv python installations.
