### PR TITLE
Restore Python 2 compatibility; deprecate Python 2 compatability

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -52,6 +52,9 @@ jobs:
         with:
           python-version: ${{ matrix.config.python }}
 
+      - if: matrix.config.python == '2.7'
+        run: python -m pip install --upgrade --user virtualenv
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: rcmdcheck remotes

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -21,15 +21,17 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'release', python: '3.8'}
-          - {os: windows-latest, r: 'release', python: '3.8'}
-          - {os: ubuntu-latest,   r: 'release', python: '3.8'}
+          - { os: macOS-latest  , r: 'release', python: '3.8' }
+          - { os: windows-latest, r: 'release', python: '3.8' }
+          - { os: ubuntu-latest , r: 'release', python: '3.8' }
 
-          - {os: ubuntu-latest,   r: 'release', python: '3.9'}
-          - {os: ubuntu-latest,   r: 'release', python: '3.10'}
-          - {os: ubuntu-latest,   r: 'oldrel-1', python: '3.8'}
-          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release', python: '3.8'}
-          - {os: ubuntu-latest,   r: 'release', python: '2.7'}
+          - { os: ubuntu-latest, r: 'oldrel-1', python: '3.8' }
+          - { os: ubuntu-latest, r: 'devel'   , python: '3.8', http-user-agent: 'release' }
+
+          - { os: ubuntu-latest, r: 'release', python: '2.7'  }
+          - { os: ubuntu-latest, r: 'release', python: '3.7'  }
+          - { os: ubuntu-latest, r: 'release', python: '3.9'  }
+          - { os: ubuntu-latest, r: 'release', python: '3.10' }
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -24,10 +24,12 @@ jobs:
           - {os: macOS-latest,   r: 'release', python: '3.8'}
           - {os: windows-latest, r: 'release', python: '3.8'}
           - {os: ubuntu-latest,   r: 'release', python: '3.8'}
+
           - {os: ubuntu-latest,   r: 'release', python: '3.9'}
           - {os: ubuntu-latest,   r: 'release', python: '3.10'}
           - {os: ubuntu-latest,   r: 'oldrel-1', python: '3.8'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release', python: '3.8'}
+          - {os: ubuntu-latest,   r: 'release', python: '2.7'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -38,7 +38,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -48,7 +48,7 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.config.python }}
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # reticulate (development version)
 
+- Fixed issue where reticulate failed to bind to python2. (#1241, #1229)
+
+- A warning is now issued when reticulate binds to python2 that python2 
+  support will be removed in an upcoming reticulate release.
+
 - Fixed an issue where `conda_install(pip=TRUE)` would install packages into 
   a user Python library instead of the conda env if the environment variable
   `PIP_USER=true` was set. `py_install()`, `virtualenv_install()`, and 
@@ -7,7 +12,6 @@
   
 - Fixed issue where `py_last_error()` would return unconverted Python objects (#1233)
 
-- Fixed issue where reticulate failed to bind to python2. (#1241, #1229) 
 
 # reticulate 1.25 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
   
 - Fixed issue where `py_last_error()` would return unconverted Python objects (#1233)
 
+- Fixed issue where reticulate failed to bind to python2. (#1241, #1229) 
+
 # reticulate 1.25 
 
 - Fixed an issue where reticulate would fail if R was running embedded under rpy2.

--- a/src/libpython.cpp
+++ b/src/libpython.cpp
@@ -184,7 +184,7 @@ bool LibPython::loadSymbols(bool python3, std::string* pError)
   LOAD_PYTHON_SYMBOL(Py_IncRef)
   LOAD_PYTHON_SYMBOL(Py_DecRef)
   LOAD_PYTHON_SYMBOL(PyObject_Size)
-  LOAD_PYTHON_SYMBOL(PyObject_Type);
+  LOAD_PYTHON_SYMBOL(PyObject_Type)
   LOAD_PYTHON_SYMBOL(PyObject_GetAttr)
   LOAD_PYTHON_SYMBOL(PyObject_HasAttr)
   LOAD_PYTHON_SYMBOL(PyObject_SetAttr)
@@ -211,7 +211,6 @@ bool LibPython::loadSymbols(bool python3, std::string* pError)
   LOAD_PYTHON_SYMBOL(PyErr_BadArgument)
   LOAD_PYTHON_SYMBOL(PyErr_NormalizeException)
   LOAD_PYTHON_SYMBOL(PyErr_ExceptionMatches)
-  LOAD_PYTHON_SYMBOL(PyException_SetTraceback)
   LOAD_PYTHON_SYMBOL(PyErr_GivenExceptionMatches)
   LOAD_PYTHON_SYMBOL(PyObject_Print)
   LOAD_PYTHON_SYMBOL(PyObject_Str)
@@ -279,6 +278,7 @@ bool LibPython::loadSymbols(bool python3, std::string* pError)
     return false;
 
   if (python3) {
+    LOAD_PYTHON_SYMBOL(PyException_SetTraceback)
     LOAD_PYTHON_SYMBOL(Py_GetProgramFullPath)
 
     // Debug versions of Python will provide PyModule_Create2TraceRefs,

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -2018,6 +2018,9 @@ void py_initialize(const std::string& python,
   s_isPython3 = python3;
   s_isInteractive = interactive;
 
+  if(!s_isPython3)
+    warning("Python 2 reached EOL on January 1, 2020. Python 2 compatability be removed in an upcoming reticulate release.");
+
   // load the library
   std::string err;
   if (!libPython().load(libpython, is_python3(), &err))

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -557,7 +557,7 @@ std::string py_fetch_error() {
   PyObject *excType, *excValue, *excTraceback;
   PyErr_Fetch(&excType, &excValue, &excTraceback);  // we now own the PyObjects
   PyErr_NormalizeException(&excType, &excValue, &excTraceback);
-  if (excTraceback != NULL) {
+  if (excTraceback != NULL && s_isPython3) {
     PyException_SetTraceback(excValue, excTraceback);
     Py_DecRef(excTraceback);
   }


### PR DESCRIPTION
- Restores compatibility with python2, after it was removed without ceremony in the last release
- Issue a warning when binding to python2 that this is the last reticulate release with python2 compatibility.

closes: #1241, #1229