### PR TITLE
Avoid segfault when raising Python errors that didn't set an exception.

### DIFF
--- a/src/python.cpp
+++ b/src/python.cpp
@@ -693,6 +693,11 @@ SEXP py_fetch_error(bool maybe_reuse_cached_r_trace) {
 
   PyObject *excType, *excValue, *excTraceback;
   PyErr_Fetch(&excType, &excValue, &excTraceback);  // we now own the PyObjects
+
+  if (!excType) {
+    Rcpp::stop("Unknown Python error.");
+  }
+
   PyErr_NormalizeException(&excType, &excValue, &excTraceback);
 
   if (excTraceback != NULL && excValue != NULL && s_isPython3) {


### PR DESCRIPTION
This fixes #1404 in the sense that we no longer segfault when calling `import_builtins()$globals()`. 

The segfault happens because the call to `globals()` fails but never sets an exceptionType in Python side, which is expected by the `py_fetch_error()`.

The reason why this call fails is still unkown to me (no backtrace makes it harder to figure it out), but it it seems that, the Python interpreter used by reticulate has no default module imported, causing the globals dictionary to not exist.

I think we might be missing somehting like:

https://github.com/rstudio/reticulate/blob/9a712cbb453595621ba157b308682c5844b5944b/src/python.cpp#L2967-L2968

during the initialization of reticulate's interpreter.

Previous reticulate versions raise:

```
> reticulate::import_builtins()$globals()
Error: <unknown error>
```

