### PR TITLE
address use of micromamba during initialization see #1378 and #1176

### DIFF
--- a/R/use_python.R
+++ b/R/use_python.R
@@ -184,6 +184,10 @@ use_condaenv <- function(condaenv = NULL, conda = "auto", required = NULL) {
   condaenv <- condaenv_resolve(condaenv)
   if (grepl("[/\\]", condaenv) && is_condaenv(condaenv)) {
     python <- conda_python(condaenv)
+    # Force use of conda_python when using micromamba.
+    .globals$micromamba <- NULL
+    if (grepl("^(micromamba)", basename(conda))) 
+      .globals$micromamba <- conda
     use_python(python, required = required)
     return(invisible(NULL))
   }


### PR DESCRIPTION
@t-kalinowski 
This is a proposed solution for handling micromamba called by using `use_condaenv("~/path_to_env", "~/pathto_micromamba/micromamba")` followed by `source_python('mypython.py')`. Addresses #1378 and #1176 I introduced a global and addressed errors during initialization. Tried to minimize behavior changes. I don't have a windows machine to test this more extensively on. There might still be changes needed for conda_run2_windows().
Best,
Zia
