### PR TITLE
trace python env management commands

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # reticulate 1.25  (UNRELEASED)
 
+- All commands that create, modify, or delete a Python environment now emit
+  an R message of the system command about to be executed. Affected:
+    virtualenv_{create,install,remove}
+    conda_{create,clone,remove,install,update}
+
 - `install_python()` and `create_virtualenv()` gain the ability to automatically
   select the latest patch of a requested Python version.
   e.g.: `install_python("3.8:latest")`, `create_virtualenv("my-env", version = "3.8:latest")`

--- a/R/conda.R
+++ b/R/conda.R
@@ -226,7 +226,7 @@ conda_create <- function(envname = NULL,
     args <- c(args, "-c", ch)
 
   # invoke conda
-  result <- system2(conda, shQuote(args))
+  result <- system2t(conda, shQuote(args))
   if (result != 0L) {
     fmt <- "Error creating conda environment '%s' [exit code %i]"
     stopf(fmt, envname, result, call. = FALSE)
@@ -252,7 +252,7 @@ conda_create_env <- function(envname, environment, conda) {
     "-f", shQuote(environment)
   )
 
-  result <- system2(conda, args)
+  result <- system2t(conda, args)
   if (result != 0L) {
     fmt <- "Error creating conda environment [exit code %i]"
     stopf(fmt, result)
@@ -287,7 +287,7 @@ conda_clone <- function(envname, ..., clone = "base", conda = "auto") {
   args <- c(args, "--clone", clone)
 
   # invoke conda
-  result <- system2(conda, shQuote(args))
+  result <- system2t(conda, shQuote(args))
   if (result != 0L) {
     fmt <- "Error creating conda environment '%s' [exit code %i]"
     stopf(fmt, envname, result, call. = FALSE)
@@ -359,7 +359,7 @@ conda_remove <- function(envname,
 
   # remove packges (or the entire environment)
   args <- conda_args("remove", envname, packages)
-  result <- system2(conda, shQuote(args))
+  result <- system2t(conda, shQuote(args))
   if (result != 0L) {
     stop("Error ", result, " occurred removing conda environment ", envname,
          call. = FALSE)
@@ -439,7 +439,7 @@ conda_install <- function(envname = NULL,
   # (should be no-op if that copy of Python already installed)
   if (!is.null(python_version)) {
     args <- conda_args("install", envname, python_package)
-    status <- system2(conda, shQuote(args))
+    status <- system2t(conda, shQuote(args))
     if (status != 0L) {
       fmt <- "installation of '%s' into environment '%s' failed [error code %i]"
       msg <- sprintf(fmt, python_package, envname, status)
@@ -476,7 +476,7 @@ conda_install <- function(envname = NULL,
     args <- c(args, "-c", ch)
 
   args <- c(args, python_package, packages)
-  result <- system2(conda, shQuote(args))
+  result <- system2t(conda, shQuote(args))
 
   # check for errors
   if (result != 0L) {
@@ -558,7 +558,7 @@ conda_update <- function(conda = "auto") {
   name <- if ("anaconda" %in% envlist$name) "anaconda" else "conda"
 
   # attempt update
-  system2(conda, c("update", "--prefix", shQuote(prefix), "--yes", name))
+  system2t(conda, c("update", "--prefix", shQuote(prefix), "--yes", name))
 
 }
 
@@ -816,7 +816,7 @@ Run `miniconda_update('%s')` to update conda.", conda)
   else
     in_env <- c("--name", envname)
 
-  system2(conda, c("run", in_env, run_args,
+  system2t(conda, c("run", in_env, run_args,
                    shQuote(cmd), args), ...)
 }
 

--- a/R/pip.R
+++ b/R/pip.R
@@ -45,7 +45,7 @@ pip_install <- function(python,
   }
 
   result <- if (is.null(conda) || identical(conda, FALSE))
-    system2(python, args)
+    system2t(python, args)
   else
     conda_run2(python, args, conda = conda, envname = envname)
 
@@ -63,7 +63,7 @@ pip_uninstall <- function(python, packages) {
 
   # run it
   args <- c("-m", "pip", "uninstall", "--yes", packages)
-  result <- system2(python, args)
+  result <- system2t(python, args)
   if (result != 0L) {
     pkglist <- paste(shQuote(packages), collapse = ", ")
     msg <- paste("Error removing package(s):", pkglist)

--- a/R/utils.R
+++ b/R/utils.R
@@ -393,3 +393,11 @@ debuglog <- function(fmt, ...) {
   msg <- sprintf(fmt, ...)
   cat(msg, file = "/tmp/reticulate.log", sep = "\n", append = TRUE)
 }
+
+system2t <- function(command, args, ...) {
+  # system2, with a trace
+  # mimic bash's set -x usage of a "+" prefix for now
+  # maybe someday take a dep on {cli} and make it prettier
+  message(paste("+", shQuote(command), paste0(args, collapse = " ")))
+  system2(command, args, ...)
+}

--- a/R/virtualenv.R
+++ b/R/virtualenv.R
@@ -131,7 +131,7 @@ virtualenv_create <- function(
   writef("Using Python: %s", python)
   printf("Creating virtual environment %s ... ", shQuote(name))
 
-  result <- system2(python, args)
+  result <- system2t(python, args)
   if (result != 0L) {
     writef("FAILED")
     fmt <- "Error creating virtual environment '%s' [error code %d]"


### PR DESCRIPTION
Tracing python environment management commands for two reasons:
1. Help users self-diagnose issues like, the wrong python or conda being found and arguments being improperly quoted, which should result in fewer issues filed. Then for issues that are filed, we should be able to easily identify the exact system command that's failing.
2. Educate users about what reticulate is doing. This will give newbies a foothold on understanding the mechanics of python environment management, and give experienced users confidence that reticulate is doing the "right thing".