### PR TITLE
Fixes to avoid attaching a truncated `r_trace` to exceptions

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -697,7 +697,6 @@ python_config <- function(python,
   # get the full textual version and the numeric version, check for anaconda
   version_string <- config$Version
   version <- config$VersionNumber
-  conda <- grepl("conda", version_string, ignore.case = TRUE)
   anaconda <- grepl("anaconda|continuum", version_string, ignore.case = TRUE)
   architecture <- config$Architecture
 
@@ -821,7 +820,7 @@ python_config <- function(python,
     version              = version,
     architecture         = architecture,
     anaconda             = anaconda,
-    conda                = conda,
+    conda                = config$IsConda,
     numpy                = numpy,
     required_module      = required_module,
     required_module_path = required_module_path,

--- a/R/python.R
+++ b/R/python.R
@@ -1737,6 +1737,8 @@ make_filepaths_clickable <- function(formatted_python_traceback) {
   # for the previous approach
 
   x <- strsplit(formatted_python_traceback, "\n", fixed = TRUE)[[1L]]
+  if (!length(x))
+    return(formatted_python_traceback)
   m <- regexec('File "([^"]+)", line ([0-9]+), in', x, perl = TRUE)
 
   new <- lapply(regmatches(x, m), function(match) {
@@ -1755,6 +1757,7 @@ make_filepaths_clickable <- function(formatted_python_traceback) {
     if(identical(as.vector(match_pos), -1L))
       return(match_pos)
     out <- match_pos[2] # only match filepath
+    # TODO, make the clickable target bigger, include ", line nn" in link.
     attr(out, "match.length") <- attr(match_pos, "match.length")[2]
     out
   })

--- a/R/python.R
+++ b/R/python.R
@@ -1720,7 +1720,7 @@ py_last_error <- function(exception) {
   )
   out$r_call <- conditionCall(e)
   out$r_class <- as_r_value(py_get_attr(e, "r_class", TRUE)) %||% class(e)
-  out$r_trace <- py_get_attr(e, "r_trace", TRUE)
+  out$r_trace <- py_get_attr(e, "r_trace", TRUE) %||% .globals$last_r_trace
   out <- lapply(out, as_r_value)
   attr(out, "exception") <- e
   class(out) <- "py_error"

--- a/R/python.R
+++ b/R/python.R
@@ -1788,7 +1788,7 @@ print.py_error <- function(x, ...) {
 
 cat_h1 <- function(x) {
   if(requireNamespace("cli", quietly = TRUE)) {
-    cli::cli_h1(x)
+    cli::cli_h1(x, .envir = NULL)
   } else {
     cat("--- ", x, "\n", sep = "")
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,69 +1,71 @@
 
 `%||%` <- function(x, y) if (is.null(x)) y else x
 
-get_r_trace <- function(maybe_use_cached = FALSE, trim_tail = 1) {
-  # this function, `get_r_trace()`, can get called repeatedly as a stack is being
-  # unwound, at each transition between r -> py frames if python 'lost' the r_trace attr
-  # as part of handling the exceptoin. Here we make sure we
-  # don't return a truncated version of the same trace if this function is being called
-  # as a stack is unwinding due to an exception propogating.
+get_r_trace <- function(maybe_use_cached = FALSE, trim_tail = 1L) {
+  # this function, `get_r_trace()`, can get called repeatedly as a stack is
+  # being unwound, at each transition between r -> py frames if python 'lost'
+  # the r_trace attr as part of handling the exception. Here we make sure we
+  # don't return a truncated version of the same trace if this function is being
+  # called as a stack is unwinding due to an exception propogating.
 
-  # note, an earlier approach to capturing the R trace  saved a py_capsule() of
-  # the r_trace as an attribute of the python exception, allowing it to traverse
-  # the r<->py boundary during stack unwinding. This approach ran into two
-  # issues:
+  # note, Exceptions typically have r_trace and r_call attrs set on creation,
+  # but those can be lost or discarded by python code. There are two
+  # common scenarios where the r_trace attr is missing after raising the
+  # exception in python and then recatching it in R as the stack is unwound:
 
-  # 1: statements in python like `raise from` would nestle the actual r_trace
-  # under a chain of `__context__` attributes. This was cumbersome, but easily
-  # solvable by walking the chain of `__context__` attributes and copying the
-  # original r_trace over to the head of the exception chain.
+  # 1: statements in python like `raise from` will nestle the exception
+  # containing the r_trace into chain of `__context__` attributes. This is
+  # scenario handled in C++ py_fetch_error() by walking the chain of
+  # `__context__` attributes and copying the original r_trace over to the head
+  # of the exception chain.
 
-  # 2: tensorflow.autograph, **completely discards the original exception** when
-  # transforming a function, replacing it with a de-novo constructed exception
-  # that contains a half-hearted text summary + pre-formatted python traceback
-  # contained in the new exception object it passes. This means that if we
-  # create an exception object here and then `raise` it in python from the
-  # wrapper created by rpytools.call, when we encounter a propogating exception at the
-  # next r<->py boundry as the stack is being unwound, it is a *different*
-  # exception (new memory address, potentially different type(), none of the
-  # original attributes, with no way to recover the original attributes we want,
-  # like r_trace). This means that attaching the r_trace to the python exception
-  # and passing it through the python runtime is not going to work (at least
-  # with with tf.autograph, or things that use it like keras. Probably other
-  # approaches that involve rewriting or modifying python ast like numba and
-  # friends will fail similarly).
+  # 2: tensorflow.autograph, **completely discards the original exception,
+  # clears the error, then raises a new exception** when transforming a
+  # function. The new exception raised is a de-novo constructed exception that
+  # containing a half-hearted text summary + pre-formatted python traceback of
+  # the original exception. This means that if we create an exception object
+  # here with an r_trace attr, and then `raise` it in python from the wrapper
+  # created by rpytools.call, when we next encounter a propogating exception at
+  # the next r<->py boundry as the stack is being unwound, it is a
+  # *different* exception (new memory address, potentially different type(),
+  # none of the original attributes, with no way to recover the original
+  # attributes we want, like r_trace). This means that attaching the r_trace to
+  # the python exception and passing it through the python runtime cannot be
+  # relied on. (at least not with with tf.autograph, or things that use it like
+  # keras. Probably other approaches that involve rewriting or modifying python
+  # ast like numba and friends will fail similarly).
 
-  # Hence, this approach, where, to avoid giving arbitrary python code an
-  # opportunity to lose the r_trace, we cache the r_trace in R, and then try to
-  # be smart about pairing the R trace with the correct python exception when
-  # presenting the error to the user. Note, pairing an r trace with the correct
-  # exception is tricky and bound to fail in edge cases too, but w.r.t.
-  # tradeoffs, the failure mode will be more forgiving; the user will be
-  # presented with an r_trace that is too long rather than too short.
+  # Hence, this approach, where, to mitigate the scenario where arbitrary python
+  # code lost the r_trace, we cache the r_trace in R, and then try to be smart
+  # about pairing the R trace with the correct python exception when presenting
+  # the error to the user. Note, pairing an r trace with the correct exception
+  # is tricky and bound to fail in edge cases too, but w.r.t. tradeoffs, the
+  # failure mode will be more forgiving; the user will be presented with an
+  # r_trace that is too long rather than too short.
 
   # (rlang traces are dataframes.)
   t <- rlang::trace_back() # bottom=2 to omit this `save_r_trace()` frame
-  t <- t[1:(nrow(t) - trim_tail), ] # https://github.com/r-lib/rlang/issues/1620
+  t <- t[1L:(nrow(t) - trim_tail), ] # https://github.com/r-lib/rlang/issues/1620
 
-  ## the rlang trace contains calls mangled for pretty printing.
-  ## Unfortunately, the mangling is too aggressive, the actual call is frequently needed
-  ## to track down where an error occurred.
+  ## the rlang trace contains calls mangled for pretty printing. Unfortunately,
+  ## the mangling is too aggressive, the actual call is frequently needed to
+  ## track down where an error occurred.
   t$full_call <- sys.calls()[seq_len(nrow(t))]
 
   # Drop reticulate internal frames that are not useful to the user
   ## (this works, except [ method for traces does not adjust the parent
   ## correctly when slicing out frames where parent == 0, and
   ## then the tree that gets printed is not useful.
-  ## TODO: file an issue with rlang
+  ## TODO: file an issue with rlang)
   # i <- 1L
   # while(i < nrow(t)) {
+  #   if(identical(t$call[[i]][[1L]], quote(call_r_function))) {
   #     # drop frames:
   #     # withRestarts(withCallingHandlers(return(list(do.call(fn, c(args, named_args)), NULL)), python.builtin.BaseException = function(e) {     r_tra…
   #     # withOneRestart(expr, restarts[[1L]])
   #     # doWithOneRestart(return(expr), restart)
   #     # withCallingHandlers(return(list(do.call(fn, c(args, named_args)), NULL)), python.builtin.BaseException = function(e) {     r_trace <- py_get_…
   #     # do.call(fn, c(args, named_args))
-  #   if(identical(t$call[[i]][[1L]], quote(call_r_function))) {
   #     i <- i + 1L
   #     t <- t[-seq.int(from = i, length.out = 5L), ]
   #   }
@@ -112,8 +114,7 @@ call_r_function <- function(fn, args, named_args) {
       return(list(do.call(fn, c(args, named_args)), NULL)),
 
       python.builtin.BaseException = function(e) {
-        # we're throwing a python exception
-        # check if we're rethrowing an exception that we've already seen
+        # check if rethrowing an exception that we've already seen
         # and if so, make sure the r_trace attr is still present
         r_trace <- as_r_value(py_get_attr(e, "r_trace", TRUE))
         if(is.null(r_trace)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -99,12 +99,6 @@ get_r_trace <- function(maybe_use_cached = FALSE, trim_tail = 1L) {
   invisible(.globals$last_r_trace)
 }
 
-printtrace <- function(x) {
-  tibble::as_tibble(x) |>
-    dplyr::mutate(call2 = sapply(call, deparse1)) |>
-    print(n = Inf)
-}
-
 
 call_r_function <- function(fn, args, named_args) {
   withRestarts(

--- a/inst/config/config.py
+++ b/inst/config/config.py
@@ -44,6 +44,14 @@ config = {
   "LIBDIR"           : sysconfig.get_config_var("LIBDIR")
 }
 
+# detect if this is a conda managed python
+# https://stackoverflow.com/a/21282816/5128728
+if sys.version_info >= (3, 7):
+  is_conda = os.path.exists(os.path.join(sys.prefix, 'conda-meta'))
+else:
+  is_conda = 'conda' in sys.version
+config['IsConda'] = is_conda
+
 # Read numpy configuration (if available)
 try:
   import numpy


### PR DESCRIPTION
As a stack with multiple r->py->r->py frames is unwinding due to an exception propagating, the python runtime can move or discard the attrs attached to the exception object. This PR addresses two scenarios where the original `r_trace` attr is no longer attached to the exception we get back from Python. 

1.  A new python exception is raised while the previous error is still propagating. Here, the original exception is still available under `__context__`.
2.  A new python exception is raised after the previous error is caught and cleared.

Without this PR, a truncated r_trace containing only a fraction of the full stack would be attached to the exception. Both these scenarios were encountered in keras/tensorflow.

Also, included is a minor fix for identifying conda python from `python_config()`. Beginning with python 3.7, the previous way of detecting if Python was a conda python no longer works.