### PR TITLE
`install_python()` changes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 
 # reticulate 1.24  (UNRELEASED)
 
+- `install_python()` changes:
+  -  gains arguments `create_virtualenv = TRUE, ...`, now creates a virtualenv by default.
+  -  gains the ability to accept python versions with the patch level omitted
+     (The latest patch level is automatically selected).
+  -  new default value: `version = "3.8"`
+
 - `virtualenv_create()` now issues a warning if the requested environment already exists.
 
 # reticulate 1.23

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 # reticulate 1.24  (UNRELEASED)
 
+- `virtualenv_create()` now issues a warning if the requested environment already exists.
+
 # reticulate 1.23
 
 - `use_condaenv()` gains the ability to accept an absolute path to a python binary for `envname`.

--- a/R/install-python.R
+++ b/R/install-python.R
@@ -9,9 +9,13 @@
 #'
 #' ```
 #' library(reticulate)
-#' version <- "3.8.7"
-#' install_python(version = version)
-#' virtualenv_create("my-environment", python_version = version)
+#' version <- "3.8"
+#'
+#' install_python(version = version, envname = "my-environment")
+#' # -- or --
+#' python <- install_python(version = version, create_virtualenv = FALSE)
+#' virtualenv_create("my-environment", python = python)
+#'
 #' use_virtualenv("my-environment")
 #' ```
 #'

--- a/R/virtualenv.R
+++ b/R/virtualenv.R
@@ -87,7 +87,9 @@ virtualenv_create <- function(
 
   # check and see if we already have a virtual environment
   if (virtualenv_exists(path)) {
-    writeLines(paste("virtualenv:", name))
+    warningf(
+      'virtualenv already exists at "%s"\nRun `unlink("%s", recursive = TRUE)` to recreate or supply a different path.',
+      path, path)
     return(invisible(path))
   }
 

--- a/man/install_python.Rd
+++ b/man/install_python.Rd
@@ -4,15 +4,28 @@
 \alias{install_python}
 \title{Install Python}
 \usage{
-install_python(version, list = FALSE, force = FALSE)
+install_python(
+  version = "3.8",
+  list = FALSE,
+  force = FALSE,
+  create_virtualenv = TRUE,
+  ...
+)
 }
 \arguments{
-\item{version}{The version of Python to install.}
+\item{version}{The version of Python to install. If the patch level is
+ommitted, then the latest patch level is automatically selected.}
 
 \item{list}{Boolean; if set, list the set of available Python versions?}
 
 \item{force}{Boolean; force re-installation even if the requested version
 of Python is already installed?}
+
+\item{create_virtualenv}{Boolean; Automatically create a virtualenv with
+the python installation.}
+
+\item{...}{Passed on to \verb{[virtualenv_create()]} if \code{create_virtualenv} is
+\code{TRUE}}
 }
 \description{
 Download and install Python, using the \href{https://github.com/pyenv/pyenv}{pyenv}.

--- a/man/install_python.Rd
+++ b/man/install_python.Rd
@@ -34,9 +34,13 @@ and \href{https://github.com/pyenv-win/pyenv-win}{pyenv-win} projects.
 \details{
 In general, it is recommended that Python virtual environments are created
 using the copies of Python installed by \code{\link[=install_python]{install_python()}}. For example:\preformatted{library(reticulate)
-version <- "3.8.7"
-install_python(version = version)
-virtualenv_create("my-environment", python_version = version)
+version <- "3.8"
+
+install_python(version = version, envname = "my-environment")
+# -- or --
+python <- install_python(version = version, create_virtualenv = FALSE)
+virtualenv_create("my-environment", python = python)
+
 use_virtualenv("my-environment")
 }
 }


### PR DESCRIPTION
- `install_python()` changes:
  -  gains arguments `create_virtualenv = TRUE, ...`, now creates a virtualenv by default.
  -  gains the ability to accept python versions with the patch level omitted
     (The latest patch level is automatically selected).
  -  new default value: `version = "3.8"`

- `virtualenv_create()` now issues a warning if the requested environment already exists.