### PR TITLE
Paths used in 'use_python()' are now normalized before being used to configure Python

### DIFF
--- a/R/use_python.R
+++ b/R/use_python.R
@@ -73,6 +73,9 @@ use_python <- function(python, required = NULL) {
   if (required && !file_test("-f", python) && !file_test("-d", python))
     stop("Specified version of python '", python, "' does not exist.")
 
+  # ensure that the python path is normalized as expected
+  python <- normalize_python_path(python)$path
+
   # if required == TRUE and python is already initialized then confirm that we
   # are using the correct version
   if (required && is_python_initialized()) {


### PR DESCRIPTION
I have reported the issue #1167 

In previous versions of reticulate it was possible to call use_python with the directory of the python binary without including the executable. This was tested in Windows. 

In newer versions (at least 1.24) this no longer works. This is due to calling `python_config_impl` with the 'unnormalized' path. Previously, the path has been normalized before proceeding further in the code. 

With this change, the given python path within `use_python` is normalized before working with it. This should restore the previous (undocumented) behavior of `use_python("C:/Users/dummy/Documents/R/win-library/4.1//extdata/python")` which currently prompts an error like:
**Error in system2(command = python, args = shQuote(script), stdout = TRUE, :
'"C:/Users/dummy/Documents/R/win-library/4.1//extdata/python"' not found**

