### PR TITLE
ensure length() returns a numeric value

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -245,8 +245,8 @@ py_list_length <- function(x) {
     .Call(`_reticulate_py_list_length`, x)
 }
 
-py_len_impl <- function(x) {
-    .Call(`_reticulate_py_len_impl`, x)
+py_len_impl <- function(x, defaultValue) {
+    .Call(`_reticulate_py_len_impl`, x, defaultValue)
 }
 
 readline <- function(prompt) {

--- a/R/python.R
+++ b/R/python.R
@@ -493,7 +493,7 @@ py_len <- function(x) {
     return(0L)
 
   # delegate to C++
-  py_len_impl(x)
+  py_len_impl(x, NULL)
 
 }
 
@@ -504,7 +504,20 @@ length.python.builtin.list <- function(x) {
 
 #' @export
 length.python.builtin.object <- function(x) {
-  py_len(x)
+
+  # return 0 if Python not yet available
+  if (py_is_null_xptr(x) || !py_available())
+    return(0L)
+
+  # Not all Python objects have a defined length, but almost all objects in R
+  # do. To reflect this behavior, we treat Python's 'None' as a zero-length
+  # object (similar to R's NULL), and treat any other objects without a
+  # `__len__` method as though they were scalar objects.
+  if (inherits(x, "python.builtin.NoneType"))
+    return(0L)
+  else
+    py_len_impl(x, 1L)
+
 }
 
 #' Convert to Python Unicode Object

--- a/R/python.R
+++ b/R/python.R
@@ -478,22 +478,31 @@ length.python.builtin.tuple <- function(x) {
 
 #' Length of Python object
 #'
-#' Get the length of a Python object (equivalent to the Python `len()`
-#' built in function).
+#' Get the length of a Python object. This is equivalent to calling
+#' the Python builtin `len()` function on the object.
+#'
+#' Not all Python objects have a defined length. For objects without a defined
+#' length, calling `py_len()` will throw an error. If you'd like to instead
+#' infer a default length in such cases, you can set the `default` argument
+#' to e.g. `1L`, to treat Python objects without a `__len__` method as having
+#' length one.
 #'
 #' @param x A Python object.
+#'
+#' @param default The default length value to return, in the case that
+#'   the associated Python object has no `__len__` method.
 #'
 #' @return The length of the object, as a numeric value.
 #'
 #' @export
-py_len <- function(x) {
+py_len <- function(x, default = NULL) {
 
   # return 0 if Python not yet available
   if (py_is_null_xptr(x) || !py_available())
     return(0L)
 
   # delegate to C++
-  py_len_impl(x, NULL)
+  py_len_impl(x, default)
 
 }
 

--- a/R/python.R
+++ b/R/python.R
@@ -513,10 +513,11 @@ length.python.builtin.object <- function(x) {
   # do. To reflect this behavior, we treat Python's 'None' as a zero-length
   # object (similar to R's NULL), and treat any other objects without a
   # `__len__` method as though they were scalar objects.
-  if (inherits(x, "python.builtin.NoneType"))
+  types <- c("python.builtin.NoneType", "python.builtin.NotImplementedType")
+  if (inherits(x, types))
     return(0L)
-  else
-    py_len_impl(x, 1L)
+
+  py_len_impl(x, 1L)
 
 }
 

--- a/R/python.R
+++ b/R/python.R
@@ -509,15 +509,9 @@ length.python.builtin.object <- function(x) {
   if (py_is_null_xptr(x) || !py_available())
     return(0L)
 
-  # Not all Python objects have a defined length, but almost all objects in R
-  # do. To reflect this behavior, we treat Python's 'None' as a zero-length
-  # object (similar to R's NULL), and treat any other objects without a
-  # `__len__` method as though they were scalar objects.
-  types <- c("python.builtin.NoneType", "python.builtin.NotImplementedType")
-  if (inherits(x, types))
-    return(0L)
-
-  py_len_impl(x, 1L)
+  # TODO: for now, we declare that all python objects have length 1,
+  # but consider calling the associated `__len__` method in the future
+  1L
 
 }
 

--- a/R/python.R
+++ b/R/python.R
@@ -490,7 +490,8 @@ length.python.builtin.tuple <- function(x) {
 #' @param x A Python object.
 #'
 #' @param default The default length value to return, in the case that
-#'   the associated Python object has no `__len__` method.
+#'   the associated Python object has no `__len__` method. When `NULL`
+#'   (the default), an error is emitted instead.
 #'
 #' @return The length of the object, as a numeric value.
 #'

--- a/man/py_len.Rd
+++ b/man/py_len.Rd
@@ -10,7 +10,8 @@ py_len(x, default = NULL)
 \item{x}{A Python object.}
 
 \item{default}{The default length value to return, in the case that
-the associated Python object has no \verb{__len__} method.}
+the associated Python object has no \verb{__len__} method. When \code{NULL}
+(the default), an error is emitted instead.}
 }
 \value{
 The length of the object, as a numeric value.

--- a/man/py_len.Rd
+++ b/man/py_len.Rd
@@ -4,15 +4,25 @@
 \alias{py_len}
 \title{Length of Python object}
 \usage{
-py_len(x)
+py_len(x, default = NULL)
 }
 \arguments{
 \item{x}{A Python object.}
+
+\item{default}{The default length value to return, in the case that
+the associated Python object has no \verb{__len__} method.}
 }
 \value{
 The length of the object, as a numeric value.
 }
 \description{
-Get the length of a Python object (equivalent to the Python \code{len()}
-built in function).
+Get the length of a Python object. This is equivalent to calling
+the Python builtin \code{len()} function on the object.
+}
+\details{
+Not all Python objects have a defined length. For objects without a defined
+length, calling \code{py_len()} will throw an error. If you'd like to instead
+infer a default length in such cases, you can set the \code{default} argument
+to e.g. \code{1L}, to treat Python objects without a \verb{__len__} method as having
+length one.
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -626,13 +626,14 @@ BEGIN_RCPP
 END_RCPP
 }
 // py_len_impl
-SEXP py_len_impl(PyObjectRef x);
-RcppExport SEXP _reticulate_py_len_impl(SEXP xSEXP) {
+SEXP py_len_impl(PyObjectRef x, SEXP defaultValue);
+RcppExport SEXP _reticulate_py_len_impl(SEXP xSEXP, SEXP defaultValueSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< PyObjectRef >::type x(xSEXP);
-    rcpp_result_gen = Rcpp::wrap(py_len_impl(x));
+    Rcpp::traits::input_parameter< SEXP >::type defaultValue(defaultValueSEXP);
+    rcpp_result_gen = Rcpp::wrap(py_len_impl(x, defaultValue));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -732,7 +733,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_reticulate_r_convert_date", (DL_FUNC) &_reticulate_r_convert_date, 2},
     {"_reticulate_py_set_interrupt_impl", (DL_FUNC) &_reticulate_py_set_interrupt_impl, 0},
     {"_reticulate_py_list_length", (DL_FUNC) &_reticulate_py_list_length, 1},
-    {"_reticulate_py_len_impl", (DL_FUNC) &_reticulate_py_len_impl, 1},
+    {"_reticulate_py_len_impl", (DL_FUNC) &_reticulate_py_len_impl, 2},
     {"_reticulate_readline", (DL_FUNC) &_reticulate_readline, 1},
     {"_reticulate_py_register_interrupt_handler", (DL_FUNC) &_reticulate_py_register_interrupt_handler, 0},
     {"_reticulate_py_clear_error", (DL_FUNC) &_reticulate_py_clear_error, 0},

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -3034,10 +3034,12 @@ SEXP py_len_impl(PyObjectRef x, SEXP defaultValue) {
 
   Py_ssize_t value = PyObject_Size(x);
   if (PyErr_Occurred()) {
-    if (defaultValue == R_NilValue)
+    if (defaultValue == R_NilValue) {
       stop(py_fetch_error());
-    else
+    } else {
+      PyErr_Clear();
       return defaultValue;
+    }
   }
 
   if (value <= static_cast<Py_ssize_t>(INT_MAX))

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -3030,12 +3030,15 @@ SEXP py_list_length(PyObjectRef x) {
 }
 
 // [[Rcpp::export]]
-SEXP py_len_impl(PyObjectRef x) {
+SEXP py_len_impl(PyObjectRef x, SEXP defaultValue) {
 
-  // TODO: do we want to allow errors here?
   Py_ssize_t value = PyObject_Size(x);
-  if (PyErr_Occurred())
-    stop(py_fetch_error());
+  if (PyErr_Occurred()) {
+    if (defaultValue == R_NilValue)
+      stop(py_fetch_error());
+    else
+      return defaultValue;
+  }
 
   if (value <= static_cast<Py_ssize_t>(INT_MAX))
     return Rf_ScalarInteger((int) value);


### PR DESCRIPTION
This PR ensures that `length.python.builtin.object()` always returns a numeric value, in line with what users would normally expect from the `length()` generic.

`py_len()` continues to emit an error for Python objects without a defined length.