### PR TITLE
bump miniconda default python version to 3.8

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@
   `pyproject.toml` file, `reticulate` will attempt to find and use the virtual
   environment managed by Poetry for that project. (#1031)
   
+- `reticulate::install_miniconda()` default python version for the default 
+  `r-reticulte` miniconda environment changes from 3.6 to 3.8.
+  
 - `reticulate::install_miniconda()` now prefers installing the latest
   arm64 builds of miniforge. See https://conda-forge.org/blog/posts/2020-10-29-macos-arm64/
   for more details.

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,8 +6,8 @@
   `pyproject.toml` file, `reticulate` will attempt to find and use the virtual
   environment managed by Poetry for that project. (#1031)
   
-- `reticulate::install_miniconda()` default python version for the default 
-  `r-reticulte` miniconda environment changes from 3.6 to 3.8.
+- The default version of Python used for the `r-reticulate` Miniconda environment 
+  installed via `reticulate::install_miniconda()` has changed from 3.6 to 3.8.
   
 - `reticulate::install_miniconda()` now prefers installing the latest
   arm64 builds of miniforge. See https://conda-forge.org/blog/posts/2020-10-29-macos-arm64/

--- a/R/miniconda.R
+++ b/R/miniconda.R
@@ -353,7 +353,7 @@ miniconda_python_envpath <- function() {
 
 # the version of python to use in the environment
 miniconda_python_version <- function() {
-  Sys.getenv("RETICULATE_MINICONDA_PYTHON_VERSION", unset = "3.6")
+  Sys.getenv("RETICULATE_MINICONDA_PYTHON_VERSION", unset = "3.8")
 }
 
 miniconda_python_package <- function() {


### PR DESCRIPTION
Right now, `install_miniconda()` fails at the `r-reticulate` environment creation step on an M1 Mac.
This is because the minimum (native Arm) python version available from `conda` is 3.8. 
Rather than installing different python versions on Arm Macs vs other platforms, I think it's better to bump the python version everywhere. 

There is also a case to be made for bumping to python 3.9, since that's the default python version that comes with miniconda, (meaning, smaller overall install and less to download).