### PR TITLE
fix conda/ssl/installation error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 - `py_run_file()` now ensures the `__file__` dunder is visible to the
   executing python code. (#1283, #1284)
+  
+- Fixed an issue where `install_miniconda()` and `conda_install()` would error
+  on Windows (#1286, #1287, conda/conda#11795)
 
 # reticulate 1.26
 

--- a/R/conda.R
+++ b/R/conda.R
@@ -101,6 +101,7 @@ conda_list <- function(conda = "auto") {
 
   # resolve conda binary
   conda <- conda_binary(conda)
+  local_conda_paths(conda)
 
   # list envs -- discard stderr as Anaconda may emit warnings that can
   # otherwise be ignored; see e.g. https://github.com/rstudio/reticulate/issues/474
@@ -190,6 +191,7 @@ conda_create <- function(envname = NULL,
 {
   # resolve conda binary
   conda <- conda_binary(conda)
+  local_conda_paths(conda)
 
   # if environment is provided, use it directly
   if (!is.null(environment))
@@ -273,6 +275,7 @@ conda_clone <- function(envname, ..., clone = "base", conda = "auto") {
 
   # resolve conda binary
   conda <- conda_binary(conda)
+  local_conda_paths(conda)
 
   # resolve environment name
   envname <- condaenv_resolve(envname)
@@ -312,6 +315,7 @@ conda_export <- function(envname,
 {
   # resolve parameters
   conda <- conda_binary(conda)
+  local_conda_paths(conda)
   envname <- condaenv_resolve(envname)
 
   # build conda argument list,
@@ -349,6 +353,7 @@ conda_remove <- function(envname,
 {
   # resolve conda binary
   conda <- conda_binary(conda)
+  local_conda_paths(conda)
 
   # resolve environment name
   envname <- condaenv_resolve(envname)
@@ -357,7 +362,7 @@ conda_remove <- function(envname,
   if (is.null(packages))
     packages <- "--all"
 
-  # remove packges (or the entire environment)
+  # remove packages (or the entire environment)
   args <- conda_args("remove", envname, packages)
   result <- system2t(conda, shQuote(args))
   if (result != 0L) {
@@ -400,6 +405,7 @@ conda_install <- function(envname = NULL,
 
   # resolve conda binary
   conda <- conda_binary(conda)
+  local_conda_paths(conda)
 
   # resolve environment name
   envname <- condaenv_resolve(envname)
@@ -538,6 +544,7 @@ conda_exe <- conda_binary
 #' @export
 conda_version <- function(conda = "auto") {
   conda_bin <- conda_binary(conda)
+  local_conda_paths(conda_bin)
   out <- system2(conda_bin, "--version", stdout = TRUE)
 
   # mamba --version gives multi-line output, with the conda version on the last line.
@@ -551,6 +558,7 @@ conda_update <- function(conda = "auto") {
 
   # resolve conda
   conda <- conda_binary(conda)
+  local_conda_paths(conda)
 
   # compute base path
   prefix <- system2(conda, c("info", "--base"), stdout = TRUE)
@@ -755,6 +763,7 @@ is_condaenv <- function(dir) {
 conda_list_packages <- function(envname = NULL, conda = "auto", no_pip = TRUE) {
 
   conda <- conda_binary(conda)
+  local_conda_paths(conda)
   envname <- condaenv_resolve(envname)
 
   # create the environment
@@ -805,6 +814,7 @@ conda_run <- function(cmd, args = c(), conda = "auto", envname = NULL,
   #  - fails if arguments need to be quoted
 
   conda <- conda_binary(conda)
+  local_conda_paths(conda)
   envname <- condaenv_resolve(envname)
 
   if (numeric_conda_version(conda) < "4.9")
@@ -836,6 +846,7 @@ conda_run2_windows <-
            cmd_line = paste(shQuote(cmd), paste(args, collapse = " ")),
            intern = FALSE, echo = !intern) {
   conda <- normalizePath(conda_binary(conda))
+  local_conda_paths(conda)
 
   if (identical(envname, "base"))
     envname <- file.path(dirname(conda), "../..")
@@ -871,6 +882,7 @@ conda_run2_nix <-
            cmd_line = paste(shQuote(cmd), paste(args, collapse = " ")),
            intern = FALSE, echo = !intern) {
   conda <- normalizePath(conda_binary(conda))
+  local_conda_paths(conda)
   activate <- normalizePath(file.path(dirname(conda), "activate"))
 
   if (!identical(envname, "base")) {
@@ -944,4 +956,40 @@ get_python_conda_info <- function(python) {
     root = normalizePath(root, winslash = "/", mustWork = TRUE)
   )
 
+}
+
+
+conda_prefix <- function(conda = "auto") {
+  conda <- normalizePath(conda_binary(conda),
+                         winslash = "/", mustWork = TRUE)
+  if(!is_windows())
+    # PREFIX/bin/conda
+    return(dirname(dirname(conda)))
+
+  # on Windows, conda can be a few places:
+  ## PREFIX/Scripts/conda.exe
+  ## PREFIX/condabin/conda.bat
+  ## PREFIX/conda.exe
+  ## others? maybe under mingw-32/ or Library/ or Tools/?
+  ## we punt and just ask conda
+  system2(conda, c("info", "--base"), stdout = TRUE)
+}
+
+conda_bin_paths <- function(conda = "auto") {
+  prefix <- conda_prefix(conda)
+  paths <- file.path(prefix, c(
+    "condabin",
+    "bin",
+    "Scripts",
+    "Library/bin",
+    "Library/usr/bin",
+    "Library/mingw-w64/bin"
+  ))
+  paths[dir.exists(paths)]
+}
+
+
+local_conda_paths <- function(conda, action = "prefix",
+                              .local_envir = parent.frame()) {
+  withr::local_path(conda_bin_paths(conda), action, .local_envir)
 }

--- a/R/miniconda.R
+++ b/R/miniconda.R
@@ -80,7 +80,8 @@ install_miniconda <- function(path = miniconda_path(),
 #' @export
 miniconda_update <- function(path = miniconda_path()) {
   conda <- miniconda_conda(path)
-  system2(conda, c("update", "--yes", "--name", "base", "conda"))
+  local_conda_paths(conda)
+  system2t(conda, c("update", "--yes", "--name", "base", "conda"))
 }
 
 #' Remove Miniconda


### PR DESCRIPTION
closes #1286

Ensure additional conda directories are on 
the PATH when invoking the conda binary.