### PR TITLE
fix conversion of subclassed dict() and list()

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -67,7 +67,7 @@ jobs:
           reticulate::virtualenv_create("r-reticulate", Sys.which("python"))
           reticulate::virtualenv_install("r-reticulate",
             c("docutils", "pandas", "scipy", "matplotlib", "ipython",
-              "tabulate", "plotly", "psutil", "kaleido"))
+              "tabulate", "plotly", "psutil", "kaleido", "wrapt"))
           python <- reticulate::virtualenv_python("r-reticulate")
           writeLines(sprintf("RETICULATE_PYTHON=%s", python),
                      Sys.getenv("GITHUB_ENV"))

--- a/src/libpython.cpp
+++ b/src/libpython.cpp
@@ -151,6 +151,7 @@ void initialize_type_objects(bool python3) {
   Py_List = Py_BuildValue("[i]", 1024);
   Py_Complex = PyComplex_FromDoubles(0.0, 0.0);
   Py_ByteArray = PyByteArray_FromStringAndSize("a", 1);
+  Py_DictClass = PyObject_Type(Py_Dict);
 }
 
 #define LOAD_PYTHON_SYMBOL_AS(name, as)             \
@@ -264,6 +265,7 @@ bool LibPython::loadSymbols(bool python3, std::string* pError)
   LOAD_PYTHON_SYMBOL(PyObject_CallFunctionObjArgs)
   LOAD_PYTHON_SYMBOL(PyType_IsSubtype)
   LOAD_PYTHON_SYMBOL(PyType_GetFlags)
+  LOAD_PYTHON_SYMBOL(PyMapping_Items)
   LOAD_PYTHON_SYMBOL(PySys_WriteStderr)
   LOAD_PYTHON_SYMBOL(PySys_GetObject)
   LOAD_PYTHON_SYMBOL(PyEval_SetProfile)

--- a/src/libpython.h
+++ b/src/libpython.h
@@ -137,6 +137,7 @@ LIBPYTHON_EXTERN PyObject* Py_Bool;
 LIBPYTHON_EXTERN PyObject* Py_True;
 LIBPYTHON_EXTERN PyObject* Py_False;
 LIBPYTHON_EXTERN PyObject* Py_Dict;
+LIBPYTHON_EXTERN PyObject* Py_DictClass;
 LIBPYTHON_EXTERN PyObject* Py_Float;
 LIBPYTHON_EXTERN PyObject* Py_List;
 LIBPYTHON_EXTERN PyObject* Py_Tuple;
@@ -346,6 +347,7 @@ LIBPYTHON_EXTERN PyObject* (*PyDict_Values)(PyObject *mp);
 LIBPYTHON_EXTERN Py_ssize_t (*PyDict_Size)(PyObject *mp);
 LIBPYTHON_EXTERN PyObject* (*PyDict_Copy)(PyObject *mp);
 
+LIBPYTHON_EXTERN PyObject*  (*PyMapping_Items)(PyObject *o);
 LIBPYTHON_EXTERN PyObject* (*PyInt_FromLong)(long);
 LIBPYTHON_EXTERN long (*PyInt_AsLong)(PyObject *);
 LIBPYTHON_EXTERN PyObject* (*PyLong_FromLong)(long);

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -407,13 +407,16 @@ std::vector<std::string> py_class_names(PyObject* object) {
 
   // call inspect.getmro to get the class and it's bases in
   // method resolution order
-  PyObjectPtr inspect(py_import("inspect"));
-  if (inspect.is_null())
-    throw PythonException(py_fetch_error());
+  static PyObject* getmro = NULL;
+  if (getmro == NULL) {
+    PyObjectPtr inspect(py_import("inspect"));
+    if (inspect.is_null())
+      throw PythonException(py_fetch_error());
 
-  PyObjectPtr getmro(PyObject_GetAttrString(inspect, "getmro"));
-  if (getmro.is_null())
-    throw PythonException(py_fetch_error());
+    getmro = PyObject_GetAttrString(inspect, "getmro");
+    if (getmro == NULL)
+      throw PythonException(py_fetch_error());
+  }
 
   PyObjectPtr classes(PyObject_CallFunctionObjArgs(getmro, classPtr.get(), NULL));
   if (classes.is_null())

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -930,7 +930,7 @@ SEXP py_to_r(PyObject* x, bool convert) {
   }
 
   // list
-  else if (PyList_Check(x)) {
+  else if (PyList_CheckExact(x)) {
 
     Py_ssize_t len = PyList_Size(x);
     int scalarType = scalar_list_type(x);
@@ -973,7 +973,7 @@ SEXP py_to_r(PyObject* x, bool convert) {
   }
 
   // tuple (but don't convert namedtuple as it's often a custom class)
-  else if (PyTuple_Check(x) && !PyObject_HasAttrString(x, "_fields")) {
+  else if (PyTuple_CheckExact(x) && !PyObject_HasAttrString(x, "_fields")) {
     Py_ssize_t len = PyTuple_Size(x);
     Rcpp::List list(len);
     for (Py_ssize_t i = 0; i<len; i++)
@@ -982,7 +982,7 @@ SEXP py_to_r(PyObject* x, bool convert) {
   }
 
   // dict
-  else if (PyDict_Check(x)) {
+  else if (PyDict_CheckExact(x)) {
 
     // copy the dict and allocate
     PyObjectPtr dict(PyDict_Copy(x));
@@ -1195,6 +1195,66 @@ SEXP py_to_r(PyObject* x, bool convert) {
 
     }
 
+  }
+
+  else if (PyList_Check(x)) {
+    // didn't pass PyList_CheckExact(), but does pass PyList_Check()
+    // so it's an object that subclasses list.
+    // (This type of subclassed list is used by tensorflow for lists of layers
+    // attached to a keras model, tensorflow.python.training.tracking.data_structures.List,
+    // https://github.com/rstudio/reticulate/issues/1226 )
+    // if needed, consider changing this check from PyList_Check(x) to either:
+    //  - PySequence_Check(x), which just checks for existence of __getitem__ and __len__ methods,
+    //  - PyObject_IsInstance(x, Py_ListClass) for wrapt.ProxyObject wrapping a list.
+
+    // Since it's a subclassed list.
+    // We can't depend on the the PyList_* API working,
+    // and must instead fallback to the generic PyObject_* API or PySequence_API.
+    // (PyList_*() function do not work for tensorflow.python.training.tracking.data_structures.List)
+    long len = PyObject_Size(x);
+    Rcpp::List list(len);
+    for (long i = 0; i < len; i++) {
+      PyObject *pi = PyLong_FromLong(i);
+      list[i] = py_to_r(PyObject_GetItem(x, pi), convert);
+      Py_DecRef(pi);
+    }
+    return list;
+  }
+
+  else if (PyObject_IsInstance(x, Py_DictClass)) {
+    // This check is kind of slow since it calls back into evaluating Python code instead of
+    // merely consulting the object header, but it is the only reliable way that works
+    // for tensorflow._DictWrapper,
+    // which in actually is a wrapt.ProxyObject pretending to be a dict.
+    // ProxyObject goes to great lenghts to pretend to be the underlying object,
+    // to the point that x.__class__ is __builtins__.dict,
+    // but it fails PyDict_CheckExact(x) and PyDict_Check(x).
+    // Registering a custom S3 r_to_py() method here isn't straighforward either,
+    // since the object presents as a plain dict when inspecting __class__,
+    // despite the fact that none of the PyDict_* C API functions work with it.
+
+    // PyMapping_Items returns a list of (key, value) tuples.
+    PyObjectPtr items(PyMapping_Items(x));
+
+    Py_ssize_t size = PyObject_Size(items);
+    std::vector<std::string> names(size);
+    Rcpp::List list(size);
+
+    for (Py_ssize_t idx = 0; idx < size; idx++) {
+      PyObjectPtr item(PySequence_GetItem(items, idx));
+      PyObject *key = PyTuple_GetItem(item, 0); // borrowed ref
+      PyObject *value = PyTuple_GetItem(item, 1); // borrowed ref
+
+      if (is_python_str(key)) {
+        names[idx] = as_utf8_r_string(key);
+      } else {
+        PyObjectPtr str(PyObject_Str(key));
+        names[idx] = as_utf8_r_string(str);
+      }
+      list[idx] = py_to_r(value, convert);
+    }
+    list.names() = names;
+    return list;
   }
 
   // callable

--- a/tests/testthat/test-python-objects.R
+++ b/tests/testthat/test-python-objects.R
@@ -50,3 +50,53 @@ test_that("py_id() returns unique strings; #1216", {
   expect_false(py_id(py_eval("object()")) == py_id(py_eval("object()")))
   expect_true(py_id(py_eval("object")) == py_id(py_eval("object")))
 })
+
+
+
+
+
+test_that("subclassed lists can be converted", {
+  skip_if_no_python()
+
+  # modeled after tensorflow ListWrapper() class,
+  # automatically applied to all keras and tf modules and models
+  # which may contain trackable resources (tensors)
+  # https://github.com/tensorflow/tensorflow/blob/r2.12/tensorflow/python/trackable/data_structures.py#L452-L456
+  List <- py_run_string("
+from collections.abc import Sequence
+class List(Sequence, list):
+  def __init__(self, *args):
+    self._storage = list(args)
+
+  def __getitem__(self, x):
+    return self._storage[x]
+
+  def __len__(self):
+    return len(self._storage)
+")$List
+
+  expect_identical(List(1,2,3), list(1,2,3))
+
+})
+
+
+test_that("wrapt.ProxyObject dicts can be converted", {
+  skip_if_no_python()
+  skip_if(!py_module_available("wrapt"))
+
+  # something similar to tensorflow _DictWrapper() class
+  # https://github.com/tensorflow/tensorflow/blob/r2.12/tensorflow/python/trackable/data_structures.py#L784
+  Dict <- py_run_string("
+
+import wrapt
+class Dict(wrapt.ObjectProxy):
+  pass
+
+assert isinstance(Dict({}), dict)
+
+")$Dict
+
+  expect_identical(Dict(dict()), structure(list(), names = character(0)))
+  expect_identical(Dict(list("abc" = 1:3)), list("abc" = 1:3))
+
+})


### PR DESCRIPTION
Fixes two issues with TensorFlow, where `dict`s and `list`s assigned as an attribute of a Keras model failed to convert back to an R `list()` when accessed from R. The cause of the issue is that any container assigned to a model get transformed into a more complex object that no longer works with the standard Python C API code for lists and dicts.

This PR is also a slight reversion of #1354, which relaxed the check for lists to from `PyList_CheckExact()` to `PyList_Check()` before passing the object to the `PyList_*` C functions. This goes back to using `PyList_CheckExact()` to make sure an object is safe to pass to `PyList_*` (and similar for `dict`s).