### PR TITLE
invoke R functions from Python with `tryCatch()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,13 @@
 # reticulate (development version)
 
+- Fixed issue where `source_python()` (and likely many other entrypoints)
+  would error if reticulate was built with Rcpp 1.0.10. Exception and
+  error handling has been updated to accommodate usage of `R_ProtectUnwind()`.
+  (#1328, #1329).
+
 - Fixed issue where reticulate failed to discover Python 3.11 on Windows. (#1325)
 
-- Fixed issue where reticulate would error by attempting to bind to 
+- Fixed issue where reticulate would error by attempting to bind to
   a cygwin/msys2 installation of Python on Windows (#1325).
 
 # reticulate 1.27

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,6 +1,12 @@
 
 `%||%` <- function(x, y) if (is.null(x)) y else x
 
+
+safe_do_call <- function(fn, args) {
+  tryCatch(list(do.call(fn, args), FALSE),
+           error = function(e) list(e$message, TRUE))
+}
+
 traceback_enabled <- function() {
 
   # if there is specific option set then respect it

--- a/inst/python/rpytools/call.py
+++ b/inst/python/rpytools/call.py
@@ -1,29 +1,25 @@
-
 import rpycall
 
-# NOTE: these are also defined in python.cpp so must be changed in both places
-kErrorKey = "F4B07A71E0ED40469929658827023424"
-kInterruptError = "E04414EDEA17488B93FE2AE30F1F67AF";
 
-def make_python_function(f, name = None):
 
-  def python_function(*args, **kwargs):
-    
-    # call the function
-    res = rpycall.call_r_function(f, *args, **kwargs)
-    
-    # check for an error
-    if isinstance(res, dict) and kErrorKey in res:
-      err = res[kErrorKey]
-      if err == kInterruptError:
-        raise KeyboardInterrupt()
-      else:
-        raise RuntimeError(res[kErrorKey])
-      
-    # otherwise return the result
-    return res
-    
-  if not name is None:
-    python_function.__name__ = name
-    
-  return python_function
+
+def make_python_function(f, name=None):
+    def python_function(*args, **kwargs):
+
+        # call the function
+        value, error = rpycall.call_r_function(f, *args, **kwargs)
+
+        if error:
+            if isinstance(error, str) and error == "KeyboardInterrupt":
+                # Only reachable if a C++ exception was caught in call_r_function()
+                # otherwise error is always a bool()
+                raise KeyboardInterrupt()
+
+            raise RuntimeError(value)
+
+        return value
+
+    if not name is None:
+        python_function.__name__ = name
+
+    return python_function


### PR DESCRIPTION
Rcpp release 1.0.10 turned on use of `R_UnwindProtect()` by default. Previous versions of Rcpp would eval R code with a `tryCatch()`, silently catching errors instead of propagating them back up to the user session. Reticulate was implicitly depending on this behavior in various locations.

With this patch, reticulate explicitly places a `tryCatch()` on the stack when Python is calling back into R, and then reticulate will raise a python Exception if an R error was caught.

closes https://github.com/rstudio/reticulate/issues/1328