### PR TITLE
don't replace `input()` builtin if R is embedded in Python

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -68,6 +68,10 @@ py_clear_error <- function() {
     invisible(.Call(`_reticulate_py_clear_error`))
 }
 
+was_python_initialized_by_reticulate <- function() {
+    .Call(`_reticulate_was_python_initialized_by_reticulate`)
+}
+
 py_initialize <- function(python, libpython, pythonhome, virtualenv_activate, python3, interactive, numpy_load_error) {
     invisible(.Call(`_reticulate_py_initialize`, python, libpython, pythonhome, virtualenv_activate, python3, interactive, numpy_load_error))
 }

--- a/R/python.R
+++ b/R/python.R
@@ -1458,7 +1458,7 @@ py_inject_hooks <- function() {
   }
 
   # override input function
-  if (interactive()) {
+  if (interactive() && was_python_initialized_by_reticulate()) {
     name <- if (is_python3()) "input" else "raw_input"
     builtins[[name]] <- input
   }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -137,6 +137,16 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
+// was_python_initialized_by_reticulate
+bool was_python_initialized_by_reticulate();
+RcppExport SEXP _reticulate_was_python_initialized_by_reticulate() {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    rcpp_result_gen = Rcpp::wrap(was_python_initialized_by_reticulate());
+    return rcpp_result_gen;
+END_RCPP
+}
 // py_initialize
 void py_initialize(const std::string& python, const std::string& libpython, const std::string& pythonhome, const std::string& virtualenv_activate, bool python3, bool interactive, const std::string& numpy_load_error);
 RcppExport SEXP _reticulate_py_initialize(SEXP pythonSEXP, SEXP libpythonSEXP, SEXP pythonhomeSEXP, SEXP virtualenv_activateSEXP, SEXP python3SEXP, SEXP interactiveSEXP, SEXP numpy_load_errorSEXP) {
@@ -694,6 +704,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_reticulate_py_activate_virtualenv", (DL_FUNC) &_reticulate_py_activate_virtualenv, 1},
     {"_reticulate_main_process_python_info", (DL_FUNC) &_reticulate_main_process_python_info, 0},
     {"_reticulate_py_clear_error", (DL_FUNC) &_reticulate_py_clear_error, 0},
+    {"_reticulate_was_python_initialized_by_reticulate", (DL_FUNC) &_reticulate_was_python_initialized_by_reticulate, 0},
     {"_reticulate_py_initialize", (DL_FUNC) &_reticulate_py_initialize, 7},
     {"_reticulate_py_finalize", (DL_FUNC) &_reticulate_py_finalize, 0},
     {"_reticulate_py_is_none", (DL_FUNC) &_reticulate_py_is_none, 1},

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -1998,6 +1998,12 @@ void py_clear_error() {
 }
 
 bool s_is_python_initialized = false;
+bool s_was_python_initialized_by_reticulate = false;
+
+// [[Rcpp::export]]
+bool was_python_initialized_by_reticulate() {
+  return s_was_python_initialized_by_reticulate;
+}
 
 // [[Rcpp::export]]
 void py_initialize(const std::string& python,
@@ -2041,6 +2047,7 @@ void py_initialize(const std::string& python,
 
       // initialize python
       Py_Initialize();
+      s_was_python_initialized_by_reticulate = true;
       const wchar_t *argv[1] = {s_python_v3.c_str()};
       PySys_SetArgv_v3(1, const_cast<wchar_t**>(argv));
 
@@ -2059,6 +2066,7 @@ void py_initialize(const std::string& python,
     if (!Py_IsInitialized()) {
       // initialize python
       Py_Initialize();
+      s_was_python_initialized_by_reticulate = true;
     }
 
     // add rpycall module
@@ -2099,12 +2107,13 @@ void py_initialize(const std::string& python,
 
 // [[Rcpp::export]]
 void py_finalize() {
-
-  // multiple calls to PyFinalize are likely to cause problems so
-  // we comment this out to play better with other packages that include
-  // python embedding code.
-
+  // We shouldn't call PyFinalize() if R is embedded in Python. https://github.com/rpy2/rpy2/issues/872
+  // if(!s_is_python_initialized && !s_was_python_initialized_by_reticulate)
+  //   return;
+  //
   // ::Py_Finalize();
+  // s_is_python_initialized = false;
+  // s_was_python_initialized_by_reticulate = false;
 }
 
 // [[Rcpp::export]]


### PR DESCRIPTION
This patch fixes https://github.com/rpy2/rpy2/issues/872, and is a continuation of #208 / #1188.

Note that `Py_Finalize()` is still commented out, because of a different segfault encountered when exiting the ipython->rpy2->reticulate stack that I didn't fully track down.

This patch fixes the segfault encountered on the default code path when a user launched an interactive session with ipython, initialized reticulate through rpy2, and then exited normally. 