### PR TITLE
prefer 'activate.bat' on windows conda

### DIFF
--- a/R/conda.R
+++ b/R/conda.R
@@ -843,11 +843,21 @@ conda_run2_windows <-
   if (grepl("[/\\]", envname))
     envname <- normalizePath(envname)
 
+  activate.bat <- normalizePath(file.path(dirname(conda), "activate.bat"),
+                                mustWork = FALSE)
+
+  activate_cmd <-
+    if (file.exists(activate.bat)) {
+      paste("CALL", shQuote(activate.bat), shQuote(envname))
+    } else {
+      paste("CALL", shQuote(conda), "activate", shQuote(envname))
+    }
+
   fi <- tempfile(fileext = ".bat")
   on.exit(unlink(fi))
   writeLines(c(
     if(!echo) "@echo off",
-    paste("CALL", shQuote(conda), "activate", shQuote(envname)),
+    activate_cmd,
     cmd_line
   ), fi)
 


### PR DESCRIPTION
Fix #1189

Not all conda installations have a 'conda.bat' entry point. 
Some Python installations, like the one that ESRI ships with ArcGIS Pro, only have an activate.bat.

This patch finds and prefers 'activate.bat' in `conda_run2` on windows.  

