### PR TITLE
More explicitly remove problematic PYTHONPATH entries

### DIFF
--- a/inst/config/config.py
+++ b/inst/config/config.py
@@ -39,7 +39,7 @@ config = {
   "Prefix"           : getattr(sys, "prefix", ""),
   "ExecPrefix"       : getattr(sys, "exec_prefix", ""),
   "BaseExecPrefix"   : getattr(sys, "base_exec_prefix", ""),
-  "PythonPath"       : pathsep.join([x for x in sys.path if x !=""]),
+  "PythonPath"       : pathsep.join((x or "." for x in sys.path)),
   "LIBPL"            : sysconfig.get_config_var("LIBPL"),
   "LIBDIR"           : sysconfig.get_config_var("LIBDIR")
 }

--- a/inst/config/config.py
+++ b/inst/config/config.py
@@ -39,7 +39,7 @@ config = {
   "Prefix"           : getattr(sys, "prefix", ""),
   "ExecPrefix"       : getattr(sys, "exec_prefix", ""),
   "BaseExecPrefix"   : getattr(sys, "base_exec_prefix", ""),
-  "PythonPath"       : pathsep.join(sys.path[1:]),
+  "PythonPath"       : pathsep.join([x for x in sys.path if x !=""]),
   "LIBPL"            : sysconfig.get_config_var("LIBPL"),
   "LIBDIR"           : sysconfig.get_config_var("LIBDIR")
 }


### PR DESCRIPTION
sys.path[0] is often an empty string, but that isn't always the case. This fixes a problem I had using a non-standard python interpreter ([spack python](https://spack.readthedocs.io/en/latest/developer_guide.html#cmd-spack-python))