### PR TITLE
Ensure `py_capsule` finalizer runs on main thread

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,9 @@
 -   Updated sparse matrix conversion routines for compatibility with
     scipy 1.11.0.
 
+-   Fixed an issue where a py capsule finalizer could access the R API from
+    a background thread. (#1406)
+
 # reticulate 1.30
 
 - Fix compilation error on R 3.5. Bump minimum R version dependency to 3.5.


### PR DESCRIPTION
While working on the latest threading issues in TF 2.13 (#1405), I observed that `py_capsule()` finalizer may access the R API from not the main thread, if the last `Py_DecRef()` on the object is called from a background thread. This PR fixes that, ensuring that the finalizer only accesses the R API from the main thread.