### PR TITLE
Fix of Error in normalizePath(conda, winslash = "/", mustWork = TRUE)

### DIFF
--- a/R/python-tools.R
+++ b/R/python-tools.R
@@ -179,8 +179,7 @@ python_info_condaenv_find <- function(path) {
     return(NULL)
 
   # get path to conda script used
-  script <- gsub("^#\\s+cmd: ", "", lines[[1]])
-  script <- gsub(pattern = "\\s.+$", replacement = "", script)
+  script <- sub("^#\\s+cmd: (.+)\\s+(create|rename)\\s+.*", "\\1", lines[[1]])
 
   # on Windows, a wrapper script is recorded in the history,
   # so instead attempt to find the real conda binary

--- a/R/python-tools.R
+++ b/R/python-tools.R
@@ -179,7 +179,8 @@ python_info_condaenv_find <- function(path) {
     return(NULL)
 
   # get path to conda script used
-  script <- sub("^#\\s+cmd: (.+)\\s+(create|install)\\s+.*", "\\1", lines[[1]])
+  script <- gsub("^#\\s+cmd: ", "", lines[[1]])
+  script <- gsub(pattern = "\\s.+$", replacement = "", script)
 
   # on Windows, a wrapper script is recorded in the history,
   # so instead attempt to find the real conda binary

--- a/R/python-tools.R
+++ b/R/python-tools.R
@@ -179,7 +179,7 @@ python_info_condaenv_find <- function(path) {
     return(NULL)
 
   # get path to conda script used
-  script <- sub("^#\\s+cmd: (.+)\\s+create\\s+.*", "\\1", lines[[1]])
+  script <- sub("^#\\s+cmd: (.+)\\s+(create|install)\\s+.*", "\\1", lines[[1]])
 
   # on Windows, a wrapper script is recorded in the history,
   # so instead attempt to find the real conda binary


### PR DESCRIPTION
The regex `script <- sub("^#\\s+cmd: (.+)\\s+create\\s+.*", "\\1",  lines[[1]])` failed to get the right path.

I create this env with "rename": `# cmd: /home/gaoch/anaconda3/bin/conda rename --name tensorflow2 tensorflow`. So, in my computer, there is no `conda create` history; and maybe the `lines[[1]]` is not `conda create` command in some other situations.

Therefore, I suggest to edit this regex to fix this issue.

This works for me, and should be also useful for similar errors.