### PR TITLE
Fix documentation error for the `packages` argument

### DIFF
--- a/R/conda.R
+++ b/R/conda.R
@@ -18,8 +18,8 @@
 #'   `c("conda-forge", <other channels>)`.
 #'
 #' @param packages A character vector, indicating package names which should be
-#'   installed or removed. Use `python=<version>` to request the installation
-#'   of a specific version of Python.
+#'   installed or removed. Use \verb{<package>==<version>} to request the installation
+#'   of a specific version of a package.}
 #'
 #' @param environment The path to an environment definition, generated via
 #'   (for example) [conda_export()], or via `conda env export`. When provided,

--- a/man/conda-tools.Rd
+++ b/man/conda-tools.Rd
@@ -71,8 +71,8 @@ See \strong{Finding Conda} and \code{\link[=conda_binary]{conda_binary()}} for m
 \item{envname}{The name of, or path to, a conda environment.}
 
 \item{packages}{A character vector, indicating package names which should be
-installed or removed. Use \verb{python=<version>} to request the installation
-of a specific version of Python.}
+installed or removed. Use \verb{<package>==<version>} to request the installation
+of a specific version of a package.}
 
 \item{...}{Optional arguments, reserved for future expansion.}
 


### PR DESCRIPTION
Documentation for the `packages` argument shows indications to set the Python version instead of a package version.