### PR TITLE
MRG: First draft of jupyter_compat mode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,21 +1,25 @@
 # reticulate (development version)
 
 - New optional feature: Reticulate now accepts a new option `jupyter_compat`
-  set to `FALSE` by default, that changes the default display behavior of
-  Reticulate chunks, to better match the behavior of Jupyter.  In the
-  Reticulate default, each standalone code expression in the code chunk that
-  does not end in a semi-colon, generates display of the expression output. For
-  Matplotlib plots, an explicit `plt.show()` generates the figure, but
-  otherwise, the chunk (by default) only generates a figure if the last line in
-  the chunk is an expression returning a recognized Matplotlib object, and
-  without a semi-colon.  With `jupyter_compat=TRUE`, a standalone expression
-  returning a Matplotlib object, anywhere in the chunk, will cause the plot to
-  be displayed automatically after the chunk.  No expression in the chunk will
+  set to `FALSE` by default, that changes the default expression output display
+  behavior of Reticulate chunks, to better match the behavior of Jupyter.  In
+  the Reticulate default, each standalone code expression in the code chunk
+  that does not end in a semi-colon, generates display of the expression
+  output. With the `jupyter_compat` option set, no expression in the chunk will
   generate output, except if there is a standalone expression as the last code
-  statement in the chunk, and that expression does not have a semicolon
-  — a semicolon suppresses the output, as it does for the default behavior.
-  See [PR](https://github.com/rstudio/reticulate/pull/1394) and [original
-  issue](https://github.com/rstudio/reticulate/issues/1391).
+  statement in the chunk, and that expression does not have a semicolon.
+  A semicolon always suppresses the expression output, for the default and
+  `jupyter_compat` case. See
+  [PR](https://github.com/rstudio/reticulate/pull/1394) and [original
+  issue](https://github.com/rstudio/reticulate/issues/1391) for discussion for
+  this and the next item.
+
+- Behavior change: Previously, a Matplotlib plot would only be automatically
+  displayed (without `plt.show()`) if there was a final standalone expression
+  returning a Matplotlib object, and that expression did not have a final
+  semicolon.  With this update, any standalone expression returning
+  a Matplotlib object, with or without a semicolon, will cause chunk to display
+  the plot automatically.  See above for discussion.
 
 - Fix: the knitr engine now automatically calls `plt.show()` for matplotlib 
   bar plots, like it does for other matplotlib plot types (#1391). 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,20 @@
 # reticulate (development version)
 
+- New optional feature: Reticulate now accepts a new option `jupyter_compat`
+  set to `FALSE` by default, that changes the default display behavior of
+  Reticulate chunks, to better match the behavior of Jupyter.  In the
+  Reticulate default, each standalone code expression in the code chunk that
+  does not end in a semi-colon, generates display of the expression output. For
+  Matplotlib plots, an explicit `plt.show()` generates the figure, but
+  otherwise, the chunk (by default) only generates a figure if the last line in
+  the chunk is an expression returning a recognized Matplotlib object, and
+  without a semi-colon.  With `jupyter_compat=TRUE`, a standalone expression
+  returning a Matplotlib object, anywhere in the chunk, will cause the plot to
+  be displayed automatically after the chunk.  No expression in the chunk will
+  generate output, except if there is a standalone expression as the last code
+  statement in the chunk, and that expression does not have a semicolon
+  — a semicolon suppresses the output, as it does for the default behavior.
+
 - Fix: the knitr engine now automatically calls `plt.show()` for matplotlib 
   bar plots, like it does for other matplotlib plot types (#1391). 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
   generate output, except if there is a standalone expression as the last code
   statement in the chunk, and that expression does not have a semicolon
   — a semicolon suppresses the output, as it does for the default behavior.
+  See [PR](https://github.com/rstudio/reticulate/pull/1394) and [original
+  issue](https://github.com/rstudio/reticulate/issues/1391).
 
 - Fix: the knitr engine now automatically calls `plt.show()` for matplotlib 
   bar plots, like it does for other matplotlib plot types (#1391). 

--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -144,6 +144,11 @@ eng_python <- function(options) {
     ranges <- mapply(c, starts, ends, SIMPLIFY = FALSE)
   }
 
+  # Stash some options.
+  is_hold <- identical(options$results, "hold")
+  is_include <- isTRUE(options$include)
+  jupyter_compat <- isTRUE(options$jupyter_compat)
+
   # line index from which source should be emitted
   pending_source_index <- 1
 
@@ -155,6 +160,9 @@ eng_python <- function(options) {
 
   # 'held' outputs, to be appended at the end (for results = "hold")
   held_outputs <- stack()
+
+  # Outputs to be appended to; these depend on the "hold" option.
+  outputs_target <- if (is_hold) held_outputs else outputs
 
   # synchronize state R -> Python
   eng_python_synchronize_before()
@@ -176,11 +184,14 @@ eng_python <- function(options) {
     }, add = TRUE)
   }
 
+  # Flag to signal plt command called, but not yet shown.
+  .engine_context$matplotlib_pending_show <- FALSE
 
   for (i in seq_along(ranges)) {
 
     # extract range
     range <- ranges[[i]]
+    last_range <- i == length(ranges)
 
     # extract code to be run
     snippet <- extract(code, range)
@@ -189,8 +200,12 @@ eng_python <- function(options) {
     py_compile_eval("'__reticulate_placeholder__'")
     .engine_context$matplotlib_show_was_called <- FALSE
 
-    # use trailing semicolon to suppress output of return value
-    suppress <- grepl(";\\s*$", snippet)
+    # In standard mode, calculate output by default, but use trailing semicolon
+    # to suppress output and check of return value, including plot.  In
+    # jupyter_compat mode, always check output, including plot, but drop
+    # output further down, if required.
+    end_semicolon <- grepl(";\\s*$", snippet)
+    suppress <- if (jupyter_compat) FALSE else end_semicolon
     compile_mode <- if (suppress) "exec" else "single"
 
     # run code and capture output
@@ -199,12 +214,16 @@ eng_python <- function(options) {
     else
       py_compile_eval(snippet, compile_mode)
 
-    # handle matplotlib output
+    # handle matplotlib and other plot output
     captured <- eng_python_autoprint(
       captured = captured,
       options  = options,
-      autoshow = i == length(ranges)
+      autoshow = (last_range & !jupyter_compat)
     )
+
+    # For Jupyter-compat mode, do not show output by default, unless this is
+    # the last code line, in which case, show if no semicolon.
+    captured <- if (jupyter_compat & (!last_range | end_semicolon)) "" else captured
 
     # emit outputs if we have any
     has_outputs <-
@@ -214,7 +233,7 @@ eng_python <- function(options) {
     if (has_outputs) {
 
       # append pending source to outputs (respecting 'echo' option)
-      if (!identical(options$echo, FALSE) && !identical(options$results, "hold")) {
+      if (!identical(options$echo, FALSE) && !is_hold) {
         extracted <- extract(code, c(pending_source_index, range[2]))
         if(!identical(options$collapse, TRUE) &&
            identical(options$strip.white, TRUE)) {
@@ -227,34 +246,15 @@ eng_python <- function(options) {
       }
 
       # append captured outputs (respecting 'include' option)
-      if (isTRUE(options$include)) {
+      if (is_include) {
+        # append captured output
+        if (!identical(captured, ""))
+          outputs_target$push(captured)
 
-        if (identical(options$results, "hold")) {
-
-          # append captured output
-          if (!identical(captured, ""))
-            held_outputs$push(captured)
-
-          # append captured images / figures
-          plots <- .engine_context$pending_plots$data()
-          for (plot in plots)
-            held_outputs$push(plot)
-          .engine_context$pending_plots$clear()
-
-        } else {
-
-          # append captured output
-          if (!identical(captured, ""))
-            outputs$push(captured)
-
-          # append captured images / figures
-          plots <- .engine_context$pending_plots$data()
-          for (plot in plots)
-            outputs$push(plot)
-          .engine_context$pending_plots$clear()
-
-        }
-
+        # append captured images / figures
+        for (plot in .engine_context$pending_plots$data())
+          outputs_target$push(plot)
+        .engine_context$pending_plots$clear()
       }
 
       # update pending source range
@@ -282,8 +282,15 @@ eng_python <- function(options) {
     outputs$push(output)
   }
 
+  if (.engine_context$matplotlib_pending_show & is_include) {
+    plt <- import("matplotlib.pyplot", convert = TRUE)
+    plt$show()
+    for (plot in .engine_context$pending_plots$data())
+      outputs_target$push(plot)
+  }
+
   # if we were using held outputs, we just inject the source in now
-  if (identical(options$results, "hold")) {
+  if (is_hold) {
     output <- structure(list(src = code), class = "source")
     outputs$push(output)
   }
@@ -456,6 +463,7 @@ eng_python_initialize_matplotlib <- function(options, envir) {
   plt$show <- function(...) {
 
     .engine_context$matplotlib_show_was_called <- TRUE
+    .engine_context$matplotlib_pending_show = FALSE
 
     # get current chunk options
     options <- knitr::opts_current$get()
@@ -613,6 +621,8 @@ eng_python_autoprint <- function(captured, options, autoshow) {
     if (autoshow && !.engine_context$matplotlib_show_was_called) {
       plt <- import("matplotlib.pyplot", convert = TRUE)
       plt$show()
+    } else if (isTRUE(options$jupyter_compat)) {
+      .engine_context$matplotlib_pending_show <- TRUE
     }
 
     return("")


### PR DESCRIPTION
This is a first attempt to replicate the default Jupyter behavior with
Reticulate.

That is:

* Always display plots
* Do not display results of code expressions unless at last code line.
* Display result of final expression unless suppressed with ;

See: gh-1391