### PR TITLE
Correctly handles Fortran ordering in numpy character arrays

### DIFF
--- a/src/python.cpp
+++ b/src/python.cpp
@@ -930,8 +930,10 @@ bool py_is_callable(PyObjectRef x) {
 
 // caches np.nditer function so we don't need to obtain it everytime we want to
 // cast numpy string arrays into R objects.
-PyObject* np_nditer;
 PyObject* get_np_nditer () {
+
+  static PyObject* np_nditer;
+
   if (np_nditer) {
     return np_nditer;
   }
@@ -1165,21 +1167,13 @@ SEXP py_to_r(PyObject* x, bool convert) {
         rArray = Rf_allocArray(STRSXP, dimsVector);
         RObject protectArray(rArray);
 
-        // empty tuple, casts to scalar value
-        PyObjectPtr itemArg(PyTuple_New(0));
+
         for (int i=0; i<len; i++) {
           PyObjectPtr el(PyIter_Next(iter)); // returns an scalar array.
-
-          PyObjectPtr itemFunc(PyObject_GetAttrString(el, "item"));
-          if (itemFunc.is_null()) {
-            throw PythonException(py_fetch_error());
-          }
-
-          PyObjectPtr pyStr(PyObject_Call(itemFunc, itemArg, NULL));
+          PyObjectPtr pyStr(PyObject_CallMethod(el, "item", NULL));
           if (pyStr.is_null()) {
             throw PythonException(py_fetch_error());
           }
-
           set_string_element(rArray, i, pyStr);
         }
         break;

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -928,6 +928,28 @@ bool py_is_callable(PyObjectRef x) {
     return py_is_callable(x.get());
 }
 
+// caches np.nditer function so we don't need to obtain it everytime we want to
+// cast numpy string arrays into R objects.
+PyObject* np_nditer;
+PyObject* get_np_nditer () {
+  if (np_nditer) {
+    return np_nditer;
+  }
+
+  requireNumPy();
+
+  PyObjectPtr numpy(PyImport_ImportModule("numpy"));
+  if (numpy.is_null()) {
+    throw PythonException(py_fetch_error());
+  }
+
+  np_nditer = PyObject_GetAttrString(numpy, "nditer");
+  if (np_nditer == NULL) {
+    throw PythonException(py_fetch_error());
+  }
+
+  return np_nditer;
+}
 
 // convert a python object to an R object
 SEXP py_to_r(PyObject* x, bool convert) {
@@ -1126,19 +1148,38 @@ SEXP py_to_r(PyObject* x, bool convert) {
 
       case NPY_STRING:
       case NPY_UNICODE: {
-        PyObjectPtr itemFunc(PyObject_GetAttrString(ptrArray, "item"));
-        if (itemFunc.is_null())
+
+        PyObjectPtr nditerArgs(PyTuple_New(1));
+        // PyTuple_SetItem steals reference the array, but it's already wraped
+        // into PyObjectPtr earlier (so it gets deleted after the scope of this function)
+        // To avoid trying to delete it twice, we need to increase its ref count here.
+        PyTuple_SetItem(nditerArgs, 0, (PyObject*)array);
+        Py_IncRef((PyObject*)array);
+
+        PyObjectPtr iter(PyObject_Call(get_np_nditer(), nditerArgs, NULL));
+
+        if (iter.is_null()) {
           throw PythonException(py_fetch_error());
+        }
+
         rArray = Rf_allocArray(STRSXP, dimsVector);
         RObject protectArray(rArray);
+
+        // empty tuple, casts to scalar value
+        PyObjectPtr itemArg(PyTuple_New(0));
         for (int i=0; i<len; i++) {
-          PyObjectPtr pyArgs(PyTuple_New(1));
-          // PyTuple_SetItem steals reference to object created by PyInt_FromLong
-          PyTuple_SetItem(pyArgs, 0, PyInt_FromLong(i));
-          PyObjectPtr pyStr(PyObject_Call(itemFunc, pyArgs, NULL));
+          PyObjectPtr el(PyIter_Next(iter)); // returns an scalar array.
+
+          PyObjectPtr itemFunc(PyObject_GetAttrString(el, "item"));
+          if (itemFunc.is_null()) {
+            throw PythonException(py_fetch_error());
+          }
+
+          PyObjectPtr pyStr(PyObject_Call(itemFunc, itemArg, NULL));
           if (pyStr.is_null()) {
             throw PythonException(py_fetch_error());
           }
+
           set_string_element(rArray, i, pyStr);
         }
         break;

--- a/tests/testthat/test-python-numpy.R
+++ b/tests/testthat/test-python-numpy.R
@@ -86,3 +86,18 @@ test_that("boolean matrices are converted appropriately", {
   A <- matrix(TRUE, nrow = 2, ncol = 2)
   expect_equal(A, py_to_r(r_to_py(A)))
 })
+
+test_that("numpy string arrays are correctly handled", {
+  # https://github.com/rstudio/reticulate/issues/1409
+  skip_if_no_numpy()
+
+  py_run_string(
+    r"(
+import numpy as np
+c1 = np.array(["1","2","3"])
+c2 = np.array(["4","5","6"])
+c = np.stack([c1,c2], axis = 1)
+)")
+
+  expect_equal(py$c, matrix(as.character(1:6), ncol = 2))
+})

--- a/tests/testthat/test-python-numpy.R
+++ b/tests/testthat/test-python-numpy.R
@@ -91,13 +91,41 @@ test_that("numpy string arrays are correctly handled", {
   # https://github.com/rstudio/reticulate/issues/1409
   skip_if_no_numpy()
 
-  py_run_string(
-    r"(
-import numpy as np
-c1 = np.array(["1","2","3"])
-c2 = np.array(["4","5","6"])
-c = np.stack([c1,c2], axis = 1)
-)")
+  np <- import("numpy", convert = FALSE)
+  c1 <- np$array(c("1", "2", "3"))
+  c2 <- np$array(c("4", "5", "6"))
+  x <- py_to_r(np$stack(list(c1, c2), axis = 1L))
+  expect_equal(x, matrix(as.character(1:6), ncol = 2))
 
-  expect_equal(py$c, matrix(as.character(1:6), ncol = 2))
+  # test for more dimensions
+  x <- np$random$rand(3L, 5L, 4L)
+  y <- x$astype("str")
+
+  a <- py_to_r(x)
+  b <- py_to_r(y)
+  storage.mode(b) <- "numeric"
+  expect_equal(a, b)
+
+  # test F ordering
+  x <- np$random$rand(3L, 5L, 4L)
+  y <- x$astype("str")
+  y <- np$asfortranarray(y)
+  expect_true(py_to_r(y$flags$f_contiguous))
+
+  a <- py_to_r(x)
+  b <- py_to_r(y)
+  storage.mode(b) <- "numeric"
+  expect_equal(a, b)
+
+  # test for strided views
+  x <- np$random$rand(3L, 5L, 4L)
+  y <- x$astype("str")
+
+  x <- np$reshape(x, c(5L, 3L, 4L))
+  y <- np$reshape(y, c(5L, 3L, 4L))
+
+  a <- py_to_r(x)
+  b <- py_to_r(y)
+  storage.mode(b) <- "numeric"
+  expect_equal(a, b)
 })

--- a/tests/testthat/test-python-numpy.R
+++ b/tests/testthat/test-python-numpy.R
@@ -128,4 +128,20 @@ test_that("numpy string arrays are correctly handled", {
   b <- py_to_r(y)
   storage.mode(b) <- "numeric"
   expect_equal(a, b)
-})
+
+  x <- np$array(as.character(1:18))$reshape(c(-1L, 2L))
+
+  fn <- py_eval("lambda x: x[::2]") # another strided view
+  expect_equal(fn(x), matrix(c("1", "2",
+                               "5", "6",
+                               "9", "10",
+                               "13", "14",
+                               "17", "18"), byrow = TRUE, ncol = 2))
+  x <- np$asfortranarray(x)
+  expect_equal(fn(x), matrix(c("1", "2",
+                               "5", "6",
+                               "9", "10",
+                               "13", "14",
+                               "17", "18"), byrow = TRUE, ncol = 2))
+
+  })


### PR DESCRIPTION
Fixes #1409, also refer to linked issue for more details on the approach.