### PR TITLE
flush python stdout/stderr from event loop.

### DIFF
--- a/src/event_loop.cpp
+++ b/src/event_loop.cpp
@@ -38,6 +38,7 @@ namespace {
 
 // Tracks whether we've requested Python to poll on the main thread.
 volatile sig_atomic_t s_pollingRequested;
+bool s_flush_std_buffers = true;
 
 // Forward declarations
 int pollForEvents(void*);
@@ -89,8 +90,12 @@ int pollForEvents(void*) {
 
   // Periodically flush stdout/stderr buffers to ensure that any output from
   // long-running Python calls is visible in the R console.
-  if (flush_std_buffers() != 0)
-    Rprintf("Error flushing Python's stdout/stderr buffers.\n");
+  if (s_flush_std_buffers) {
+    if (flush_std_buffers() != 0) {
+      Rprintf("Error flushing Python's stdout/stderr buffers. Auto-flushing is now disabled.\n");
+      s_flush_std_buffers = false;
+    }
+  }
 
   {
     // Process events. We wrap this in R_ToplevelExec just to avoid jumps.

--- a/src/event_loop.cpp
+++ b/src/event_loop.cpp
@@ -87,6 +87,11 @@ int pollForEvents(void*) {
   // can be throttled)
   s_pollingRequested = 0;
 
+  // Periodically flush stdout/stderr buffers to ensure that any output from
+  // long-running Python calls is visible in the R console.
+  if (flush_std_buffers() != 0)
+    Rprintf("Error flushing Python's stdout/stderr buffers.\n");
+
   {
     // Process events. We wrap this in R_ToplevelExec just to avoid jumps.
     // Suspend interrupts here so we don't inadvertently handle them.

--- a/src/libpython.cpp
+++ b/src/libpython.cpp
@@ -399,5 +399,40 @@ bool import_numpy_api(bool python3, std::string* pError) {
 }
 
 
+int flush_std_buffers() {
+  int status = 0;
+  PyObject* tmp = NULL;
+  PyObject *error_type, *error_value, *error_traceback;
+  PyErr_Fetch(&error_type, &error_value, &error_traceback);
+
+  PyObject* sys_stdout(PySys_GetObject("stdout"));  // returns borrowed reference
+  if (sys_stdout == NULL)
+    status = -1;
+  else
+    tmp = PyObject_CallMethod(sys_stdout, "flush", NULL);
+
+  if (tmp == NULL)
+    status = -1;
+  else {
+    Py_DecRef(tmp);
+    tmp = NULL;
+  }
+
+  PyObject* sys_stderr(PySys_GetObject("stderr"));  // returns borrowed reference
+  if (sys_stderr == NULL)
+    status = -1;
+  else
+    tmp = PyObject_CallMethod(sys_stderr, "flush", NULL);
+
+  if (tmp == NULL)
+    status = -1;
+  else
+    Py_DecRef(tmp);
+
+  PyErr_Restore(error_type, error_value, error_traceback);
+  return status;
+}
+
+
 } // namespace libpython
 } // namespace reticulate

--- a/src/libpython.h
+++ b/src/libpython.h
@@ -763,6 +763,8 @@ LIBPYTHON_EXTERN PyThreadState* (*PyThreadState_Next)(PyThreadState*);
 
 /* End PyFrameObject */
 
+int flush_std_buffers();
+
 } // namespace libpython
 } // namespace reticulate
 

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -564,39 +564,7 @@ bool traceback_enabled() {
   return as<bool>(func());
 }
 
-int flush_std_buffers() {
-  int status = 0;
-  PyObject* tmp = NULL;
-  PyObject *error_type, *error_value, *error_traceback;
-  PyErr_Fetch(&error_type, &error_value, &error_traceback);
 
-  PyObject* sys_stdout(PySys_GetObject("stdout"));  // returns borrowed reference
-  if (sys_stdout == NULL)
-    status = -1;
-  else
-    tmp = PyObject_CallMethod(sys_stdout, "flush", NULL);
-
-  if (tmp == NULL)
-    status = -1;
-  else {
-    Py_DecRef(tmp);
-    tmp = NULL;
-  }
-
-  PyObject* sys_stderr(PySys_GetObject("stderr"));  // returns borrowed reference
-  if (sys_stderr == NULL)
-    status = -1;
-  else
-    tmp = PyObject_CallMethod(sys_stderr, "flush", NULL);
-
-  if (tmp == NULL)
-    status = -1;
-  else
-    Py_DecRef(tmp);
-
-  PyErr_Restore(error_type, error_value, error_traceback);
-  return status;
-}
 
 
 


### PR DESCRIPTION
Presently, long running Python calls in `repl_python()` that stream to stdout will not show any output in the R console until the Python call has fully returned. This PR add periodic calls to flush the stdout and stderr buffers from the event loop, ensuring that streaming python output is visible in the R console.

Related: https://github.com/rstudio/reticulate/issues/739
cc: @falbukrek

    