### PR TITLE
use 'required = TRUE' by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@
 
 - The development branch for `reticulate` has moved to the "main" branch.
 
+- `reticulate::use_python()` and friends now assume `required = TRUE` by
+  default. For backwards compatibility, when `use_python()` is called
+  as part of a package load hook, the default value will instead be `FALSE`.
+
 - `reticulate` now provides support for Python environments managed by
   [poetry](https://python-poetry.org/). For projects containing a
   `pyproject.toml` file, `reticulate` will attempt to find and use the virtual

--- a/R/install-python.R
+++ b/R/install-python.R
@@ -1,27 +1,27 @@
 
 #' Install Python
-#' 
+#'
 #' Download and install Python, using the [pyenv](https://github.com/pyenv/pyenv).
 #' and [pyenv-win](https://github.com/pyenv-win/pyenv-win) projects.
-#' 
+#'
 #' In general, it is recommended that Python virtual environments are created
 #' using the copies of Python installed by [install_python()]. For example:
-#' 
+#'
 #' ```
 #' library(reticulate)
 #' version <- "3.8.7"
 #' install_python(version = version)
 #' virtualenv_create("my-environment", python_version = version)
-#' use_virtualenv("my-environment", required = TRUE)
+#' use_virtualenv("my-environment")
 #' ```
-#' 
+#'
 #' @param version The version of Python to install.
-#' 
+#'
 #' @param list Boolean; if set, list the set of available Python versions?
-#' 
+#'
 #' @param force Boolean; force re-installation even if the requested version
 #'   of Python is already installed?
-#' 
+#'
 #' @export
 install_python <- function(version,
                            list = FALSE,
@@ -31,24 +31,24 @@ install_python <- function(version,
   pyenv <- pyenv_find()
   if (!file.exists(pyenv))
     stop("could not locate 'pyenv' binary")
-  
+
   # if list is set, then list available versions instead
   if (identical(list, TRUE))
     return(pyenv_list(pyenv = pyenv))
-  
+
   # install the requested package
   status <- pyenv_install(version, force, pyenv = pyenv)
   if (!identical(status, 0L))
     stopf("installation of Python %s failed", version)
-  
+
   # ensure that virtualenv is installed for older versions of Python
   python <- pyenv_python(version = version)
   version <- python_version(python)
   if (version < "3.5" && !python_has_module(python, "virtualenv"))
     pip_install(python, "virtualenv")
-  
+
   # return path to python
   python
-  
+
 }
 

--- a/R/use_python.R
+++ b/R/use_python.R
@@ -217,6 +217,7 @@ use_python_required <- function() {
   for (call in calls) {
 
     match <-
+      length(call) >= 2 &&
       identical(call[[1L]], as.name("runHook")) &&
       identical(call[[2L]], ".onLoad")
 

--- a/R/use_python.R
+++ b/R/use_python.R
@@ -2,71 +2,60 @@
 #' Use Python
 #'
 #' Select the version of Python to be used by `reticulate`.
-#' 
+#'
 #' The `reticulate` package initializes its Python bindings lazily -- that is,
 #' it does not initialize its Python bindings until an API that explicitly
 #' requires Python to be loaded is called. This allows users and package authors
 #' to request particular versions of Python by calling `use_python()` or one of
 #' the other helper functions documented in this help file.
-#' 
+#'
 #' @section RETICULATE_PYTHON:
-#' 
+#'
 #' The `RETICULATE_PYTHON` environment variable can also be used to control
 #' which copy of Python `reticulate` chooses to bind to. It should be set to
 #' the path to a Python interpreter, and that interpreter can either be:
-#' 
+#'
 #' - A standalone system interpreter,
 #' - Part of a virtual environment,
 #' - Part of a Conda environment.
-#' 
+#'
 #' When set, this will override any other requests to use a particular copy of
 #' Python. Setting this in `~/.Renviron` (or optionally, a project `.Renviron`)
 #' can be a useful way of forcing `reticulate` to use a particular version of
 #' Python.
-#' 
+#'
 #' @section Caveats:
-#' 
-#' By default, requests are _advisory_, and may be ignored for a number of reasons:
-#' 
-#' - The requested copy of Python cannot be initialized,
-#' - The requested copy of Python does not have an installation of `numpy` available,
-#' - Another call to `use_python()` has requested a different version of Python,
-#' - The request has been overridden via `use_python(..., required = TRUE)`.
-#' 
-#' In general, if you explicitly want to use a particular version of Python, it
-#' is recommended to set `required = TRUE`, or explicitly set the
-#' `RETICULATE_PYTHON` environment variable.
-#' 
+#'
 #' Note that the requests for a particular version of Python via `use_python()`
 #' and friends only persist for the active session; they must be re-run in each
 #' new \R session as appropriate.
-#' 
+#'
 #' If `use_python()` (or one of the other `use_*()` functions) are called
 #' multiple times, the most recently-requested version of Python will be
 #' used. Note that any request to `use_python()` will always be overridden
 #' by the `RETICULATE_PYTHON` environment variable, if set.
-#' 
+#'
 #' The [py_config()] function will also provide a short note describing why
 #' `reticulate` chose to select the version of Python that was ultimately
 #' activated.
-#' 
+#'
 #' @param python
 #'   The path to a Python binary.
-#' 
+#'
 #' @param version
 #'   The version of Python to use. `reticulate` will search for versions of
 #'   Python as installed by the [install_python()] helper function.
 #'
 #' @param virtualenv
 #'   Either the name of, or the path to, a Python virtual environment.
-#'   
+#'
 #' @param condaenv
 #'   The name of the Conda environment to use.
-#' 
+#'
 #' @param conda
 #'   The path to a `conda` executable. By default, `reticulate` will check the
 #'   `PATH`, as well as other standard locations for Anaconda installations.
-#'   
+#'
 #' @param required
 #'   Is the requested copy of Python required? If `TRUE`, an error will be
 #'   emitted if the requested copy of Python does not exist. Otherwise, the
@@ -76,15 +65,16 @@
 #' @importFrom utils file_test
 #'
 #' @export
-use_python <- function(python, required = FALSE) {
+use_python <- function(python, required = NULL) {
 
+  required <- required %||% use_python_required()
   if (required && !file_test("-f", python) && !file_test("-d", python))
     stop("Specified version of python '", python, "' does not exist.")
 
   # if required == TRUE and python is already initialized then confirm that we
   # are using the correct version
   if (required && is_python_initialized()) {
-    
+
     if (!file_same(py_config()$python, python)) {
 
       fmt <- paste(
@@ -110,14 +100,17 @@ use_python <- function(python, required = FALSE) {
 
 #' @rdname use_python
 #' @export
-use_python_version <- function(version, required = FALSE) {
+use_python_version <- function(version, required = NULL) {
+  required <- required %||% use_python_required()
   path <- pyenv_python(version)
   use_python(path, required = required)
 }
 
 #' @rdname use_python
 #' @export
-use_virtualenv <- function(virtualenv = NULL, required = FALSE) {
+use_virtualenv <- function(virtualenv = NULL, required = NULL) {
+
+  required <- required %||% use_python_required()
 
   # resolve path to virtualenv
   virtualenv <- virtualenv_path(virtualenv)
@@ -135,7 +128,9 @@ use_virtualenv <- function(virtualenv = NULL, required = FALSE) {
 
 #' @rdname use_python
 #' @export
-use_condaenv <- function(condaenv = NULL, conda = "auto", required = FALSE) {
+use_condaenv <- function(condaenv = NULL, conda = "auto", required = NULL) {
+
+  required <- required %||% use_python_required()
 
   # check for condaenv supplied by path
   condaenv <- condaenv_resolve(condaenv)
@@ -144,10 +139,10 @@ use_condaenv <- function(condaenv = NULL, conda = "auto", required = FALSE) {
     use_python(python, required = required)
     return(invisible(NULL))
   }
-  
+
   # if the user has requested the 'base' environment, then just activate
   # the conda installation associated with the conda binary found
-  # 
+  #
   # TODO: what if there are multiple conda installations? users could still
   # use 'use_python()' explicitly to target a specific install
   conda <- conda_binary(conda)
@@ -163,14 +158,14 @@ use_condaenv <- function(condaenv = NULL, conda = "auto", required = FALSE) {
 
   # look for one with that name
   matches <- which(conda_envs$name == condaenv)
-  
+
   # if we had no matches, then either fail or return early as appropriate
   if (length(matches) == 0) {
     if (required)
       stop("Unable to locate conda environment '", condaenv, "'.")
     return(invisible(NULL))
   }
-  
+
   # check for multiple matches (this could happen if the user has multiple
   # Conda installations, or multiple environment paths)
   envs <- conda_envs[matches, ]
@@ -178,36 +173,59 @@ use_condaenv <- function(condaenv = NULL, conda = "auto", required = FALSE) {
     output <- paste(capture.output(print(envs)), collapse = "\n")
     warning("multiple Conda environments found; the first-listed will be chosen.\n", output)
   }
-  
+
   # we now have a copy of Python to use -- add it to the list
   python <- envs$python[[1]]
   use_python(python, required = required)
 
   invisible(NULL)
-  
+
 }
 
 #' @rdname use_python
 #' @export
-use_miniconda <- function(condaenv = NULL, required = FALSE) {
-  
+use_miniconda <- function(condaenv = NULL, required = NULL) {
+
+  required <- required %||% use_python_required()
+
   # check that Miniconda is installed
   if (!miniconda_exists()) {
-    
+
     msg <- paste(
       "Miniconda is not installed.",
       "Use reticulate::install_miniconda() to install Miniconda.",
       sep = "\n"
     )
     stop(msg)
-    
+
   }
-  
+
   # use it
   use_condaenv(
     condaenv = condaenv,
     conda = miniconda_conda(),
     required = required
   )
-  
+
+}
+
+use_python_required <- function() {
+
+  # for now, assume that calls from within a package's .onLoad() are
+  # advisory, but we may consider relaxing this in the future
+  calls <- sys.calls()
+  for (call in calls) {
+
+    match <-
+      identical(call[[1L]], as.name("runHook")) &&
+      identical(call[[2L]], ".onLoad")
+
+    if (match)
+      return(FALSE)
+
+  }
+
+  # default to TRUE
+  TRUE
+
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -13,7 +13,7 @@
 "py"
 
 .onLoad <- function(libname, pkgname) {
- 
+
   main <- NULL
   makeActiveBinding("py", env = asNamespace(pkgname), function() {
 
@@ -29,30 +29,30 @@
     main
 
   })
-  
+
   # register a callback auto-flushing Python output as appropriate
   sys <- NULL
   addTaskCallback(function(...) {
-    
+
     enabled <- getOption("reticulate.autoflush", default = TRUE)
     if (!enabled)
       return(TRUE)
-    
+
     if (!is_python_initialized())
       return(TRUE)
-    
+
     sys <- sys %||% import("sys", convert = TRUE)
-    
+
     if (!is.null(sys$stdout) && !is.null(sys$stdout$flush))
       sys$stdout$flush()
-    
+
     if (!is.null(sys$stderr) && !is.null(sys$stderr$flush))
       sys$stderr$flush()
-    
+
     TRUE
-    
+
   })
-  
+
   # on macOS, set the OPENBLAS environment variable if possible, as otherwise
   # numpy will complain that we're using the broken Accelerate BLAS
   #
@@ -69,7 +69,7 @@
         Sys.setenv(OMP_NUM_THREADS = "1")
     }
   }
-  
+
 }
 
 .onUnload <- function(libpath) {

--- a/man/use_python.Rd
+++ b/man/use_python.Rd
@@ -8,15 +8,15 @@
 \alias{use_miniconda}
 \title{Use Python}
 \usage{
-use_python(python, required = FALSE)
+use_python(python, required = NULL)
 
-use_python_version(version, required = FALSE)
+use_python_version(version, required = NULL)
 
-use_virtualenv(virtualenv = NULL, required = FALSE)
+use_virtualenv(virtualenv = NULL, required = NULL)
 
-use_condaenv(condaenv = NULL, conda = "auto", required = FALSE)
+use_condaenv(condaenv = NULL, conda = "auto", required = NULL)
 
-use_miniconda(condaenv = NULL, required = FALSE)
+use_miniconda(condaenv = NULL, required = NULL)
 }
 \arguments{
 \item{python}{The path to a Python binary.}
@@ -66,18 +66,6 @@ Python.
 
 \section{Caveats}{
 
-
-By default, requests are \emph{advisory}, and may be ignored for a number of reasons:
-\itemize{
-\item The requested copy of Python cannot be initialized,
-\item The requested copy of Python does not have an installation of \code{numpy} available,
-\item Another call to \code{use_python()} has requested a different version of Python,
-\item The request has been overridden via \code{use_python(..., required = TRUE)}.
-}
-
-In general, if you explicitly want to use a particular version of Python, it
-is recommended to set \code{required = TRUE}, or explicitly set the
-\code{RETICULATE_PYTHON} environment variable.
 
 Note that the requests for a particular version of Python via \code{use_python()}
 and friends only persist for the active session; they must be re-run in each


### PR DESCRIPTION
This PR makes `use_python()` and friends use `required = TRUE` by default.

For packages calling `use_*()` APIs in their `.onLoad()` hooks, we default to `FALSE` (as per the old behavior) just to reduce the chances of breaking backwards compatibility.