### PR TITLE
fix RETICULATE_MINICONDA_ENVNAME=base

### DIFF
--- a/R/miniconda.R
+++ b/R/miniconda.R
@@ -304,6 +304,10 @@ miniconda_conda <- function(path = miniconda_path()) {
 
 miniconda_envpath <- function(env = NULL, path = miniconda_path()) {
   env <- env %||% Sys.getenv("RETICULATE_MINICONDA_ENVNAME", unset = "r-reticulate")
+  
+  if(env == 'base')
+    return(path)
+  
   file.path(path, "envs", env)
 }
 


### PR DESCRIPTION
At the moment, when `RETICULATE_MINICONDA_ENVNAME=base` reticulate tries to load `<conda path>/envs/base` and as it does not exists it tries to create it which leads to:
```
+ '/opt/conda/bin/conda' 'create' '--yes' '--prefix' '/opt/conda/envs/base' 'python=3.8' 'numpy' '--quiet' '-c' 'conda-forge'

CondaValueError: 'base' is a reserved environment name

Error: Error creating conda environment '/opt/conda/envs/base' [exit code 1]
```

This is a proposal to fix that case.