### PR TITLE
Fix binding to system python

### DIFF
--- a/R/conda.R
+++ b/R/conda.R
@@ -511,6 +511,9 @@ conda_binary <- function(conda = "auto") {
 
   conda <- normalizePath(conda, winslash = "/", mustWork = FALSE)
   
+  if(!grepl("^conda", basename(conda)))
+    stop("Supplied path is not a conda binary: ", sQuote(conda, FALSE))
+  
   # if the user has requested a conda binary in the 'condabin' folder,
   # try to find and use its sibling in the 'bin' folder instead as
   # we rely on other tools typically bundled in the 'bin' folder

--- a/R/conda.R
+++ b/R/conda.R
@@ -850,3 +850,37 @@ conda_info <- function(conda = "auto") {
   json <- system2(conda, c("info", "--json"), stdout = TRUE)
   jsonlite::parse_json(json, simplifyVector = TRUE)
 }
+
+is_conda_python <- function(python) {
+  root <- if (is_windows())
+    dirname(python)
+  else
+    dirname(dirname(python))
+  
+  file.exists(file.path(root, "conda-meta"))
+}
+
+
+get_python_conda_info <- function(python) {
+  stopifnot(is_conda_python(python))
+  
+  root <- if (is_windows()) 
+    dirname(python)
+  else
+    dirname(dirname(python))
+  
+  if(dir.exists(file.path(root, "condabin"))) {
+    # base conda env
+    conda <- if(is_windows())
+      file.path(root, "condabin/conda.bat")
+    else
+      file.path(root, "bin/conda")
+  } else {
+    # not base env, parse conda-meta history to find the conda binary
+    # that created it
+    conda <- python_info_condaenv_find(root)
+  }
+  
+  list(conda = normalizePath(conda, winslash = "/", mustWork = TRUE),
+       root = normalizePath(root, winslash = "/", mustWork = TRUE))
+}

--- a/R/config.R
+++ b/R/config.R
@@ -513,31 +513,25 @@ python_munge_path <- function(python) {
     }
   }
 
-  info <- tryCatch(
-    python_info(python),
-    # python_info() throws error for non-envs.
-    # if requested python is a system / base conda installation.
-    # Still use conda_run() to munge path
-    error = function(e) {
-      conda <- tryCatch(conda_binary(python), error = function(e) NULL)
-      if (is.null(conda) || !file.exists(conda)) return(list())
-      list(python = python, type = "conda",
-           root = "base", conda = conda)
-    })
 
-  if(isTRUE(info$type == "conda") && numeric_conda_version(info$conda) >= "4.9") {
 
-    new_path <- conda_run(
-      "python",
-      c("-c", shQuote("import os; print(os.environ['PATH'])")),
-      conda = info$conda,
-      envname = info$root,
-      stdout = TRUE
-    )
+  if (is_conda_python(python)) {
+    conda_info <- get_python_conda_info(python)
 
-    old_path <- Sys.getenv("PATH")
-    Sys.setenv("PATH" = new_path)
-    return(old_path)
+    if (numeric_conda_version(conda_info$conda) >= "4.9") {
+
+      new_path <- conda_run(
+        "python",
+        c("-c", shQuote("import os; print(os.environ['PATH'])")),
+        conda = conda_info$conda,
+        envname = conda_info$root,
+        stdout = TRUE
+      )
+
+      old_path <- Sys.getenv("PATH")
+      Sys.setenv("PATH" = new_path)
+      return(old_path)
+    }
 
   }
 


### PR DESCRIPTION
Follow up to #1083

cc: @cderv.
Note, even with this fix, binding to the Python installed from the Microsoft Store fails for me, albeit for a different reason now.

Now I get this error message:
```
Error in py_initialize(config$python, config$libpython, config$pythonhome,  :
  C:/Program Files/WindowsApps/PythonSoftwareFoundation.Python.3.9_3.9.2544.0_x64__qbz5n2kfra8p0/python39.dll - Access is denied.
Calls: print ... tryCatch -> tryCatchList -> tryCatchOne -> <Anonymous>
In addition: Warning message:
In file.info(x, extra_cols = FALSE) :
  cannot open file 'C:\Users\kalin\AppData\Local\Microsoft\WindowsApps\python.exe': The file cannot be accessed by the system
Execution halted
```

After some googeling this appears to be not easily resolvable: https://stackoverflow.com/questions/56974927/permission-denied-trying-to-run-python-on-windows-10

I tested this locally on Windows 10 with python's:
- installed via installer from www.python.org
- `r-reticulate` condaenv created by `reticulate::install_miniconda()`
- base condaenv of `r-reticulate`
- Microsoft Store Python (which errors for me)

and on WSL with `/usr/bin/python3`, `r-reticulate`, and base of `r-reticulate`.

