### PR TITLE
Run CI against several explicit python versions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -12,17 +12,19 @@ jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}
 
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+    name: OS=${{ matrix.config.os }} R=${{ matrix.config.r }} py=${{ matrix.config.python }}
 
     strategy:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'release'}
-          - {os: windows-latest, r: 'release'}
-          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-latest,   r: 'release'}
-          - {os: ubuntu-latest,   r: 'oldrel-1'}
+          - {os: macOS-latest,   r: 'release', python: '3.8'}
+          - {os: windows-latest, r: 'release', python: '3.8'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release', python: '3.8'}
+          - {os: ubuntu-latest,   r: 'oldrel-1', python: '3.8'}
+          - {os: ubuntu-latest,   r: 'release', python: '3.8'}
+          - {os: ubuntu-latest,   r: 'release', python: '3.9'}
+          - {os: ubuntu-latest,   r: 'release', python: '3.10'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -38,6 +40,10 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
+
+      - uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.config.python }}
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:


### PR DESCRIPTION
Follow NEP29[1], the de facto standard of the scientific python ecosystem,
for supported versions, but more backwards compatibility could be added.

1: https://numpy.org/neps/nep-0029-deprecation_policy.html