### PR TITLE
Feature/pkgdown deploy gha

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,42 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: pkgdown
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: Build site
+        run: Rscript -e 'pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)'
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,8 @@ Description: Interface to 'Python' modules, classes, and functions. When calling
     types. When values are returned from 'Python' to R they are converted back to R
     types. Compatible with all versions of 'Python' >= 2.7.
 License: Apache License 2.0
-URL: https://github.com/rstudio/reticulate
+URL: https://github.com/rstudio/reticulate,
+    https://rstudio.github.io/reticulate
 BugReports: https://github.com/rstudio/reticulate/issues
 SystemRequirements: Python (>= 2.7.0)
 Encoding: UTF-8

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -5,6 +5,9 @@ template:
   params:
     bootswatch: flatly
 
+development:
+  mode: auto
+
 reference:
 
   - title: "Python Execution"
@@ -84,4 +87,3 @@ reference:
       - install_miniconda
       - miniconda_path
       - miniconda_update
-        


### PR DESCRIPTION
+ Add a GitHub Action that builds and deploys pkgdown site to Github Pages
+ Makes the development version of the package docs available at https://rstudio.github.io/reticulate/dev