### PR TITLE
R wrapper functions with matching Py callable signature

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,8 @@
 # reticulate (development version)
 
 - R functions wrapping Python callables now have formals matching
-  those of the Python function, enabling better autocompletion in
-  more contexts.
+  those of the Python callable signature, enabling better
+  autocompletion in more contexts (#1361).
 
 - The knitr engine now suppresses warnings from python code if
   `warning=FALSE` is set in the chunk options. (quarto-dev/quarto#125, #1358)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 # reticulate (development version)
 
-- The knitr engine now suppresses warnings from python code if 
+- R functions wrapping Python callables now have formals matching
+  those of the Python function, enabling better autocompletion in
+  more contexts.
+
+- The knitr engine now suppresses warnings from python code if
   `warning=FALSE` is set in the chunk options. (quarto-dev/quarto#125, #1358)
 
 - Fixed issue where reticulate's knitr engine would attach comments in a

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -52,8 +52,8 @@ py_is_callable <- function(x) {
     .Call(`_reticulate_py_is_callable`, x)
 }
 
-py_get_formals <- function(func) {
-    .Call(`_reticulate_py_get_formals`, func)
+py_get_formals <- function(callable) {
+    .Call(`_reticulate_py_get_formals`, callable)
 }
 
 r_to_py_impl <- function(object, convert) {

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -97,13 +97,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // py_get_formals
-SEXP py_get_formals(PyObjectRef func);
-RcppExport SEXP _reticulate_py_get_formals(SEXP funcSEXP) {
+SEXP py_get_formals(PyObjectRef callable);
+RcppExport SEXP _reticulate_py_get_formals(SEXP callableSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< PyObjectRef >::type func(funcSEXP);
-    rcpp_result_gen = Rcpp::wrap(py_get_formals(func));
+    Rcpp::traits::input_parameter< PyObjectRef >::type callable(callableSEXP);
+    rcpp_result_gen = Rcpp::wrap(py_get_formals(callable));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/libpython.cpp
+++ b/src/libpython.cpp
@@ -181,6 +181,7 @@ bool LibPython::loadSymbols(bool python3, std::string* pError)
   LOAD_PYTHON_SYMBOL(PyErr_SetInterrupt)
   LOAD_PYTHON_SYMBOL(PyErr_CheckSignals)
   LOAD_PYTHON_SYMBOL(PyExc_KeyboardInterrupt)
+  LOAD_PYTHON_SYMBOL(PyExc_ValueError)
   LOAD_PYTHON_SYMBOL(Py_IncRef)
   LOAD_PYTHON_SYMBOL(Py_DecRef)
   LOAD_PYTHON_SYMBOL(PyObject_Size)
@@ -274,6 +275,7 @@ bool LibPython::loadSymbols(bool python3, std::string* pError)
   LOAD_PYTHON_SYMBOL(PySequence_GetItem)
   LOAD_PYTHON_SYMBOL(PyObject_IsTrue)
   LOAD_PYTHON_SYMBOL(PyCapsule_Import)
+  LOAD_PYTHON_SYMBOL(PyUnicode_AsUTF8)
 
   // PyUnicode_AsEncodedString may have several different names depending on the Python
   // version and the UCS build type

--- a/src/libpython.h
+++ b/src/libpython.h
@@ -143,6 +143,7 @@ LIBPYTHON_EXTERN PyObject* Py_Tuple;
 LIBPYTHON_EXTERN PyObject* Py_Complex;
 LIBPYTHON_EXTERN PyObject* Py_ByteArray;
 LIBPYTHON_EXTERN PyObject* PyExc_KeyboardInterrupt;
+LIBPYTHON_EXTERN PyObject* PyExc_ValueError;
 
 void initialize_type_objects(bool python3);
 
@@ -285,6 +286,8 @@ LIBPYTHON_EXTERN int (*PyBytes_AsStringAndSize)(
   (only possible for 0-terminated
   strings) */
 );
+LIBPYTHON_EXTERN const char* (*PyUnicode_AsUTF8)(PyObject *unicode);
+
 #ifdef _WIN32
 LIBPYTHON_EXTERN PyObject* (*PyUnicode_AsMBCSString)(PyObject *unicode);
 #endif

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -1263,13 +1263,14 @@ SEXP NewList(void) {
 }
 
 /* Add named element to the end of a stretchy list */
-void GrowList(SEXP args, SEXP tag, SEXP dflt) {
-  SEXP tmp;
-  tmp = Rf_cons(dflt, R_NilValue);
+void GrowList(SEXP args_list, SEXP tag, SEXP dflt) {
+  PROTECT(dflt);
+  SEXP tmp = PROTECT(Rf_cons(dflt, R_NilValue));
   SET_TAG(tmp, tag);
 
-  SETCDR(CAR(args), tmp); // set cdr on the last cons-cell
-  SETCAR(args, tmp);      // update pointer to last cons cell
+  SETCDR(CAR(args_list), tmp); // set cdr on the last cons-cell
+  SETCAR(args_list, tmp);      // update pointer to last cons cell
+  UNPROTECT(2);
 }
 
 // [[Rcpp::export]]

--- a/tests/testthat/test-python-formals.R
+++ b/tests/testthat/test-python-formals.R
@@ -28,12 +28,12 @@ test_that("Python signatures convert properly", {
   skip_if(py_version() < "3.3")
 
   expect_formals('a', alist(a = ))
-  expect_formals('a, b=1', alist(a = , b = NULL))
-  expect_formals('a, *, b=1', alist(a = , ... = , b = NULL))
-  expect_formals('a, *args, b=1', alist(a = , ... = , b = NULL))
-  expect_formals('a, b=1, **kw', alist(a = , b = NULL, ... = ))
+  expect_formals('a, b=1', alist(a = , b = 1L))
+  expect_formals('a, *, b=1', alist(a = , ... = , b = 1L))
+  expect_formals('a, *args, b=1', alist(a = , ... = , b = 1L))
+  expect_formals('a, b=1, **kw', alist(a = , b = 1L, ... = ))
   expect_formals('a, *args, **kw', alist(a = , ... = ))
-  expect_formals('a, *args, b=1, **kw', alist(a = , ... = , b = NULL))
+  expect_formals('a, *args, b=1, **kw', alist(a = , ... = , b = 1L))
 
 })
 
@@ -42,10 +42,7 @@ test_that("Errors from e.g. builtins are not propagated", {
   skip_if(py_version() < "3.3")
 
   print <- import_builtins()$print
-  if(py_version() >= "3.11")
-    expect_no_error(py_get_formals(print))
-  else
-    expect_error(py_get_formals(print))
+  expect_no_error(py_get_formals(print))
 })
 
 test_that("The inspect.Parameter signature converts properly", {
@@ -59,7 +56,7 @@ test_that("The inspect.Parameter signature converts properly", {
   fmls <- py_get_formals(Parameter)
   expect_formals(fmls, alist(
     name = , kind = , ... = ,
-    default = NULL, annotation = NULL
+    default = , annotation =
   ))
 
 })


### PR DESCRIPTION
To check that this doesn't have a major impact on conversion times, I did some quick benchmarks by timing how long it takes to convert all callables in the tensorflow module, going down 3 levels of recursion (~22k callables)

```r
Sys.setenv("CUDA_VISIBLE_DEVICES" = "")

library(tensorflow)
library(reticulate)

py_is_callable <- import_builtins()$callable
stack <- fastmap::faststack(22500)

fetch_functions <- function(x, depth = 0, path = character()) {
  nms <- py_list_attributes(x)
  nms <- nms[!startsWith(nms, "_")]
  for(nm in nms) {
    if (depth > 3) return()
    obj <- x[[nm]]

    if (py_is_callable(obj)) {
      obj_ <- list(obj)
      names(obj_) <- paste0(c(path, nm), collapse = ".")
      stack$push(obj_)
    }

    if (inherits(obj, c("python.builtin.module", "python.builtin.type"))) {
      # recurse
      fetch_functions(obj, depth = depth + 1, c(path, nm))
    }
  }
  invisible()
}


invisible(as_tensor(1)) # initialize tensorflow
print(system.time(fetch_functions(tf, path = "tf")))



## with this py_formals branch:
# cold start terminal
#   user  system elapsed
# 11.441   0.031  11.371

# with dev main tensorflow/reticulate
#   user  system elapsed
# 10.131   0.029  10.160

# with cran tensorflow/reticulate
#  user  system elapsed
# 8.142   0.016   8.163
```