### PR TITLE
document environment removal

### DIFF
--- a/R/conda.R
+++ b/R/conda.R
@@ -19,7 +19,8 @@
 #'
 #' @param packages A character vector, indicating package names which should be
 #'   installed or removed. Use  \verb{<package>==<version>} to request the installation
-#'   of a specific version of a package.
+#'   of a specific version of a package. A `NULL` value for [conda_remove()] 
+#'   will be interpretted to `"--all"`, removing the entire environment.
 #'
 #' @param environment The path to an environment definition, generated via
 #'   (for example) [conda_export()], or via `conda env export`. When provided,


### PR DESCRIPTION
The `conda_remove()` implementation interprets a `packages=NULL` argument as `--all`, removing the environment. This PR documents this important behavior.

https://github.com/rstudio/reticulate/blob/a1d7f7f573f652212bc2c72c39317340e6d8b511/R/conda.R#L362-L363