### PR TITLE
add support for _repr_markdown_ IPython methods

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -65,8 +65,8 @@ jobs:
           remotes::install_local()
           reticulate::virtualenv_create("r-reticulate", Sys.which("python"))
           reticulate::virtualenv_install("r-reticulate",
-            c("docutils", "pandas", "scipy", "matplotlib",
-              "plotly", "psutil", "kaleido"))
+            c("docutils", "pandas", "scipy", "matplotlib", "ipython",
+              "tabulate", "plotly", "psutil", "kaleido"))
           python <- reticulate::virtualenv_python("r-reticulate")
           writeLines(sprintf("RETICULATE_PYTHON=%s", python),
                      Sys.getenv("GITHUB_ENV"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,9 @@
 
 - Fixed issue where `py_last_error()` would return unconverted Python objects (#1233)
 
+- The Knitr engine now supports printing Python objects with
+  `_repr_markdown_` methods. (via quarto,
+  https://github.com/quarto-dev/quarto-cli/issues/1501)
 
 # reticulate 1.25
 

--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -618,6 +618,12 @@ eng_python_autoprint <- function(captured, options, autoshow) {
 
     return("")
 
+  } else if (py_has_method(value, "_repr_markdown_")) {
+
+    data <- as_r_value(value$`_repr_markdown_`())
+    .engine_context$pending_plots$push(knitr::asis_output(data))
+    return("")
+
   } else if (py_has_method(value, "to_html")) {
 
     data <- as_r_value(value$to_html())

--- a/tests/testthat/resources/eng-reticulate-example.Rmd
+++ b/tests/testthat/resources/eng-reticulate-example.Rmd
@@ -170,3 +170,20 @@ import pandas as pd
 pt = pd.DataFrame()
 type(pt)
 ```
+
+`_repr_markdown_()` methods are supported 
+(https://github.com/quarto-dev/quarto-cli/issues/1501):
+
+```{python}
+from IPython.display import Markdown
+from tabulate import tabulate
+table = [["Sun",696000,1989100000],
+         ["Earth",6371,5973.6],
+         ["Moon",1737,73.5],
+         ["Mars",3390,641.85]]
+Markdown(tabulate(
+  table, 
+  headers=["Planet","R (km)", "mass (x 10^29 kg)"],
+  tablefmt="pipe"
+))
+```


### PR DESCRIPTION
This addresses an [issue with quarto users](https://github.com/quarto-dev/quarto-cli/issues/1501) who expect the behavior of Python cells to more closely match those of quarto's Jupyter engine.

I'm happy to add supporting tests/documentation, though I could use some help navigating your expectations on that!

(@kevinushey thanks for the help!)