### PR TITLE
refactor `python_info_condaenv_find()` to handle spaces in file paths when parsing `conda-meta/history`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # reticulate 1.25  (UNRELEASED)
 
+- Exception handling changes (#1154, @t-kalinkowski):
+  - `python_info_condaenv_find()` now handles file paths that contain spaces when parsing the `conda-meta/history` log file.
+
 - `use_python(, required = TRUE)` now issues a warning if the request will be ignored.
 
 - `print()` changes (#1148):

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # reticulate 1.25  (UNRELEASED)
 
-- Exception handling changes (#1154, @t-kalinkowski):
-  - `python_info_condaenv_find()` now handles file paths that contain spaces when parsing the `conda-meta/history` log file.
+- Fixed an issue where reticulate would fail to bind to a conda python if 
+  spaces were present in the file path to the associated conda binary (#1154).
 
 - `use_python(, required = TRUE)` now issues a warning if the request will be ignored.
 

--- a/R/python-tools.R
+++ b/R/python-tools.R
@@ -165,9 +165,7 @@ python_info_condaenv_find <- function(path) {
     return(NULL)
 
   # get path to conda script used
-  line <- gsub(pattern, "", lines[[1]])
-  parts <- strsplit(line, "[[:space:]]+")[[1]]
-  script <- parts[[1]]
+  script <- sub("^#\\s+cmd: (.+)\\s+create\\s+.*", "\\1", lines[[1]])
 
   # on Windows, a wrapper script is recorded in the history,
   # so instead attempt to find the real conda binary


### PR DESCRIPTION
This pull request addresses #1149. 

I have refactored the `python_info_condaenv_find()` method to handle spaces within the file paths returned from the `conda-meta/history` file. This allows me to call `use_condaenv()` on my ArcGIS Pro installation of conda, but this approach should also work for other installations with non-standard file paths. 

Before these changes were made I would see this error:
```r
use_condaenv(condaenv = "arcgispro-py3-clone", conda = "C:/Program Files/ArcGIS/Pro/bin/Python/envs/arcgispro-py3-clone/Scripts/conda.bat", required = T)
use_condaenv(condaenv = "C:/Program Files/ArcGIS/Pro/bin/Python/envs/arcgispro-py3-clone", required = T)

# Error in normalizePath(path.expand(path), winslash, mustWork) : 
#   path[1]="C:/conda.exe": The system cannot find the file specified
```

With the proposed changes, I'm now able to load the correct conda env without any issues:
```r
use_condaenv(condaenv = "arcgispro-py3-clone", conda = "C:/Program Files/ArcGIS/Pro/bin/Python/envs/arcgispro-py3-clone/Scripts/conda.bat", required = T)
use_condaenv(condaenv = "C:/Program Files/ArcGIS/Pro/bin/Python/envs/arcgispro-py3-clone", required = T)
```