### PR TITLE
use brew to install some python build deps if brew is available

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,14 +1,17 @@
 # reticulate (development version)
 
+- Fixed an issue where reticulate would fail to bind to a conda environment on macOS or linux
+  if conda installed a non-POSIX compliant activation script into the conda environment. (#1234)
+
 - Fixed an issue where the python knitr engine would error when printing to
   HTML a constructor of class instances with a `_repr_html_` or `to_html` method
   (e.g., `pandas.DataFrame`; #1249, #1250).
-  
-- Fixed an issue where the python knitr engine would error when printing a 
-  plotly figure to an HTML document in some (head-less) linux environments. 
-  Reticulate now automatically sets 
-  `plotly.io.renderers.default = "plotly_mimetype+notebook"` if plotly 
-  fails to infer a more appropriate default renderer target. 
+
+- Fixed an issue where the python knitr engine would error when printing a
+  plotly figure to an HTML document in some (head-less) linux environments.
+  Reticulate now automatically sets
+  `plotly.io.renderers.default = "plotly_mimetype+notebook"` if plotly
+  fails to infer a more appropriate default renderer target.
 
 - Fixed issue where reticulate failed to bind to python2. (#1241, #1229)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@
 - Fixed an issue where reticulate would fail to bind to a conda environment on macOS or linux
   if conda installed a non-POSIX compliant activation script into the conda environment. (#1234)
 
+- `install_python()` now leverages brew for python build dependencies like
+  openssl@1.1 if brew is already installed and on the PATH, substantially speeding up
+  `install_python()` on macOS systems with brew configured.
+
 - Fixed an issue where the python knitr engine would error when printing to
   HTML a constructor of class instances with a `_repr_html_` or `to_html` method
   (e.g., `pandas.DataFrame`; #1249, #1250).

--- a/R/conda.R
+++ b/R/conda.R
@@ -897,7 +897,7 @@ conda_run2_nix <-
       commands))
 
   writeLines(commands, fi)
-  system2(Sys.which("sh"), fi,
+  system2(Sys.which("bash"), fi,
           stdout = if(identical(intern, FALSE)) "" else intern)
 }
 

--- a/R/pyenv.R
+++ b/R/pyenv.R
@@ -200,6 +200,12 @@ pyenv_bootstrap_unix <- function() {
   owd <- setwd(tempdir())
   on.exit(setwd(owd), add = TRUE)
 
+  # pyenv python builds are substantially faster on macOS if we pre-install
+  # some dependencies (especially openssl@1.1) as pre-built but "untapped kegs"
+  # (i.e., unlinked to somewhere on the PATH but tucked away under $BREW_ROOT/Cellar).
+  if(nzchar(Sys.which("brew")))
+    system("brew install --only-dependencies pyenv python@3.9")
+
   # download the installer
   url <- "https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer"
   name <- basename(url)


### PR DESCRIPTION
@kevinushey I'm admittedly not a very heavy user of brew. Do you see any pitfalls with this approach? 

(pyenv goes specifically looking for brew untapped build deps, and if this fails for any reason, then everything should still work, albeit slower since openssl@1.1 needs to be built from source.)