### PR TITLE
Fix/conda activate

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,14 +1,17 @@
 # reticulate (development version)
 
+- Fixed an issue where reticulate would fail to bind to a conda environment on macOS or linux
+  if conda installed a non-POSIX compliant activation script into the conda environment. (#1234)
+
 - Fixed an issue where the python knitr engine would error when printing to
   HTML a constructor of class instances with a `_repr_html_` or `to_html` method
   (e.g., `pandas.DataFrame`; #1249, #1250).
-  
-- Fixed an issue where the python knitr engine would error when printing a 
-  plotly figure to an HTML document in some (head-less) linux environments. 
-  Reticulate now automatically sets 
-  `plotly.io.renderers.default = "plotly_mimetype+notebook"` if plotly 
-  fails to infer a more appropriate default renderer target. 
+
+- Fixed an issue where the python knitr engine would error when printing a
+  plotly figure to an HTML document in some (head-less) linux environments.
+  Reticulate now automatically sets
+  `plotly.io.renderers.default = "plotly_mimetype+notebook"` if plotly
+  fails to infer a more appropriate default renderer target.
 
 - Fixed issue where reticulate failed to bind to python2. (#1241, #1229)
 

--- a/R/conda.R
+++ b/R/conda.R
@@ -897,7 +897,7 @@ conda_run2_nix <-
       commands))
 
   writeLines(commands, fi)
-  system2(Sys.which("sh"), fi,
+  system2(Sys.which("bash"), fi,
           stdout = if(identical(intern, FALSE)) "" else intern)
 }
 


### PR DESCRIPTION
closes #1243 

Conda activation scripts in an environment's `conda.d` directory start with the shebang `#!/bin/sh` and have a `.sh` file extension suffix, but practice has show that, despite the advertisements, many of the activation scripts are not actually POSIX compliant scripts. Two in recent memory are the conda packages for gnu-bin-utils and base-r.

With this patch, reticulate will now use bash instead of sh as the default shell to activate conda environments on *nix systems.