### PR TITLE
Minor pyenv tweaks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,9 +14,9 @@
 
 - `install_python()` and `create_virtualenv()` gain the ability to automatically
   select the latest patch of a requested Python version.
-  e.g.: `install_python("3.8:latest")`, `create_virtualenv("my-env", version = "3.8:latest")`
+  e.g.: `install_python("3.9:latest")`, `create_virtualenv("my-env", version = "3.9:latest")`
 
-- `install_python()` `version` arg gains default value of `"3.8:latest"`.
+- `install_python()` `version` arg gains default value of `"3.9:latest"`.
   `install_python()` can now be called with no arguments.
 
 - Fixed an issue where reticulate would fail to bind to a conda python

--- a/R/install-python.R
+++ b/R/install-python.R
@@ -9,16 +9,16 @@
 #'
 #' ```
 #' library(reticulate)
-#' version <- "3.8.10"
+#' version <- "3.9.12"
 #' install_python(version)
 #' virtualenv_create("my-environment", version = version)
 #' use_virtualenv("my-environment")
 #'
 #' # There is also support for a ":latest" suffix to select the latest patch release
-#' install_python("3.8:latest") # install latest patch available at python.org
+#' install_python("3.9:latest") # install latest patch available at python.org
 #'
-#' # select the latest 3.8.* patch installed locally
-#' virtualenv_create("my-environment", version = "3.8:latest")
+#' # select the latest 3.9.* patch installed locally
+#' virtualenv_create("my-environment", version = "3.9:latest")
 #' ```
 #'
 #' @param version The version of Python to install.
@@ -30,7 +30,7 @@
 #'
 #' @note On macOS and Linux this will build Python from sources, which may take a few minutes.
 #' @export
-install_python <- function(version = "3.8:latest",
+install_python <- function(version = "3.9:latest",
                            list = FALSE,
                            force = FALSE)
 {

--- a/man/install_python.Rd
+++ b/man/install_python.Rd
@@ -4,7 +4,7 @@
 \alias{install_python}
 \title{Install Python}
 \usage{
-install_python(version = "3.8:latest", list = FALSE, force = FALSE)
+install_python(version = "3.9:latest", list = FALSE, force = FALSE)
 }
 \arguments{
 \item{version}{The version of Python to install.}
@@ -21,16 +21,16 @@ and \href{https://github.com/pyenv-win/pyenv-win}{pyenv-win} projects.
 \details{
 In general, it is recommended that Python virtual environments are created
 using the copies of Python installed by \code{\link[=install_python]{install_python()}}. For example:\preformatted{library(reticulate)
-version <- "3.8.10"
+version <- "3.9.12"
 install_python(version)
 virtualenv_create("my-environment", version = version)
 use_virtualenv("my-environment")
 
 # There is also support for a ":latest" suffix to select the latest patch release
-install_python("3.8:latest") # install latest patch available at python.org
+install_python("3.9:latest") # install latest patch available at python.org
 
-# select the latest 3.8.* patch installed locally
-virtualenv_create("my-environment", version = "3.8:latest")
+# select the latest 3.9.* patch installed locally
+virtualenv_create("my-environment", version = "3.9:latest")
 }
 }
 \note{


### PR DESCRIPTION
+  Run `pyenv update` as part of installing pyenv on windows (the default list of Python versions it ships with is outdated)
+  Better error message if user requests an unavailable version like `install_python("3.13:latest")`
+  Bump default arg in `install_python()` from "3.8:latest" to "3.9:latest", because 3.8 fails to build on M1 Macs.
+  Implement internal utility `pyenv_update()`