### PR TITLE
add `miniconda_path` to `use_miniconda`, fix #1308

### DIFF
--- a/R/use_python.R
+++ b/R/use_python.R
@@ -58,6 +58,9 @@
 #'   The path to a `conda` executable. By default, `reticulate` will check the
 #'   `PATH`, as well as other standard locations for Anaconda installations.
 #'
+#' @param miniconda_path
+#'   The path to miniconda. By default, it is [miniconda_path()].
+#' 
 #' @param required
 #'   Is the requested copy of Python required? If `TRUE`, an error will be
 #'   emitted if the requested copy of Python does not exist. Otherwise, the
@@ -230,12 +233,12 @@ use_condaenv <- function(condaenv = NULL, conda = "auto", required = NULL) {
 
 #' @rdname use_python
 #' @export
-use_miniconda <- function(condaenv = NULL, required = NULL) {
+use_miniconda <- function(condaenv = NULL, required = NULL, miniconda_path = miniconda_path()) {
 
   required <- required %||% use_python_required()
 
   # check that Miniconda is installed
-  if (!miniconda_exists()) {
+  if (!miniconda_exists(path = miniconda_path)) {
 
     msg <- paste(
       "Miniconda is not installed.",
@@ -249,7 +252,7 @@ use_miniconda <- function(condaenv = NULL, required = NULL) {
   # use it
   use_condaenv(
     condaenv = condaenv,
-    conda = miniconda_conda(),
+    conda = miniconda_conda(path = miniconda_path),
     required = required
   )
 

--- a/man/use_python.Rd
+++ b/man/use_python.Rd
@@ -16,7 +16,11 @@ use_virtualenv(virtualenv = NULL, required = NULL)
 
 use_condaenv(condaenv = NULL, conda = "auto", required = NULL)
 
-use_miniconda(condaenv = NULL, required = NULL)
+use_miniconda(
+  condaenv = NULL,
+  required = NULL,
+  miniconda_path = miniconda_path()
+)
 }
 \arguments{
 \item{python}{The path to a Python binary.}
@@ -37,6 +41,8 @@ first environment is used and a warning is issued.}
 
 \item{conda}{The path to a \code{conda} executable. By default, \code{reticulate} will check the
 \code{PATH}, as well as other standard locations for Anaconda installations.}
+
+\item{miniconda_path}{The path to miniconda. By default, it is \code{\link[=miniconda_path]{miniconda_path()}}.}
 }
 \description{
 Select the version of Python to be used by \code{reticulate}.


### PR DESCRIPTION
This is a proposed fix to #1308 . The problem is that it introduces a new param `miniconda_path` and default to `miniconda_path()`. For most users who use the default location (or use the envvar `"RETICULATE_MINICONDA_PATH"`), it doesn't matter.

For some cases, it can be useful. (for example, if I want to have another envvar that store the path of another miniconda installation and I don't want to mask `"RETICULATE_MINICONDA_PATH"`).