### PR TITLE
Fix knitr output remapping from a clean new session

### DIFF
--- a/R/output.R
+++ b/R/output.R
@@ -36,6 +36,7 @@ set_knitr_python_stdout_hook <- function() {
     # if knitr is already in progress here, this means that python was initialized
     # during a chunk execution. We have to force an instant remap as the hook won't
     # have a chance to run for that chunk.
+    # In such cases `context.__enter__` is never called.
     if (isTRUE(getOption('knitr.in.progress'))) set_output_streams(tty = FALSE)
   } else {
     setHook(

--- a/inst/python/rpytools/output.py
+++ b/inst/python/rpytools/output.py
@@ -157,12 +157,14 @@ class RemapOutputStreams:
     self._stderr = sys.stderr
   
   def __enter__(self):
+    # It's possible that __enter__ does not execute before __exit__ in some
+    # special cases. We also store _stdout and _stderr when creating the context.
     self._stdout = sys.stdout
     self._stderr = sys.stderr
     
     _remap_output_streams(self.r_stdout, self.r_stderr, self.tty)
   
-  def __exit__(self):
+  def __exit__(self, *args):
     sys.stdout = self._stdout
     sys.stderr = self._stderr
 

--- a/inst/python/rpytools/output.py
+++ b/inst/python/rpytools/output.py
@@ -153,6 +153,8 @@ class RemapOutputStreams:
     self.r_stdout = r_stdout
     self.r_stderr = r_stderr
     self.tty = tty
+    self._stdout = sys.stdout
+    self._stderr = sys.stderr
   
   def __enter__(self):
     self._stdout = sys.stdout

--- a/tests/testthat/_snaps/python-knitr-engine/knitr-print2.md
+++ b/tests/testthat/_snaps/python-knitr-engine/knitr-print2.md
@@ -1,0 +1,4 @@
+    bt <- reticulate::import_builtins()
+    bt$print("Hello world")
+
+    ## Hello world

--- a/tests/testthat/test-python-knitr-engine.R
+++ b/tests/testthat/test-python-knitr-engine.R
@@ -87,4 +87,11 @@ test_that("Output streams are remaped when kniting", {
   }))
   expect_length(out, 0)
 
+  # make sure it works from a background session
+  callr::r(function(path) {
+    setwd(path)
+    rmarkdown::render("knitr-print.Rmd", output_file = "knitr-print2.md")
+  }, args = list(path = test_path("resources")))
+
+  expect_snapshot_file(test_path("resources", "knitr-print2.md"))
 })

--- a/tests/testthat/test-python-knitr-engine.R
+++ b/tests/testthat/test-python-knitr-engine.R
@@ -71,7 +71,7 @@ test_that("Output streams are remaped when kniting", {
   local_edition(3)
 
   owd <- setwd(test_path("resources"))
-  rmarkdown::render("knitr-print.Rmd")
+  rmarkdown::render("knitr-print.Rmd", quiet = TRUE)
   setwd(owd)
 
   rendered <- test_path("resources", "knitr-print.md")
@@ -90,7 +90,11 @@ test_that("Output streams are remaped when kniting", {
   # make sure it works from a background session
   callr::r(function(path) {
     setwd(path)
-    rmarkdown::render("knitr-print.Rmd", output_file = "knitr-print2.md")
+    rmarkdown::render(
+      "knitr-print.Rmd",
+      output_file = "knitr-print2.md",
+      quiet = TRUE
+    )
   }, args = list(path = test_path("resources")))
 
   expect_snapshot_file(test_path("resources", "knitr-print2.md"))


### PR DESCRIPTION
Follow up for https://github.com/rstudio/reticulate/pull/1412#issuecomment-1644001337