### PR TITLE
Add `prefetch` arg to `py_iterator()`

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -27,8 +27,8 @@ jobs:
 
           - { os: ubuntu-latest, r: 'oldrel-1', python: '3.9' }
           - { os: ubuntu-latest, r: 'oldrel-2', python: '3.9' }
-          - { os: ubuntu-latest, r: '3.6',      python: '3.8' }
-          - { os: ubuntu-latest, r: '3.5',      python: '3.6' }
+          - { os: ubuntu-20.04,  r: '3.6',      python: '3.8' }
+          - { os: ubuntu-20.04,  r: '3.5',      python: '3.6' }
           # - { os: ubuntu-latest, r: 'devel'   , python: '3.8', http-user-agent: 'release' }
 
           - { os: ubuntu-latest, r: 'release', python: '3.7'  }

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,8 @@
 # reticulate (development version)
 
 -   `py_iterator()` gains a `prefetch` argument, primarily to avoid deadlocks
-    in situations where a background thread is attempting to use the iterator 
-    while the main thread is fully blocked (as encountered in TensorFlow).
+    where the main thread is blocked, waiting for the iterator, which is waiting
+    to run on the main thread, as encountered in TensorFlow/Keras. (#1405).
 
 -   The knitr engine gains a `jupyter_compat` option, enabling
     reticulate to better match the behavior of Jupyter. When this chunk

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # reticulate (development version)
 
+-   `py_iterator()` gains a `prefetch` argument, primarily to avoid deadlocks
+    in situations where a background thread is attempting to use the iterator 
+    while the main thread is fully blocked (as encountered in TensorFlow).
+
 -   The knitr engine gains a `jupyter_compat` option, enabling
     reticulate to better match the behavior of Jupyter. When this chunk
     option is set to `TRUE`, only the return value from the last

--- a/inst/python/rpytools/generator.py
+++ b/inst/python/rpytools/generator.py
@@ -1,50 +1,80 @@
-
 import rpycall
 import threading
 
 import sys
-is_py2 = sys.version[0] == '2'
+
+is_py2 = sys.version[0] == "2"
 if is_py2:
-  import Queue as queue
+    import Queue as queue
 else:
-  import queue as queue
+    import queue as queue
+
+_completed_sentinel = object()
+
 
 class RGenerator(object):
-  
-  def __init__(self, r_function, completed):
-    
-    self.r_function = r_function
-    self.completed = completed
-  
-  def __iter__(self):
-    return self
+    def __init__(self, r_function, prefetch=0):
+        self.r_function = r_function
+        self.prefetch = prefetch
+        self.values_queue = queue.Queue()
+        self.completed = False
+        self._pending_tend_queue = False
+        if prefetch:
+            self._tend_queue()
 
-  def __next__(self):
-    return self.next()
+    def __iter__(self):
+        return self
 
-  def next(self):
-    
-    # call iterator
-    if (isinstance(threading.current_thread(), threading._MainThread)):
-      res = self.r_function()
-    else:
-      result = queue.Queue()
-      rpycall.call_python_function_on_main_thread(
-        lambda: result.put(self.r_function()), 
-        None
-      )
-      res = result.get()
-      
-    # check for special 'completed' return value
-    if (res == self.completed):
-      raise StopIteration()
-      
-    # return result
-    return res
+    def next(self):
+        return self.__next__()
 
+    def __next__(self):
+        self._tend_queue(1)
+        val = self._get_or_raise()
+        if self.prefetch:
+            self._tend_queue()
+        return val
 
+    def _tend_queue(self, min_fetch=0):
+        if self.completed:
+            return
 
+        ## Prefetch and enqueue generator generated values.
 
+        # If we're not on the main thread, register a pending call to
+        # this function from the py main thread and return.
+        if (
+            not self._pending_tend_queue
+            and threading.current_thread() is not threading.main_thread()
+        ):
+            self._pending_tend_queue = True
+            rpycall.call_python_function_on_main_thread(self._tend_queue, min_fetch)
+            return
 
+        # We're on the main thread, call the generator and put values on the queue.
+        self._pending_tend_queue = False
 
+        fetch = max(min_fetch, self.prefetch - self.values_queue.qsize())
+        for _ in range(fetch):
+            try:
+                val = self.r_function()
+            except StopIteration:
+                self.values_queue.put(_completed_sentinel)
+                self.completed = True
+                return
 
+            self.values_queue.put(val)
+
+    def _get_or_raise(self):
+        try:
+            # only wait/block-thread/yield-to-another-thread if the R generator
+            # is not exhausted.
+            val = self.values_queue.get(block=~self.completed)
+            if val is _completed_sentinel:
+                raise StopIteration()
+            return val
+        except queue.Empty:
+            # only get here if self.completed = True and the queue is empty,
+            # meaning we've already pulled off _completed_sentinel and
+            # raised StopIteration
+            raise StopIteration()

--- a/inst/python/rpytools/generator.py
+++ b/inst/python/rpytools/generator.py
@@ -41,14 +41,12 @@ class RGenerator(object):
 
         ## Prefetch and enqueue generator generated values.
 
-        # If we're not on the main thread, register a pending call to
-        # this function from the py main thread and return.
-        if (
-            not self._pending_tend_queue
-            and threading.current_thread() is not threading.main_thread()
-        ):
-            self._pending_tend_queue = True
-            rpycall.call_python_function_on_main_thread(self._tend_queue, min_fetch)
+        # If we're not on the main thread, make sure there is a pending call to
+        # this function from the main thread and return.
+        if threading.current_thread() is not threading.main_thread():
+            if not self._pending_tend_queue:
+                self._pending_tend_queue = True
+                rpycall.call_python_function_on_main_thread(self._tend_queue, min_fetch)
             return
 
         # We're on the main thread, call the generator and put values on the queue.

--- a/man/py_iterator.Rd
+++ b/man/py_iterator.Rd
@@ -4,13 +4,17 @@
 \alias{py_iterator}
 \title{Create a Python iterator from an R function}
 \usage{
-py_iterator(fn, completed = NULL)
+py_iterator(fn, completed = NULL, prefetch = 0L)
 }
 \arguments{
 \item{fn}{R function with no arguments.}
 
 \item{completed}{Special sentinel return value which indicates that
-iteration is complete (defaults to \code{NULL})}
+iteration is complete (defaults to \code{NULL}).}
+
+\item{prefetch}{Number items to prefetch. Set this to a positive integer to
+avoid a deadlock in situations where the generator values are consumed by
+python background threads while the main thread is blocked.}
 }
 \value{
 Python iterator which calls the R function for each iteration.


### PR DESCRIPTION
`py_iterator()` is used to create a python iterator from an R function. This PR adds a `prefetch` argument to `py_iterator()`. 

TensorFlow/Keras can accept user defined iterators for producing data (e.g., batches of training data). TensorFlow will in some circumstances call `iterator.__next__()` from a Python background thread which has the GIL acquired, and with the main thread fully blocked in a C++ call until the `__next__()` call has completed. 

With an iterator which calls an R function, this results in either:
- A `stackOverflowError` R error (or segfault, or corrupted data), due to the R API being called from the non-main thread. 
- A deadlock, where the main thread is blocked waiting on the R function to run, and the R function call is waiting to run on the main thread.

One such location where this happens is `tf.data.Dataset.from_generator()`.
 
Keras version 2.13 refactored internals to consolidate code paths in `fit()`, `predict()`, etc.  to use `tf.data.Dataset`, with user-supplied iterators being converted to TF Datasets via `tf.data.Dataset.from_generator()`. Hence, the deadlocks/error observed in various API entrypoints in TensorFlow 2.13 when R iterators are supplied.
