### PR TITLE
Changes to how we pick which Python to use.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # reticulate (development version)
 
+- reticulate will no longer prompt users to install miniconda. Instead,
+  reticulate will now prompt users to create a default `r-reticulate` venv.
+
+- The python search behavior that reticulate uses to select a Python has changed.
+  See the updated "versions" vignette for the new order of discovery.
+
 - `py_iterator()` gains a `prefetch` argument, primarily to avoid deadlocks
   where the main thread is blocked, waiting for the iterator, which is waiting
   to run on the main thread, as encountered in TensorFlow/Keras. (#1405).

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,16 @@
 - The python search behavior that reticulate uses to select a Python has changed.
   See the updated "versions" vignette for the new order of discovery.
   
+- Updated recommendations in the "python_dependencies" vignette for how R packages 
+  can approach Python dependency management.
+  
 - `virtualenv_create()` gains a `force` argument.
+
+- Fixed an issue where the list of available python versions used by `install_python()` 
+  would be out-of-date.
+  
+- `install_python()` on macOS will now will use brew, if it's available, to install
+   build dependencies, substantially speeding up python build times.
 
 - `virtualenv_install()` gains a `python_version` argument, allowing users to customize
   which python version is used when bootstrapping a new virtual environment.

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,11 @@
 
 - The python search behavior that reticulate uses to select a Python has changed.
   See the updated "versions" vignette for the new order of discovery.
+  
+- `virtualenv_create()` gains a `force` argument.
+
+- `virtualenv_install()` gains a `python_version` argument, allowing users to customize
+  which python version is used when bootstrapping a new virtual environment.
 
 - `py_iterator()` gains a `prefetch` argument, primarily to avoid deadlocks
   where the main thread is blocked, waiting for the iterator, which is waiting

--- a/R/config.R
+++ b/R/config.R
@@ -282,8 +282,8 @@ py_discover_config <- function(required_module = NULL, use_environment = NULL) {
 
 
   ## At this point, the user, (and package authors on behalf of the user), has
-  ## expressed no intent or preference for any particular python installation,
-  ## or the preference expressed is for the python environment that don't exist.
+  ## expressed no preference for any particular python installation, or the
+  ## preference expressed is for the python environment that don't exist.
   ##
   ## In other words,
   ##  - no use_python(), use_virtualenv(), use_condaenv()
@@ -294,7 +294,7 @@ py_discover_config <- function(required_module = NULL, use_environment = NULL) {
   ##  - no configured poetry or pipfile in the current working directory
 
   # Look for a "r-reticulate" venv. if found, use that.
-  # This is the default in the absence of any expressed intent by the user.
+  # This is the default in the absence of any expressed preference by the user.
   python <- tryCatch(py_resolve("r-reticulate"), error = identity)
   if (!inherits(python, "error"))
     return(python_config(python, required_module))
@@ -305,7 +305,6 @@ py_discover_config <- function(required_module = NULL, use_environment = NULL) {
   python <- tryCatch(py_resolve("r-reticulate"), error = identity)
   if (!inherits(python, "error"))
     return(python_config(python, required_module))
-
 
   # At this point, user has expressed no preference, and has declined
   # to use the create the "r-reticulate" venv.

--- a/R/config.R
+++ b/R/config.R
@@ -325,10 +325,12 @@ py_discover_config <- function(required_module = NULL, use_environment = NULL) {
   # use the first one that has the requested module.
   python_versions <- unique(c(
     Sys.which("python3"),
-    Sys.which("python"),
-    if (is_windows())
-      py_versions_windows(include_conda = FALSE)$executable_path
+    Sys.which("python")
   ))
+  if(is_windows()) {
+    append(python_versions) <-
+      subset(py_versions_windows(), type == "PythonCore")$executable_path
+  }
 
   # filter locations by existence
   if (length(python_versions) > 0)
@@ -462,11 +464,11 @@ create_default_virtualenv <- function(package = "reticulate", ...) {
 #'
 #' @keywords internal
 #' @export
-py_versions_windows <- function(include_conda = TRUE) {
+py_versions_windows <- function() {
   rbind(
     read_python_versions_from_registry("HCU", key = "PythonCore"),
     read_python_versions_from_registry("HLM", key = "PythonCore"),
-    if(include_conda) windows_registry_anaconda_versions()
+    windows_registry_anaconda_versions()
   )
 }
 
@@ -1003,7 +1005,7 @@ windows_registry_anaconda_versions <- function() {
         read_python_versions_from_registry("HLM", key = "ContinuumAnalytics", type = "Anaconda"))
 }
 
-read_python_versions_from_registry <- function(hive, key,type=key) {
+read_python_versions_from_registry <- function(hive, key, type=key) {
 
   python_core_key <- tryCatch(utils::readRegistry(
     key = paste0("SOFTWARE\\Python\\", key), hive = hive, maxdepth = 3),

--- a/R/config.R
+++ b/R/config.R
@@ -327,10 +327,12 @@ py_discover_config <- function(required_module = NULL, use_environment = NULL) {
     Sys.which("python3"),
     Sys.which("python")
   ))
-  if(is_windows()) {
-    append(python_versions) <-
-      subset(py_versions_windows(), type == "PythonCore")$executable_path
-  }
+  if(is_windows())
+    append(python_versions) <- local({
+      df <- py_versions_windows()
+      df$executable_path[df$type == "PythonCore"]
+    })
+
 
   # filter locations by existence
   if (length(python_versions) > 0)

--- a/R/config.R
+++ b/R/config.R
@@ -322,11 +322,11 @@ py_discover_config <- function(required_module = NULL, use_environment = NULL) {
   #   - which python is found should be predictable.
 
   # create a list of possible python versions to bind to
-  # use the first one that has the requested module.
   python_versions <- unique(c(
     Sys.which("python3"),
     Sys.which("python")
   ))
+
   if(is_windows())
     append(python_versions) <- local({
       df <- py_versions_windows()

--- a/R/config.R
+++ b/R/config.R
@@ -327,7 +327,7 @@ py_discover_config <- function(required_module = NULL, use_environment = NULL) {
     Sys.which("python3"),
     Sys.which("python"),
     if (is_windows())
-      py_versions_windows()$executable_path,
+      py_versions_windows(include_conda = FALSE)$executable_path
   ))
 
   # filter locations by existence
@@ -462,11 +462,11 @@ create_default_virtualenv <- function(package = "reticulate", ...) {
 #'
 #' @keywords internal
 #' @export
-py_versions_windows <- function() {
+py_versions_windows <- function(include_conda = TRUE) {
   rbind(
     read_python_versions_from_registry("HCU", key = "PythonCore"),
     read_python_versions_from_registry("HLM", key = "PythonCore"),
-    windows_registry_anaconda_versions()
+    if(include_conda) windows_registry_anaconda_versions()
   )
 }
 

--- a/R/config.R
+++ b/R/config.R
@@ -260,6 +260,15 @@ py_discover_config <- function(required_module = NULL, use_environment = NULL) {
     return(config)
   }
 
+  # check if we're running in an activated venv
+  if (is_virtualenv(envpath <- Sys.getenv("VIRTUAL_ENV", NA))) {
+    # If this check ends up being too strict, we can alternatively do:
+    # if (python_info(Sys.which("python"))$type == "virtualenv") {
+    config <- python_config(virtualenv_python(envpath), required_module,
+                            forced = "`. bin/activate` (before R started)")
+    return(config)
+  }
+
   # if RETICULATE_PYTHON_FALLBACK is specified then use it
   reticulate_env <- Sys.getenv("RETICULATE_PYTHON_FALLBACK", unset = NA)
   if (!is.na(reticulate_env)) {
@@ -271,14 +280,6 @@ py_discover_config <- function(required_module = NULL, use_environment = NULL) {
     return(config)
   }
 
-  # check if we're running in an activated venv
-  if (is_virtualenv(envpath <- Sys.getenv("VIRTUAL_ENV", NA))) {
-    # If this check ends up being too strict, we can alternatively do:
-    # if (python_info(Sys.which("python"))$type == "virtualenv") {
-    config <- python_config(virtualenv_python(envpath), required_module,
-                            forced = "`. bin/activate` (before R started)")
-    return(config)
-  }
 
 
   ## At this point, the user, (and package authors on behalf of the user), has

--- a/R/config.R
+++ b/R/config.R
@@ -156,6 +156,10 @@ py_module_available <- function(module) {
 #' @export
 py_discover_config <- function(required_module = NULL, use_environment = NULL) {
 
+  required_module <- required_module %||% .globals$delay_load_module
+  if (!is.null(required_module))
+    required_module <- strsplit(required_module, ".", fixed = TRUE)[[1L]][[1L]]
+
   # check if python symbols can already be found in the current process
   main_process_info <- main_process_python_info()
   if (!is.null(main_process_info)) {
@@ -228,6 +232,7 @@ py_discover_config <- function(required_module = NULL, use_environment = NULL) {
 
   # look for any environment names supplied in a call like:
   #  import("bar", delayed = list(environment = "r-barlyr"))
+  use_environment <- use_environment %||% .globals$delay_load_environment
   if(!is.null(use_environment)) {
     python <- tryCatch(py_resolve(use_environment), error = identity)
     if (!inherits(python, "error"))

--- a/R/config.R
+++ b/R/config.R
@@ -204,7 +204,7 @@ py_discover_config <- function(required_module = NULL, use_environment = NULL) {
       stop("Python specified in RETICULATE_PYTHON_ENV (", reticulate_python_env, ") does not exist")
     })
 
-    config <- python_config(path, required_module, forced = "RETICULATE_PYTHON_ENV")
+    config <- python_config(python, required_module, forced = "RETICULATE_PYTHON_ENV")
     return(config)
 
   }
@@ -435,7 +435,7 @@ create_default_virtualenv <- function(package = "reticulate", ...) {
 
   if (permission == "") {
     if(is_interactive()) {
-      permission <- askYesNo(sprintf(
+      permission <- utils::askYesNo(sprintf(
         "Would you like to create a default python environment for the %s package?",
         package))
       if(!isTRUE(permission))

--- a/R/config.R
+++ b/R/config.R
@@ -242,6 +242,17 @@ py_discover_config <- function(required_module = NULL, use_environment = NULL) {
       ))
   }
 
+  # check for `use_python(required = FALSE)`. This should rarely be triggered
+  # any more by users, since the default value for `required` changed from FALSE to TRUE.
+  # excepting if the use_*() call is within a `.onLoad()` call of a package.
+  # last call of use_*(,required = FALSE) wins
+  optional_requested_use_pythons <- reticulate_python_versions()
+  for (python in rev(optional_requested_use_pythons)) {
+    config <- python_config(python, required_module,
+                            forced = "use_python(, required = FALSE)")
+    return(config)
+  }
+
   # look in virtual environments that have a required module derived name,
   # e.g., given a call to import("bar"), look for an environment named "r-bar"
   if (!is.null(required_module)) {
@@ -252,17 +263,6 @@ py_discover_config <- function(required_module = NULL, use_environment = NULL) {
         python, required_module,
         forced = sprintf('import("%s")', required_module)
       ))
-  }
-
-  # check for `use_python( , required = FALSE)`. This should rarely be triggered
-  # any more, since the default value for `required` changed from FALSE to TRUE,
-  # excepting if the use_*() call is within a `.onLoad()` call of a package.
-  # last call of use_*(,required = FALSE) wins
-  optional_requested_use_pythons <- reticulate_python_versions()
-  for (python in rev(optional_requested_use_pythons)) {
-    config <- python_config(python, required_module,
-                            forced = "use_python(, required = FALSE)")
-    return(config)
   }
 
   # check if we're running in an activated venv
@@ -319,7 +319,7 @@ py_discover_config <- function(required_module = NULL, use_environment = NULL) {
   # We intentionally do not go on a fishing expedition for every possible python,
   # for two reasons:
   #   - the default workflow should be to use venvs
-  #   - make which python is found more predictable.
+  #   - which python is found should be predictable.
 
   # create a list of possible python versions to bind to
   # use the first one that has the requested module.

--- a/R/import.R
+++ b/R/import.R
@@ -4,66 +4,66 @@
 #' Import the specified Python module, making it available for use from \R.
 #'
 #' @param module The name of the Python module.
-#' 
+#'
 #' @param as An alias for module name (affects names of R classes). Note that
 #'   this is an advanced parameter that should generally only be used in package
 #'   development (since it affects the S3 name of the imported class and can
 #'   therefore interfere with S3 method dispatching).
-#'  
+#'
 #' @param path The path from which the module should be imported.
-#' 
+#'
 #' @param convert Boolean; should Python objects be automatically converted
 #'   to their \R equivalent? If set to `FALSE`, you can still manually convert
 #'   Python objects to \R via the [py_to_r()] function.
-#'   
+#'
 #' @param delay_load Boolean; delay loading the module until it is first used?
 #'   When `FALSE`, the module will be loaded immediately. See **Delay Load**
 #'   for advanced usages.
 #'
 #'
 #' @section Python Built-ins:
-#' 
+#'
 #' Python's built-in functions (e.g. `len()`) can be accessed via Python's
 #' built-in module. Because the name of this module has changed between Python 2
 #' and Python 3, we provide the function `import_builtins()` to abstract over
 #' that name change.
-#' 
+#'
 #'
 #' @section Delay Load:
-#' 
+#'
 #' The `delay_load` parameter accepts a variety of inputs. If you just need to
 #' ensure your module is lazy-loaded (e.g. because you are a package author and
 #' want to avoid initializing Python before the user has explicitly requested it),
 #' then passing `TRUE` is normally the right choice.
-#' 
+#'
 #' You can also provide a list of named functions, which act as callbacks to be
 #' run when the module is later loaded. For example:
-#' 
+#'
 #' ```
 #' delay_load = list(
-#'   
+#'
 #'   # run before the module is loaded
 #'   before_load = function() { ... }
-#'   
+#'
 #'   # run immediately after the module is loaded
 #'   on_load = function() { ... }
-#'   
+#'
 #'   # run if an error occurs during module import
 #'   on_error = function(error) { ... }
-#'   
+#'
 #' )
 #' ```
-#' 
+#'
 #' Alternatively, if you supply only a single function, that will be treated as
 #' an `on_load` handler.
-#' 
-#' 
+#'
+#'
 #' @section Import from Path:
-#' 
+#'
 #' `import_from_path()` can be used in you need to import a module from an arbitrary
 #' filesystem path. This is most commonly used when importing modules bundled with an
 #' \R package -- for example:
-#' 
+#'
 #' ```
 #' path <- system.file("python", package = <package>)
 #' reticulate::import_from_path(<module>, path = path, delay_load = TRUE)
@@ -80,14 +80,14 @@
 #'
 #' @export
 import <- function(module, as = NULL, convert = TRUE, delay_load = FALSE) {
-  
+
   # if there is an as argument then register a filter for it
   if (!is.null(as)) {
     register_class_filter(function(classes) {
       sub(paste0("^", module), as, classes)
     })
   }
-  
+
   # resolve delay load
   delay_load_environment <- NULL
   delay_load_priority <- 0
@@ -102,30 +102,35 @@ import <- function(module, as = NULL, convert = TRUE, delay_load = FALSE) {
       delay_load_priority <- delay_load$priority
     delay_load <- TRUE
   }
-  
+
   # normal case (load immediately)
   if (!delay_load || is_python_initialized()) {
-    
+
     # ensure that python is initialized (pass top level module as
     # a hint as to which version of python to choose)
     ensure_python_initialized(required_module = module)
-    
+
     # import the module
     py_module_import(module, convert = convert)
 
   }
-  
+
   # delay load case (wait until first access)
   else {
     if (is.null(.globals$delay_load_module) || (delay_load_priority > .globals$delay_load_priority)) {
       .globals$delay_load_module <- module
-      .globals$delay_load_environment <- delay_load_environment
+      .globals$delay_load_environment <- delay_load_environment # environment name, like "r-keras"
       .globals$delay_load_priority <- delay_load_priority
     }
     module_proxy <- new.env(parent = emptyenv())
     module_proxy$module <- module
     module_proxy$convert <- convert
     if (!is.null(delay_load_functions)) {
+
+      # `get_module()` can be a function that at runtime can resolve the name
+      # (length 1 character vector) of the actual module to import e.g., in
+      # keras, we can decide at run time if this should be "tensorflow.keras",
+      # "keras", or "keras_core" based on any env vars or versions installed.
       module_proxy$get_module <- delay_load_functions$get_module
       module_proxy$before_load <- delay_load_functions$before_load
       module_proxy$on_load <- delay_load_functions$on_load
@@ -166,7 +171,7 @@ import_from_path <- function(module,
   delay <-
     !identical(delay_load, FALSE) &&
     !py_available(initialize = FALSE)
-  
+
   if (delay)
     import_from_path_delayed(module, path, convert, delay_load)
   else
@@ -174,68 +179,68 @@ import_from_path <- function(module,
 }
 
 import_from_path_delayed <- function(module, path, convert, delay_load) {
-  
+
   # resolve delay_load
   # single function, maps to on_load
   if (is.function(delay_load)) {
     delay_load <- list(on_load = delay_load)
   }
-  
+
   # TRUE translates to an empty list of hooks
   if (identical(delay_load, TRUE)) {
     delay_load <- list()
   }
-  
+
   # anything else not a list is an error
   if (!is.list(delay_load)) {
     stop("delay_load should be a boolean, a single function, or a list of functions.")
   }
-  
+
   .before_load <- delay_load$before_load %||% function() {}
   .on_load     <- delay_load$on_load %||% function() {}
   .on_error    <- delay_load$on_error %||% function(error) {}
-  
+
   hooks <- list(
-    
+
     before_load = function() {
       sys <- import("sys", convert = FALSE)
       sys$path$insert(0L, path)
       .before_load()
     },
-    
+
     on_load = function() {
       sys <- import("sys", convert = FALSE)
       sys$path$remove(path)
       .on_load()
     },
-    
+
     on_error = function(error) {
       sys <- import("sys", convert = FALSE)
       sys$path$remove(path)
       .on_error(error)
     }
-    
+
   )
-  
+
   import(module, convert = convert, delay_load = hooks)
-  
+
 }
 
 import_from_path_immediate <- function(module, path, convert) {
-  
+
   # normalize path
   path <- normalizePath(path)
-  
+
   # get sys module
   sys <- import("sys", convert = FALSE)
-  
+
   # prepend the requested path, then remove it when we're done
   sys$path$insert(0L, path)
   on.exit(sys$path$remove(path), add = TRUE)
-  
+
   # import the requested module
   import(module, convert = convert)
-  
+
 }
 
 

--- a/R/install-python.R
+++ b/R/install-python.R
@@ -48,6 +48,9 @@ install_python <- function(version = "3.9:latest",
   if (!file.exists(pyenv))
     stop("could not locate 'pyenv' binary")
 
+  # make sure pyenv is up-to-date
+  pyenv_update(pyenv)
+
   # if list is set, then list available versions instead
   if (identical(list, TRUE))
     return(pyenv_list(pyenv = pyenv))

--- a/R/install.R
+++ b/R/install.R
@@ -5,17 +5,15 @@ py_install_method_detect <- function(envname, conda = "auto") {
   if (virtualenv_exists(envname))
     return("virtualenv")
 
-  # check and prompt for miniconda
-  if (miniconda_enabled() && miniconda_installable() && !miniconda_exists())
-    miniconda_install_prompt()
-
   # try to find an existing condaenv
   if (condaenv_exists(envname, conda = conda))
     return("conda")
 
   # check to see if virtualenv or venv is available
-  python <- virtualenv_default_python()
-  if (python_has_module(python, "virtualenv") || python_has_module(python, "venv"))
+  python <- virtualenv_starter()
+  if (!is.null(python) &&
+      (python_has_module(python, "venv") ||
+       python_has_module(python, "virtualenv")))
     return("virtualenv")
 
   # check to see if conda is available
@@ -130,6 +128,7 @@ py_install <- function(packages,
       envname = envname,
       packages = packages,
       ignore_installed = pip_ignore_installed,
+      python_version = python_version,
       ...
     ),
 

--- a/R/install.R
+++ b/R/install.R
@@ -161,6 +161,8 @@ py_resolve <- function(envname = NULL,
   if (is.null(envname))
     return(py_exe())
 
+  type <- match.arg(type)
+
   # if envname was supplied, try to resolve the environment path
   envpath <- if (type == "virtualenv") {
 

--- a/R/package.R
+++ b/R/package.R
@@ -111,7 +111,7 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
 
   # provide hint to install Miniconda if no Python is found
   python_not_found <- function(msg) {
-    hint <- "Use reticulate::install_miniconda() if you'd like to install a Miniconda Python environment."
+    hint <- "Please create a default virtual environment with `reticulate::virtualenv_create('r-reticulate')`."
     stop(paste(msg, hint, sep = "\n"), call. = FALSE)
   }
 

--- a/R/package.R
+++ b/R/package.R
@@ -297,6 +297,8 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
   config
 }
 
+# unused presently, formerly called from initialize_python()
+# https://github.com/rstudio/reticulate/commit/e8c82a1f95eb97c4e5fc27b6550a4498827438e0#r122213856
 check_forbidden_initialization <- function() {
 
   if (is_python_initialized())

--- a/R/pyenv.R
+++ b/R/pyenv.R
@@ -217,10 +217,12 @@ pyenv_bootstrap_unix <- function() {
   on.exit(setwd(owd), add = TRUE)
 
   # pyenv python builds are substantially faster on macOS if we pre-install
-  # some dependencies (especially openssl@1.1) as pre-built but "untapped kegs"
+  # some dependencies (especially openssl) as pre-built but "untapped kegs"
   # (i.e., unlinked to somewhere on the PATH but tucked away under $BREW_ROOT/Cellar).
-  if (nzchar(Sys.which("brew")))
-    system("brew install --only-dependencies pyenv python@3.9")
+  if (nzchar(Sys.which("brew"))) {
+    system2t("brew", c("install -q openssl readline sqlite3 xz zlib tcl-tk"))
+    system2t("brew", c("install --only-dependencies pyenv python"))
+  }
 
   # download the installer
   url <- "https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer"

--- a/R/pyenv.R
+++ b/R/pyenv.R
@@ -269,7 +269,7 @@ pyenv_update <- function(pyenv = pyenv_find()) {
     system2("git", c("clone", "https://github.com/pyenv/pyenv-update.git",
                       file.path(root, "plugins/pyenv-update")))
 
-  result <- system2t(pyenv, "update", stdout = TRUE, stderr = TRUE)a
+  result <- system2t(pyenv, "update", stdout = TRUE, stderr = TRUE)
   if (result != 0L) {
     fmt <- "Error creating conda environment [exit code %i]"
     stopf(fmt, result)

--- a/R/use_python.R
+++ b/R/use_python.R
@@ -114,20 +114,24 @@ use_python <- function(python, required = NULL) {
   }
 
   if (required) {
-    if (!is.null(prior_required_python <-
-                 .globals$required_python_version) &&
+    # warn if we're overriding a previous request that will be ignored.
+    prior_required_python <- .globals$required_python_version
+    if (!is.null(prior_required_python) &&
         !isTRUE(canonical_path(prior_required_python) == canonical_path(python)))
-      warningf(
-        'Previous request to `use_python("%s", required = TRUE)` will be ignored. It is superseded by request to `use_python("%s")',
+      warningf(heredoc(c(
+        'Previous request to `use_python("%s", required = TRUE)` will be ignored.',
+        'It is superseded by request to `use_python("%s")')),
         prior_required_python, python)
 
     .globals$required_python_version <- python
 
-    if (!is.na(python_w_precedence <-
-               Sys.getenv("RETICULATE_PYTHON", NA)) &&
+    # warn if this setting will be ignored because RETICULATE_PYTHON is set
+    python_w_precedence <- Sys.getenv("RETICULATE_PYTHON", NA)
+    if (!is.na(python_w_precedence) &&
         !isTRUE(canonical_path(python_w_precedence) == canonical_path(python)))
-      warningf(
-        'The request to `use_python("%s")` will be ignored because the environment variable RETICULATE_PYTHON is set to "%s"',
+      warningf(heredoc(c(
+        'The request to `use_python("%s")` will be ignored because the',
+        'environment variable RETICULATE_PYTHON is set to "%s"')),
         python, python_w_precedence)
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -615,8 +615,14 @@ system2t <- function(command, args, ...) {
   # system2, with a trace
   # mimic bash's set -x usage of a "+" prefix for now
   # maybe someday take a dep on {cli} and make it prettier
-  message(paste("+", shQuote(command), paste0(args, collapse = " ")))
+  message(paste("+", maybe_shQuote(command), paste0(args, collapse = " ")))
   system2(command, args, ...)
+}
+
+maybe_shQuote <- function(x) {
+  if(grepl("[\\s'\"]", x))
+    x <- shQuote(x)
+  x
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -574,6 +574,10 @@ str_drop_prefix <- function(x, prefix) {
 
 }
 
+`append<-` <- function(x, value) {
+  c(x, value)
+}
+
 if (getRversion() < "3.3.0") {
 
 startsWith <- function(x, prefix) {

--- a/R/virtualenv.R
+++ b/R/virtualenv.R
@@ -1,21 +1,22 @@
 #' Interface to Python Virtual Environments
 #'
-#' R functions for managing Python [virtual environments](https://virtualenv.pypa.io/en/stable/).
+#' R functions for managing Python [virtual
+#' environments](https://virtualenv.pypa.io/en/stable/).
 #'
 #' Virtual environments are by default located at `~/.virtualenvs` (accessed
-#' with the `virtualenv_root()` function). You can change the default location by
-#' defining the `WORKON_HOME` environment variable.
+#' with the `virtualenv_root()` function). You can change the default location
+#' by defining the `WORKON_HOME` environment variable.
 #'
 #' Virtual environments are created from another "starter" or "seed" Python
 #' already installed on the system. Suitable Pythons installed on the system are
 #' found by `virtualenv_starter()`.
 #'
-#' @param envname The name of, or path to, a Python virtual environment. If
-#'   this name contains any slashes, the name will be interpreted as a path;
-#'   if the name does not contain slashes, it will be treated as a virtual
-#'   environment within `virtualenv_root()`. When `NULL`, the virtual environment
-#'   as specified by the `RETICULATE_PYTHON_ENV` environment variable will be
-#'   used instead. To refer to a virtual environment in the current working
+#' @param envname The name of, or path to, a Python virtual environment. If this
+#'   name contains any slashes, the name will be interpreted as a path; if the
+#'   name does not contain slashes, it will be treated as a virtual environment
+#'   within `virtualenv_root()`. When `NULL`, the virtual environment as
+#'   specified by the `RETICULATE_PYTHON_ENV` environment variable will be used
+#'   instead. To refer to a virtual environment in the current working
 #'   directory, you can prefix the path with `./<name>`.
 #'
 #' @param packages A character vector with package names to install or remove.
@@ -24,8 +25,8 @@
 #'
 #' @param ignore_installed Boolean; ignore previously-installed versions of the
 #'   requested packages? (This should normally be `TRUE`, so that pre-installed
-#'   packages available in the site libraries are ignored and hence packages
-#'   are installed into the virtual environment.)
+#'   packages available in the site libraries are ignored and hence packages are
+#'   installed into the virtual environment.)
 #'
 #' @param pip_options An optional character vector of additional command line
 #'   arguments to be passed to `pip`.
@@ -42,15 +43,16 @@
 #'   first deleted and recreated. Otherwise, if `FALSE`, the path to the
 #'   existing environment is returned.
 #'
-#' @param version The version of Python to be used with the newly-created
-#'   virtual environment. Python installations as installed via
-#'   [install_python()] will be used. This can also be a comma separated list of
-#'   version constraints, like `">=3.8"`, or `"<=3.11,!=3.9.3,>3.6"`
+#' @param version,python_version The version of Python to use when creating a
+#'   virtual environment. Python installations will be searched for using
+#'   [`virtualenv_starter()`]. This can a specific version, like `"3.9"` or
+#'   `"3.9.3`, or a comma separated list of version constraints, like `">=3.8"`,
+#'   or `"<=3.11,!=3.9.3,>3.6"`
 #'
 #' @param all If `TRUE`, `virtualenv_starter()` returns a 2-column data frame,
 #'   with column names `path` and `version`. If `FALSE`, only a single path to a
-#'   python binary is returned, corresponding to the first entry when
-#'   `all = TRUE`, or `NULL` if no suitable python binaries were found.
+#'   python binary is returned, corresponding to the first entry when `all =
+#'   TRUE`, or `NULL` if no suitable python binaries were found.
 #'
 #' @param packages A set of Python packages to install (via `pip install`) into
 #'   the virtual environment, after it has been created. By default, the
@@ -59,26 +61,27 @@
 #'   any packages after the virtual environment has been created.
 #'
 #' @param module The Python module to be used when creating the virtual
-#'   environment -- typically, `virtualenv` or `venv`. When `NULL` (the default),
-#'   `venv` will be used if available with Python >= 3.6; otherwise, the
-#'   `virtualenv` module will be used.
+#'   environment -- typically, `virtualenv` or `venv`. When `NULL` (the
+#'   default), `venv` will be used if available with Python >= 3.6; otherwise,
+#'   the `virtualenv` module will be used.
 #'
-#' @param system_site_packages Boolean; create new virtual environments with
-#'   the `--system-site-packages` flag, thereby allowing those virtual
-#'   environments to access the system's site packages? Defaults to `FALSE`.
+#' @param system_site_packages Boolean; create new virtual environments with the
+#'   `--system-site-packages` flag, thereby allowing those virtual environments
+#'   to access the system's site packages? Defaults to `FALSE`.
 #'
 #' @param pip_version The version of `pip` to be installed in the virtual
 #'   environment. Relevant only when `module == "virtualenv"`. Set this to
 #'   `FALSE` to disable installation of `pip` altogether.
 #'
-#' @param setuptools_version The version of `setuptools` to be installed in
-#'   the virtual environment. Relevant only when `module == "virtualenv"`.
-#'   Set this to `FALSE` to disable installation of `setuptools` altogether.
+#' @param setuptools_version The version of `setuptools` to be installed in the
+#'   virtual environment. Relevant only when `module == "virtualenv"`. Set this
+#'   to `FALSE` to disable installation of `setuptools` altogether.
 #'
 #' @param extra An optional set of extra command line arguments to be passed.
 #'   Arguments should be quoted via `shQuote()` when necessary.
 #'
-#' @param ... Optional arguments; currently ignored and reserved for future expansion.
+#' @param ... Optional arguments; currently ignored and reserved for future
+#'   expansion.
 #'
 #' @name virtualenv-tools
 NULL

--- a/R/virtualenv.R
+++ b/R/virtualenv.R
@@ -199,7 +199,8 @@ virtualenv_install <- function(envname = NULL,
                                ignore_installed = FALSE,
                                pip_options = character(),
                                requirements = NULL,
-                               ...)
+                               ...,
+                               python_version = NULL)
 {
   check_forbidden_install("Python packages")
 
@@ -222,7 +223,7 @@ virtualenv_install <- function(envname = NULL,
   # create virtual environment on demand
   path <- virtualenv_path(envname)
   if (!file.exists(path))
-    path <- virtualenv_create(envname)
+    path <- virtualenv_create(envname, version = python_version)
 
   # validate that we've received the path to a virtual environment
   name <- if (is.null(envname)) path else envname

--- a/README.md
+++ b/README.md
@@ -40,10 +40,9 @@ install.packages("reticulate")
 
 #### Python version
 
-By default, reticulate uses the version of Python found on your `PATH`
-(i.e. `Sys.which("python")`).
+By default, reticulate uses an isolated python virtual environment named "r-reticulate".
 
-The `use_python()` function enables you to specify an alternate version,
+The `use_python()` function enables you to specify an alternate python,
 for example:
 
 ``` r

--- a/man/import.Rd
+++ b/man/import.Rd
@@ -61,16 +61,16 @@ You can also provide a list of named functions, which act as callbacks to be
 run when the module is later loaded. For example:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{delay_load = list(
-  
+
   # run before the module is loaded
   before_load = function() \{ ... \}
-  
+
   # run immediately after the module is loaded
   on_load = function() \{ ... \}
-  
+
   # run if an error occurs during module import
   on_error = function(error) \{ ... \}
-  
+
 )
 }\if{html}{\out{</div>}}
 

--- a/man/import.Rd
+++ b/man/import.Rd
@@ -61,16 +61,16 @@ You can also provide a list of named functions, which act as callbacks to be
 run when the module is later loaded. For example:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{delay_load = list(
-
+  
   # run before the module is loaded
   before_load = function() \{ ... \}
-
+  
   # run immediately after the module is loaded
   on_load = function() \{ ... \}
-
+  
   # run if an error occurs during module import
   on_error = function(error) \{ ... \}
-
+  
 )
 }\if{html}{\out{</div>}}
 

--- a/man/py_discover_config.Rd
+++ b/man/py_discover_config.Rd
@@ -7,17 +7,17 @@
 py_discover_config(required_module = NULL, use_environment = NULL)
 }
 \arguments{
-\item{required_module}{A optional module name that must be available
-in order for a version of Python to be used.}
+\item{required_module}{A optional module name that will be used to select the
+Python environment used.}
 
-\item{use_environment}{An optional virtual/conda environment name
-to prefer in the search.}
+\item{use_environment}{An optional virtual/conda environment name to prefer
+in the search.}
 }
 \value{
 Python configuration object.
 }
 \description{
-This function enables callers to check which versions of Python will
-be discovered on a system as well as which one will be chosen for
-use with reticulate.
+This function enables callers to check which versions of Python will be
+discovered on a system as well as which one will be chosen for use with
+reticulate.
 }

--- a/man/virtualenv-tools.Rd
+++ b/man/virtualenv-tools.Rd
@@ -35,7 +35,8 @@ virtualenv_install(
   ignore_installed = FALSE,
   pip_options = character(),
   requirements = NULL,
-  ...
+  ...,
+  python_version = NULL
 )
 
 virtualenv_remove(envname = NULL, packages = NULL, confirm = interactive())
@@ -51,24 +52,26 @@ virtualenv_exists(envname = NULL)
 virtualenv_starter(version = NULL, all = FALSE)
 }
 \arguments{
-\item{envname}{The name of, or path to, a Python virtual environment. If
-this name contains any slashes, the name will be interpreted as a path;
-if the name does not contain slashes, it will be treated as a virtual
-environment within \code{virtualenv_root()}. When \code{NULL}, the virtual environment
-as specified by the \code{RETICULATE_PYTHON_ENV} environment variable will be
-used instead. To refer to a virtual environment in the current working
+\item{envname}{The name of, or path to, a Python virtual environment. If this
+name contains any slashes, the name will be interpreted as a path; if the
+name does not contain slashes, it will be treated as a virtual environment
+within \code{virtualenv_root()}. When \code{NULL}, the virtual environment as
+specified by the \code{RETICULATE_PYTHON_ENV} environment variable will be used
+instead. To refer to a virtual environment in the current working
 directory, you can prefix the path with \verb{./<name>}.}
 
 \item{python}{The path to a Python interpreter, to be used with the created
 virtual environment. When \code{NULL}, the Python interpreter associated with
 the current session will be used.}
 
-\item{...}{Optional arguments; currently ignored and reserved for future expansion.}
+\item{...}{Optional arguments; currently ignored and reserved for future
+expansion.}
 
-\item{version}{The version of Python to be used with the newly-created
-virtual environment. Python installations as installed via
-\code{\link[=install_python]{install_python()}} will be used. This can also be a comma separated list of
-version constraints, like \code{">=3.8"}, or \code{"<=3.11,!=3.9.3,>3.6"}}
+\item{version, python_version}{The version of Python to use when creating a
+virtual environment. Python installations will be searched for using
+\code{\link[=virtualenv_starter]{virtualenv_starter()}}. This can a specific version, like \code{"3.9"} or
+\verb{"3.9.3}, or a comma separated list of version constraints, like \code{">=3.8"},
+or \code{"<=3.11,!=3.9.3,>3.6"}}
 
 \item{packages}{A set of Python packages to install (via \verb{pip install}) into
 the virtual environment, after it has been created. By default, the
@@ -84,29 +87,29 @@ first deleted and recreated. Otherwise, if \code{FALSE}, the path to the
 existing environment is returned.}
 
 \item{module}{The Python module to be used when creating the virtual
-environment -- typically, \code{virtualenv} or \code{venv}. When \code{NULL} (the default),
-\code{venv} will be used if available with Python >= 3.6; otherwise, the
-\code{virtualenv} module will be used.}
+environment -- typically, \code{virtualenv} or \code{venv}. When \code{NULL} (the
+default), \code{venv} will be used if available with Python >= 3.6; otherwise,
+the \code{virtualenv} module will be used.}
 
-\item{system_site_packages}{Boolean; create new virtual environments with
-the \code{--system-site-packages} flag, thereby allowing those virtual
-environments to access the system's site packages? Defaults to \code{FALSE}.}
+\item{system_site_packages}{Boolean; create new virtual environments with the
+\code{--system-site-packages} flag, thereby allowing those virtual environments
+to access the system's site packages? Defaults to \code{FALSE}.}
 
 \item{pip_version}{The version of \code{pip} to be installed in the virtual
 environment. Relevant only when \code{module == "virtualenv"}. Set this to
 \code{FALSE} to disable installation of \code{pip} altogether.}
 
-\item{setuptools_version}{The version of \code{setuptools} to be installed in
-the virtual environment. Relevant only when \code{module == "virtualenv"}.
-Set this to \code{FALSE} to disable installation of \code{setuptools} altogether.}
+\item{setuptools_version}{The version of \code{setuptools} to be installed in the
+virtual environment. Relevant only when \code{module == "virtualenv"}. Set this
+to \code{FALSE} to disable installation of \code{setuptools} altogether.}
 
 \item{extra}{An optional set of extra command line arguments to be passed.
 Arguments should be quoted via \code{shQuote()} when necessary.}
 
 \item{ignore_installed}{Boolean; ignore previously-installed versions of the
 requested packages? (This should normally be \code{TRUE}, so that pre-installed
-packages available in the site libraries are ignored and hence packages
-are installed into the virtual environment.)}
+packages available in the site libraries are ignored and hence packages are
+installed into the virtual environment.)}
 
 \item{pip_options}{An optional character vector of additional command line
 arguments to be passed to \code{pip}.}
@@ -116,16 +119,15 @@ environments?}
 
 \item{all}{If \code{TRUE}, \code{virtualenv_starter()} returns a 2-column data frame,
 with column names \code{path} and \code{version}. If \code{FALSE}, only a single path to a
-python binary is returned, corresponding to the first entry when
-\code{all = TRUE}, or \code{NULL} if no suitable python binaries were found.}
+python binary is returned, corresponding to the first entry when \code{all = TRUE}, or \code{NULL} if no suitable python binaries were found.}
 }
 \description{
 R functions for managing Python \href{https://virtualenv.pypa.io/en/stable/}{virtual environments}.
 }
 \details{
 Virtual environments are by default located at \verb{~/.virtualenvs} (accessed
-with the \code{virtualenv_root()} function). You can change the default location by
-defining the \code{WORKON_HOME} environment variable.
+with the \code{virtualenv_root()} function). You can change the default location
+by defining the \code{WORKON_HOME} environment variable.
 
 Virtual environments are created from another "starter" or "seed" Python
 already installed on the system. Suitable Pythons installed on the system are

--- a/man/virtualenv-tools.Rd
+++ b/man/virtualenv-tools.Rd
@@ -14,11 +14,12 @@
 \usage{
 virtualenv_create(
   envname = NULL,
-  python = NULL,
+  python = virtualenv_starter(version),
   ...,
   version = NULL,
   packages = "numpy",
   requirements = NULL,
+  force = FALSE,
   module = getOption("reticulate.virtualenv.module"),
   system_site_packages = getOption("reticulate.virtualenv.system_site_packages", default
     = FALSE),
@@ -76,6 +77,11 @@ the virtual environment, after it has been created. By default, the
 any packages after the virtual environment has been created.}
 
 \item{requirements}{Filepath to a pip requirements file.}
+
+\item{force}{Boolean; force recreating the environment specified by
+\code{envname}, even if it already exists. If \code{TRUE}, the previous enviroment is
+first deleted and recreated. Otherwise, if \code{FALSE}, the path to the
+existing environment is returned.}
 
 \item{module}{The Python module to be used when creating the virtual
 environment -- typically, \code{virtualenv} or \code{venv}. When \code{NULL} (the default),

--- a/vignettes/package.Rmd
+++ b/vignettes/package.Rmd
@@ -8,11 +8,9 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(eval = FALSE)
 ```
-
 
 ## Delay Loading Python Modules
 
@@ -20,7 +18,7 @@ If you write an R package that wraps one or more Python packages, it's likely th
 
 When you do this, you should use the `delay_load` flag to the `import()` function, for example:
 
-```r
+``` r
 # global reference to scipy (will be initialized in .onLoad)
 scipy <- NULL
 
@@ -30,14 +28,13 @@ scipy <- NULL
 }
 ```
 
-
 Using the `delay_load` flag has two important benefits:
 
-1. It allows you to successfully load your package even when Python / Python packages are not installed on the target system (this is particularly important when testing on CRAN build machines).
+1.  It allows you to successfully load your package even when Python / Python packages are not installed on the target system (this is particularly important when testing on CRAN build machines).
 
-2. It allows users to specify a desired location for Python before interacting with your package. For example:
+2.  It allows users to specify a desired location for Python before interacting with your package. For example:
 
-    ```r
+    ``` r
     library(mypackage)
     reticulate::use_virtualenv("~/pythonenvs/userenv")
     # call functions from mypackage
@@ -45,14 +42,13 @@ Using the `delay_load` flag has two important benefits:
 
 Without the `delay_load`, Python would be loaded immediately and the user's call to `use_virtualenv` would have no effect.
 
-
 ## Installing Python Dependencies
 
-Your R package likely depends on the installation of one or more Python packages. As a convenience to your users, you may want to provide a high-level R function to allow users to install these Python packages. It's furthermore beneficial if multiple R packages that depend on Python packages install their dependencies in the same Python environment (so that they can be easily used together).
+Your R package likely depends on the installation of one or more Python packages. As a convenience to your users, you may want to provide a high-level R function to allow users to install these Python packages. By default, the Python packages should be installed in an isolated virtual environemt, but it's beneficial if users could easily configure multiple R packages to depend on a common Python environment (so that they can be easily used together).
 
 The `py_install()` function provides a high-level interface for installing one or more Python packages. The packages will by default be installed within a virtualenv or Conda environment named "r-reticulate". For example:
 
-```r
+``` r
 library(reticulate)
 py_install("scipy")
 ```
@@ -60,13 +56,13 @@ py_install("scipy")
 You can document the use of this function along with your package or alternatively provide a wrapper function for `py_install()`. For example:
 
 ```{r, eval = FALSE}
-install_scipy <- function(method = "auto", conda = "auto") {
-  reticulate::py_install("scipy", method = method, conda = conda)
+install_scipy <- function(envname = "r-scipy", method = "auto", ...) {
+  reticulate::py_install("scipy", envname = envname, 
+                         method = method, ...)
 }
 ```
 
 While reticulate is capable of binding to [any Python environment](calling_python.html#python-version) available on a system, it's much more straightforward for users if there is a common environment used by R packages with convenient high-level functions provided for installation. We therefore strongly recommend that R package developers use the approach described here.
-
 
 ## Checking and Testing on CRAN
 
@@ -74,7 +70,7 @@ If you use **reticulate** in another R package you need to account for the fact 
 
 There are two things you should do to ensure your package is well behaved on CRAN:
 
-1. Use the `delay_load` option (as described above) to ensure that the module (and Python) is loaded only on its first use. For example:
+1.  Use the `delay_load` option (as described above) to ensure that the module (and Python) is loaded only on its first use. For example:
 
     ```{r}
     # python 'scipy' module I want to use in my package
@@ -86,7 +82,7 @@ There are two things you should do to ensure your package is well behaved on CRA
     }
     ```
 
-2. When writing tests, check to see if your module is available and if it isn't then skip the test. For example, if you are using the **testthat** package, you might do this:
+2.  When writing tests, check to see if your module is available and if it isn't then skip the test. For example, if you are using the **testthat** package, you might do this:
 
     ```{r}
     # helper function to skip tests if we don't have the 'foo' module
@@ -102,7 +98,6 @@ There are two things you should do to ensure your package is well behaved on CRA
       # test code here...
     })
     ```
-
 
 ## Implementing S3 Methods
 
@@ -135,26 +130,22 @@ py_str.MyModule.MyPythonClass <- function(object, ...) {
 
 The `print` and `summary` methods for Python objects both call the `str` method by default, so if you implement `py_str()` you will automatically inherit implementations for those methods.
 
-
 ### Converting between R and Python
 
 **reticulate** provides the generics `r_to_py()` for converting R objects into Python objects, and `py_to_r()` for converting Python objects back into R objects. Package authors can provide methods for these generics to convert Python and R objects otherwise not handled by **reticulate**.
 
 **reticulate** provides conversion operators for some of the most commonly used Python objects, including:
 
-- Built-in Python objects (lists, dictionaries, numbers, strings, tuples)
-- NumPy arrays,
-- Pandas objects (`Index`, `Series`, `DataFrame`),
-- Python `datetime` objects.
+-   Built-in Python objects (lists, dictionaries, numbers, strings, tuples)
+-   NumPy arrays,
+-   Pandas objects (`Index`, `Series`, `DataFrame`),
+-   Python `datetime` objects.
 
 If you see that **reticulate** is missing support for conversion of one or more objects from these packages, please [let us know](https://github.com/rstudio/reticulate/issues) and we'll try to implement the missing converter. For Python packages not in this set, you can provide conversion operators in your own extension package.
 
-
 ### Writing your own `r_to_py()` methods
 
-`r_to_py()` accepts a `convert` argument, which controls how objects generated
-from the created Python object are converted. To illustrate, consider the
-difference between these two cases:
+`r_to_py()` accepts a `convert` argument, which controls how objects generated from the created Python object are converted. To illustrate, consider the difference between these two cases:
 
 ```{r}
 library(reticulate)
@@ -170,14 +161,11 @@ class(sys$path)
 # [1] "python.builtin.list" "python.builtin.object"
 ```
 
-This is accomplished through the use of a `convert` flag, which is set on the
-Python object wrappers used by `reticulate`. Therefore, if you're writing a
-method `r_to_py.foo()` for an object of class `foo`, you should take care to
-preserve the `convert` flag on the generated object. This is typically done by:
+This is accomplished through the use of a `convert` flag, which is set on the Python object wrappers used by `reticulate`. Therefore, if you're writing a method `r_to_py.foo()` for an object of class `foo`, you should take care to preserve the `convert` flag on the generated object. This is typically done by:
 
-1. Passing `convert` along to the appropriate lower-level `r_to_py()` method;
+1.  Passing `convert` along to the appropriate lower-level `r_to_py()` method;
 
-2. Explicitly setting the `convert` attribute on the returned Python object.
+2.  Explicitly setting the `convert` attribute on the returned Python object.
 
 As an example of the second:
 
@@ -191,12 +179,11 @@ r_to_py.my_r_object <- function(x, convert) {
 }
 ```
 
-
 ## Using Github Actions
 
 [Github Actions](https://github.com/features/actions) are commonly used for continuous integration and testing of R packages. Making it work with **reticulate** is pretty simple - all you need to do is ensure that there is a valid Python installation on the runner, and that reticulate knows to use it. You can do this all with shell commands, or you can use functions in reticulate to do this. Here is an example sequence of `steps` demonstrating how you can do this with reticulate functions:
 
-```yaml
+``` yaml
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -226,6 +213,4 @@ r_to_py.my_r_object <- function(x, convert) {
                      Sys.getenv("GITHUB_ENV"))
 
       - uses: r-lib/actions/check-r-package@v2
-
 ```
-

--- a/vignettes/package.Rmd
+++ b/vignettes/package.Rmd
@@ -44,7 +44,7 @@ Without the `delay_load`, Python would be loaded immediately and the user's call
 
 ## Installing Python Dependencies
 
-Your R package likely depends on the installation of one or more Python packages. As a convenience to your users, you may want to provide a high-level R function to allow users to install these Python packages. By default, the Python packages should be installed in an isolated virtual environemt, but it's beneficial if users could easily configure multiple R packages to depend on a common Python environment (so that they can be easily used together).
+Your R package likely depends on the installation of one or more Python packages. As a convenience to your users, you may want to provide a high-level R function to allow users to install these Python packages. By default, the Python packages should be installed in an isolated virtual environment, but it's beneficial if users could easily configure multiple R packages to depend on a common Python environment (so that they can be easily used together).
 
 The `py_install()` function provides a high-level interface for installing one or more Python packages. The packages will by default be installed within a virtualenv or Conda environment named "r-reticulate". For example:
 
@@ -53,7 +53,7 @@ library(reticulate)
 py_install("scipy")
 ```
 
-You can document the use of this function along with your package or alternatively provide a wrapper function for `py_install()`. For example:
+You can document the use of this function along with your package, or alternatively you can provide a wrapper function for `py_install()` that defaults to installing in a Python environment created specifically for your R package. For example:
 
 ```{r, eval = FALSE}
 install_scipy <- function(envname = "r-scipy", method = "auto", ...) {
@@ -62,7 +62,7 @@ install_scipy <- function(envname = "r-scipy", method = "auto", ...) {
 }
 ```
 
-While reticulate is capable of binding to [any Python environment](calling_python.html#python-version) available on a system, it's much more straightforward for users if there is a common environment used by R packages with convenient high-level functions provided for installation. We therefore strongly recommend that R package developers use the approach described here.
+For a fuller discussion of how to use reticulate in an R package, include alternative approaches, and how to create a "pit of success" for R users with regards to managing Python installations, see the guide on [Python Dependencies](python_dependencies.html) 
 
 ## Checking and Testing on CRAN
 

--- a/vignettes/package.Rmd
+++ b/vignettes/package.Rmd
@@ -46,7 +46,7 @@ Without the `delay_load`, Python would be loaded immediately and the user's call
 
 Your R package likely depends on the installation of one or more Python packages. As a convenience to your users, you may want to provide a high-level R function to allow users to install these Python packages. By default, the Python packages should be installed in an isolated virtual environment, but it's beneficial if users could easily configure multiple R packages to depend on a common Python environment (so that they can be easily used together).
 
-The `py_install()` function provides a high-level interface for installing one or more Python packages. The packages will by default be installed within a virtualenv or Conda environment named "r-reticulate". For example:
+The `py_install()` function provides a high-level interface for installing one or more Python packages. The packages will by default be installed within the currently active virtual environment or conda environment, (which is, by default, an environent named "r-reticulate"). For example:
 
 ``` r
 library(reticulate)
@@ -62,7 +62,7 @@ install_scipy <- function(envname = "r-scipy", method = "auto", ...) {
 }
 ```
 
-For a fuller discussion of how to use reticulate in an R package, include alternative approaches, and how to create a "pit of success" for R users with regards to managing Python installations, see the guide on [Python Dependencies](python_dependencies.html) 
+For a fuller discussion of how to use reticulate in an R package, include alternative approaches, and how to create a "pit of success" for R users with regards to managing Python installations, see the guide on [Python Dependencies](python_dependencies.html)
 
 ## Checking and Testing on CRAN
 

--- a/vignettes/python_dependencies.Rmd
+++ b/vignettes/python_dependencies.Rmd
@@ -3,8 +3,11 @@ title: "Managing an R Package's Python Dependencies"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Managing an R Package's Python Dependencies}
-  %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
+  %\VignetteEngine{knitr::rmarkdown}
+editor_options: 
+  markdown: 
+    wrap: 72
 ---
 
 ```{r, include = FALSE}
@@ -14,66 +17,156 @@ knitr::opts_chunk$set(
 )
 ```
 
-If you're writing an R package that uses `reticulate` as an interface to a
-Python session, you likely also need to install one or more Python packages on
-the user's machine for your package to function. In addition, you'd likely
-prefer to insulate users from details around how Python + `reticulate` are
-configured as much as possible. This vignette documents a few approaches for
-accomplishing these goals.
+If you're writing an R package that uses `reticulate` as an interface to
+a Python session, you likely also need to one or more Python packages
+installed on the user's machine for your package to function. In
+addition, you'd likely prefer to insulate users from details around how
+Python + `reticulate` are configured as much as possible. This vignette
+documents a few approaches for accomplishing these goals.
 
-## Manual Configuration
+Overall, the goal as a package author is to have safe defaults that work
+reliably and don't require users to intervene or to have a sophisticated
+understanding of python installation management. At the same time, it
+must also be easy for users to override the default behavior. There are
+two key questions to keep in mind:
 
-Previously, packages like [tensorflow](https://tensorflow.rstudio.com)
-accomplished this by providing helper functions (e.g.
-`tensorflow::install_tensorflow()`), and documenting that users should call this
-function to prepare the environment. For example:
+-   What will the default behavior be when the user expresses no
+    preference for any specific python installation, and
+-   How can users express a preference that is satisfiable, (and why
+    would they want to).
 
-```R
+Packages like [tensorflow](https://tensorflow.rstudio.com) approach this
+task this by providing a helper function,
+`tensorflow::install_tensorflow()`, and documenting that users should
+call this function to prepare the environment. For example:
+
+``` r
 library(tensorflow)
 install_tensorflow()
 # use tensorflow
 ```
 
-The biggest downside with this approach is that it requires users to manually
-download and install an appropriate version of Python. In addition, if the user
-has _not_ downloaded an appropriate version of Python, then the version
-discovered on the user's system may not conform with the requirements imposed by
-the `tensorflow` package -- leading to more trouble.
+It's best practice for the default to be to install your R packages
+python dependencies in an isolated virtualenv dedicated specifically for
+your R package. This ensures that your package doesn't accidentally
+break another python installation on the users system.
 
-Fixing this often requires instructing the user to install Python, and then use
-`reticulate` APIs (e.g. `reticulate::use_python()` and other tools) to find and
-use an appropriate Python version + environment. This is, understandably, more
-cognitive overhead than you might want to impose on users of your package.
+For example, `install_tensorflow()` takes has an argument with default:
+`envname = "r-tensorflow"`. This ensures that unless explicitly
+provided, `install_tensorflow()` will only install into an environment
+named `"r-tensorflow"`, optionally creating it as needed.
 
-Another huge problem with manual configuration is that if different R packages
-use different default Python environments, then those packages can't ever be
-loaded in the same R session (since there can only be one active Python
-environment at a time within an R session).
+The counterpart to the default behavior of `install_tensorflow()` is the
+work that happens in `tensorflow::.onLoad()`, where the R package
+expresses a preference, on behalf of the user, to use the `r-tensorflow`
+environment if it exists.
+
+```{r}
+install_tensorflow <- function(..., envname = "r-tensorflow") {
+  reticulate::py_install("tensorflow", envname = envname, ...)
+}
+
+
+tf <- NULL
+.onLoad <- function(...) {
+  tf <<- reticulate::import("tensorflow", delay_load = list(
+    environment = "r-tensorflow"
+  ))
+}
+
+```
+
+With this setup, after the user has successfully called
+`install_tensorflow()` once, then a user call to `library(tensorflow)`
+will cause reticulate to use the `r-tensorflow` environment, unless has
+explicitly expressed preference for another python installation (e.g, by
+calling `use_python()`). In other words, the R package provides hints to
+reticulate, on what environment to use if it exists, and an easy way for
+users to opt-in to making that hints actionable, by creating the
+environment.
+
+One downside of this isolated-package-environments approach is that if
+multiple R packages that use reticulate are in the same R session, then
+those packages won't all be able to use their preferred environment in
+the same R session (since there can only be one active Python
+environment at a time within an R session). To resolve this, it's
+encouraged for users to resolve this explicitly by taking a more active
+role in managing their python environments.
+
+The most straightforward approach is for users to create a dedicated
+python environment for a specific project. For example, a user can can
+do something like:
+
+```{r}
+envname <- "~/my/project/venv"
+tensorflow::install_tensorflow(envname = envname)
+sparklyr::install_sparklyr(envname = envname)
+use_virtualenv(envname)
+```
+
+This approach minimizes the risk that an already working environments
+will accidentally be broken.
+
+Another approach is for users to install your packages Python
+dependencies into another Python environment already on the search path.
+For example, users can *opt-in* to installing everything into the
+default `r-reticulate` venv:
+
+```{r}
+tensorflow::install_tensorflow(envname = "r-reticulate")
+```
+
+Or they can install spark into the default "r-tensorflow" environment:
+
+```{r}
+tensorflow::install_tensorflow()
+sparklyr::install_spark(envname = "r-tensorflow")
+```
+
+This approach empower users to configure and select the virtualenv as
+they see fit, declaring their preferences by taking advantage of the
+reticulates order of python discovery, while encouraging a default
+workflow that is robust and reliable.
 
 ## Automatic Configuration
 
-With newer versions of `reticulate`, it's possible for client packages to
-declare their Python dependencies directly in the `DESCRIPTION` file, with the
+It's possible for client packages to declare their Python dependencies
+in such a way that they are automatically installed in the actived
+python environment. This is a maximally convenient approach; when it
+works it can feel a little bit magical, but it is also potentially
+dangerous and can result in frustration. You can opt-in to this behavior
+as a package author through your packages `DESCRIPTION` file, with the
 use of the `Config/reticulate` field.
 
-With automatic configuration, `reticulate` wants to encourage a world wherein
-different R packages wrapping Python packages can live together in the same
-Python environment / R session. In essence, we would like to minimize the number
-of conflicts that could arise through different R packages having incompatible
-Python dependencies.
+With automatic configuration, `reticulate` envisions a world wherein
+different R packages wrapping Python packages can live together in the
+same Python environment / R session. This approach only works when the
+packages being wrapped don't have conflicting dependencies.
+
+You must be a judge of the python dependencies your R package
+requires--if automatically bootstrapping an installation of the python
+package into the users active python environment is a safe action to
+perform by default. For example, this is most likely a safe action for a
+python package like "requests", but perhaps not for a frequently updated
+package with many dependencies, like torch or tensorflow (e.g., it's not
+uncommon for torch and tensorflow to have conflicting version
+requirements for dependencies like numpy or cuda). Keep in mind that,
+unlike CRAN, PyPI does not perform any compatibility or consistency
+checks across the package repository.
 
 ### Using Config/reticulate
 
-For example, if we had a package `rscipy` that acted as an interface to the
-[SciPy](https://scipy.org) Python package, we might use the following
-`DESCRIPTION`:
+As a package author, you can opt-in to automatic configuration like
+this. For example, if we had a package `rscipy` that acted as an
+interface to the [SciPy](https://scipy.org) Python package, we might use
+the following `DESCRIPTION`:
 
-```
+```         
 Package: rscipy
 Title: An R Interface to scipy
 Version: 1.0.0
 Description: Provides an R interface to the Python package scipy.
-Config/reticulate:
+Config/reticulate/autoconfigure: 
   list(
     packages = list(
       list(package = "scipy")
@@ -82,93 +175,100 @@ Config/reticulate:
 < ... other fields ... >
 ```
 
-### Installation 
+### Installation
 
-With this, `reticulate` will take care of automatically configuring a Python
-environment for the user when the `rscipy` package is loaded and used (i.e. it's
-no longer necessary to provide the user with a special `install_tensorflow()`
-type function).
+With this, `reticulate` will take care of automatically configuring a
+Python environment for the user when the `rscipy` package is loaded and
+used (i.e. it's no longer necessary to provide the user with a special
+`install_tensorflow()` type function).
 
-Specifically, after the `rscipy` package is loaded, the following will occur:
+Specifically, after the `rscipy` package is loaded, the following will
+occur:
 
-1. Unless the user has explicitly instructed `reticulate` to use an existing
-   Python environment, `reticulate` will prompt the user to download and install
-   [Miniconda](https://docs.conda.io/en/latest/miniconda.html) (if necessary).
+1.  Unless the user has explicitly instructed `reticulate` to use an
+    existing Python environment, `reticulate` will prompt the user to
+    download and install
+    [Miniconda](https://docs.conda.io/en/latest/miniconda.html) (if
+    necessary).
 
-2. After this, when the Python session is initialized by `reticulate`, all
-   declared dependencies of loaded packages in `Config/reticulate` will be
-   discovered.
+2.  After this, when the Python session is initialized by `reticulate`,
+    all declared dependencies of loaded packages in `Config/reticulate`
+    will be discovered.
 
-3. These dependencies will then be installed into an appropriate Conda
-   environment, as provided by the Miniconda installation.
+3.  These dependencies will then be installed into an appropriate Conda
+    environment, as provided by the Miniconda installation.
 
-In this case, the end user workflow will be exactly as with an R package that
-has no Python dependencies:
+In this case, the end user workflow will be exactly as with an R package
+that has no Python dependencies:
 
-```r
+``` r
 library(rscipy)
 # use the package
 ```
 
-If the user has no compatible version of Python available on their system, they
-will be prompted to install Miniconda. If they do have Python already, then the
-required Python packages (in this case `scipy`) will be installed in the
-standard shared environment for R sessions (typically a virtual environment, or
-a Conda environment named "r-reticulate").
+If the user has no compatible version of Python available on their
+system, they will be prompted to install Miniconda. If they do have
+Python already, then the required Python packages (in this case `scipy`)
+will be installed in the standard shared environment for R sessions
+(typically a virtual environment, or a Conda environment named
+"r-reticulate").
 
-In effect, users have to pay a one-time, mostly-automated initialization cost in
-order to use your package, and then things will then work as any other R package
-would. In particular, users are otherwise insulated from details as to how
-`reticulate` works.
+In effect, users have to pay a one-time, mostly-automated initialization
+cost in order to use your package, and then things will then work as any
+other R package would. In particular, users are otherwise insulated from
+details as to how `reticulate` works.
 
 ### .onLoad Configuration
 
-In some cases, a user may try to load your package after Python has already been
-initialized. To ensure that `reticulate` can still configure the active Python
-environment, you can include the code:
+In some cases, a user may try to load your package after Python has
+already been initialized. To ensure that `reticulate` can still
+configure the active Python environment, you can include the code:
 
-```R
+``` r
 .onLoad <- function(libname, pkgname) {
   reticulate::configure_environment(pkgname)
 }
 ```
 
-This will instruct `reticulate` to immediately try to configure the active
-Python environment, installing any required Python packages as necessary.
+This will instruct `reticulate` to immediately try to configure the
+active Python environment, installing any required Python packages as
+necessary.
 
 ## Versions
 
 The goal of these mechanisms is to allow easy interoperability between R
-packages that have Python dependencies, as well as to minimize specialized
-version/configuration steps for end-users. To that end, `reticulate` will (by
-default) track an older version of Python than the current release, giving
-Python packages time to adapt as is required. Python 2 will not be supported.
+packages that have Python dependencies, as well as to minimize
+specialized version/configuration steps for end-users. To that end,
+`reticulate` will (by default) track an older version of Python than the
+current release, giving Python packages time to adapt as is required.
+Python 2 will not be supported.
 
-Tools for breaking these rules are not yet implemented, but will be provided as
-the need arises.
+Tools for breaking these rules are not yet implemented, but will be
+provided as the need arises.
 
 ## Format
 
 Declared Python package dependencies should have the following format:
 
-- **package**: The name of the Python package.
+-   **package**: The name of the Python package.
 
-- **version**: The version of the package that should be installed. When left
-  unspecified, the latest-available version will be installed. This should only
-  be set in exceptional cases -- for example, if the most recently-released
-  version of a Python package breaks compatibility with your package (or other
-  Python packages) in a fundamental way. If multiple R packages request
-  different versions of a particular Python package, `reticulate` will signal a
-  warning.
+-   **version**: The version of the package that should be installed.
+    When left unspecified, the latest-available version will be
+    installed. This should only be set in exceptional cases -- for
+    example, if the most recently-released version of a Python package
+    breaks compatibility with your package (or other Python packages) in
+    a fundamental way. If multiple R packages request different versions
+    of a particular Python package, `reticulate` will signal a warning.
 
-- **pip**: Whether this package should be retrieved from the
-  [PyPI](https://pypi.org) with `pip`, or (if `FALSE`) from the Anaconda
-  repositories.
+-   **pip**: Whether this package should be retrieved from the
+    [PyPI](https://pypi.org) with `pip`, or (if `FALSE`) from the
+    Anaconda repositories.
 
-For example, we could change the `Config/reticulate` directive from above to specify
-that `scipy [1.3.0]` be installed from PyPI (with `pip`):
+For example, we could change the `Config/reticulate` directive from
+above to specify that `scipy [1.3.0]` be installed from PyPI (with
+`pip`):
 
-```
+```         
 Config/reticulate:
   list(
     packages = list(
@@ -176,4 +276,3 @@ Config/reticulate:
     )
   )
 ```
-

--- a/vignettes/python_dependencies.Rmd
+++ b/vignettes/python_dependencies.Rmd
@@ -20,10 +20,11 @@ documents a few approaches for accomplishing these goals.
 ## Creating a Pit Of Success
 
 Overall, the goal of an R package author using reticulate is to create a
-default experience works reliably and don't require users to intervene
-or to have a sophisticated understanding of Python installation
-management. At the same time, it must also be easy for users to override
-the default behavior. There are two key questions to keep in mind:
+default experience that works reliably and don't require users to
+intervene or to have a sophisticated understanding of Python
+installation management. At the same time, it should also be easy to
+adjust the default behavior. There are two key questions to keep in
+mind:
 
 -   What will the default behavior be when the user expresses no
     preference for any specific Python installation, and
@@ -32,8 +33,8 @@ the default behavior. There are two key questions to keep in mind:
 
 Packages like [tensorflow](https://tensorflow.rstudio.com) approach this
 task this by providing a helper function,
-`tensorflow::install_tensorflow()`, and documenting that users should
-call this function to prepare the environment. For example:
+`tensorflow::install_tensorflow()`, and documenting that users can call
+this function to prepare the environment. For example:
 
 ``` r
 library(tensorflow)
@@ -71,20 +72,25 @@ tf <- NULL
 }a
 ```
 
-The R package expresses to reticulate a soft preference for an
-environment named "r-tensorflow", and users can make that optional hint
-actionable by actually creating the "r-tensorflow" environment.
+The R package:
+
+-   in `.onLoad()` expresses to reticulate a soft preference for an
+    environment named "r-tensorflow", and
+
+-   with `install_tensorflow()`, provides a conventint way to make the
+    optional hint in `.onLoad()` actionable, by actually creating the
+    "r-tensorflow" environment.
 
 With this setup, the default experience is for the user to call
 `install_tensorflow()` once (creating a "r-tensorflow" environment).
 Subsequently, calls to `library(tensorflow)` will cause reticulate to
 use the `r-tensorflow` environment, and for everything to "just-work".
-The risk of the Python environment disrupting or being disrupted is
-minimal, since the environment is designated for the R package. At the
-same time, if the environment is disrupted at some time later (perhaps
-because something with conflicting python dependencies was manually
-installed by the user), the user can easily revert to a working state by
-just calling `install_tensorflow()`.
+The risk of disrupting another Python environment, or of this one being
+disrupting, is minimal, since the environment is designated for the R
+package. At the same time, if the environment is disrupted at some time
+later (perhaps because something with conflicting python dependencies
+was manually installed), the user can easily revert to a working state
+by calling `install_tensorflow()`.
 
 ## Managing Multiple Package Dependencies.
 
@@ -135,11 +141,12 @@ to a particular environment, and a hint in `.onLoad()` to use that
 environment---is one way to create a "pit-of-success". It encourages a
 default workflow that is robust and reliable, especially for users
 not-yet familiar with the mechanics of Python installation management.
-At the same time, it still empowers users to configure and select a
-Python environments through a variety of ways as they see fit, either
-implicitly by creating the appropriately named environments and taking
-advantage of the reticulates order of Python discovery, or explicitly
-through function calls like `use_python()`.
+At the same time, an installation helper function empowers users to
+manage Python environments through simply providing an environment name.
+It makes it easy to combine dependencies of multiple R packages, and,
+should anything go wrong due to conflicting Python dependencies, it also
+provides a straighforward way to revert to a working state at any time,
+by calling the helper function without arguments.
 
 ## Automatic Configuration
 

--- a/vignettes/python_dependencies.Rmd
+++ b/vignettes/python_dependencies.Rmd
@@ -10,7 +10,7 @@ editor_options:
     wrap: 72
 ---
 
-```{r, include = FALSE}
+``` r
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
@@ -61,7 +61,7 @@ work that happens in `tensorflow::.onLoad()`, where the R package
 expresses a preference, on behalf of the user, to use the `r-tensorflow`
 environment if it exists.
 
-```{r}
+``` r
 install_tensorflow <- function(..., envname = "r-tensorflow") {
   reticulate::py_install("tensorflow", envname = envname, ...)
 }
@@ -97,7 +97,7 @@ The most straightforward approach is for users to create a dedicated
 python environment for a specific project. For example, a user can can
 do something like:
 
-```{r}
+``` r
 envname <- "~/my/project/venv"
 tensorflow::install_tensorflow(envname = envname)
 sparklyr::install_sparklyr(envname = envname)
@@ -112,13 +112,13 @@ dependencies into another Python environment already on the search path.
 For example, users can *opt-in* to installing everything into the
 default `r-reticulate` venv:
 
-```{r}
+``` r
 tensorflow::install_tensorflow(envname = "r-reticulate")
 ```
 
 Or they can install spark into the default "r-tensorflow" environment:
 
-```{r}
+``` r
 tensorflow::install_tensorflow()
 sparklyr::install_spark(envname = "r-tensorflow")
 ```

--- a/vignettes/python_dependencies.Rmd
+++ b/vignettes/python_dependencies.Rmd
@@ -5,8 +5,8 @@ vignette: >
   %\VignetteIndexEntry{Managing an R Package's Python Dependencies}
   %\VignetteEncoding{UTF-8}
   %\VignetteEngine{knitr::rmarkdown}
-editor_options: 
-  markdown: 
+editor_options:
+  markdown:
     wrap: 72
 ---
 
@@ -141,18 +141,19 @@ use of the `Config/reticulate` field.
 With automatic configuration, `reticulate` envisions a world wherein
 different R packages wrapping Python packages can live together in the
 same Python environment / R session. This approach only works when the
-packages being wrapped don't have conflicting dependencies.
+Python packages being wrapped don't have conflicting dependencies.
 
 You must be a judge of the python dependencies your R package
 requires--if automatically bootstrapping an installation of the python
-package into the users active python environment is a safe action to
-perform by default. For example, this is most likely a safe action for a
-python package like "requests", but perhaps not for a frequently updated
-package with many dependencies, like torch or tensorflow (e.g., it's not
-uncommon for torch and tensorflow to have conflicting version
-requirements for dependencies like numpy or cuda). Keep in mind that,
-unlike CRAN, PyPI does not perform any compatibility or consistency
-checks across the package repository.
+package into the users active python environment, whatever it may
+contain, is a safe action to perform by default. For example, this is
+most likely a safe action for a python package like "requests", but
+perhaps not for a frequently updated package with many dependencies,
+like torch or tensorflow (e.g., it's not uncommon for torch and
+tensorflow to have conflicting version requirements for dependencies
+like numpy or cuda). Keep in mind that, unlike CRAN, PyPI does not
+perform any compatibility or consistency checks across the package
+repository.
 
 ### Using Config/reticulate
 
@@ -166,7 +167,7 @@ Package: rscipy
 Title: An R Interface to scipy
 Version: 1.0.0
 Description: Provides an R interface to the Python package scipy.
-Config/reticulate/autoconfigure: 
+Config/reticulate/autoconfigure:
   list(
     packages = list(
       list(package = "scipy")

--- a/vignettes/python_dependencies.Rmd
+++ b/vignettes/python_dependencies.Rmd
@@ -10,30 +10,25 @@ editor_options:
     wrap: 72
 ---
 
-``` r
-knitr::opts_chunk$set(
-  collapse = TRUE,
-  comment = "#>"
-)
-```
-
 If you're writing an R package that uses `reticulate` as an interface to
-a Python session, you likely also need to one or more Python packages
+a Python session, you likely also need one or more Python packages
 installed on the user's machine for your package to function. In
 addition, you'd likely prefer to insulate users from details around how
 Python + `reticulate` are configured as much as possible. This vignette
 documents a few approaches for accomplishing these goals.
 
-Overall, the goal as a package author is to have safe defaults that work
-reliably and don't require users to intervene or to have a sophisticated
-understanding of python installation management. At the same time, it
-must also be easy for users to override the default behavior. There are
-two key questions to keep in mind:
+## Creating a Pit Of Success
+
+Overall, the goal of an R package author using reticulate is to create a
+default experience works reliably and don't require users to intervene
+or to have a sophisticated understanding of Python installation
+management. At the same time, it must also be easy for users to override
+the default behavior. There are two key questions to keep in mind:
 
 -   What will the default behavior be when the user expresses no
-    preference for any specific python installation, and
--   How can users express a preference that is satisfiable, (and why
-    would they want to).
+    preference for any specific Python installation, and
+-   How can users express a preference for a specific Python
+    installation that is satisfiable, (and why would they want to).
 
 Packages like [tensorflow](https://tensorflow.rstudio.com) approach this
 task this by providing a helper function,
@@ -46,20 +41,21 @@ install_tensorflow()
 # use tensorflow
 ```
 
-It's best practice for the default to be to install your R packages
-python dependencies in an isolated virtualenv dedicated specifically for
-your R package. This ensures that your package doesn't accidentally
-break another python installation on the users system.
+As a best practice, an R packages' Python dependencies should default to
+installing in an isolated virtual environment specifically designated
+for the R package. This minimizes the risk of inadvertently disrupting
+another Python installation on the user's system.
 
-For example, `install_tensorflow()` takes has an argument with default:
-`envname = "r-tensorflow"`. This ensures that unless explicitly
-provided, `install_tensorflow()` will only install into an environment
-named `"r-tensorflow"`, optionally creating it as needed.
+As an example, `install_tensorflow()` takes an argument with a default
+value: `envname = "r-tensorflow"`. This default value ensures that
+`install_tensorflow()` will install into an environment named
+`"r-tensorflow"`, optionally creating it as needed.
 
 The counterpart to the default behavior of `install_tensorflow()` is the
 work that happens in `tensorflow::.onLoad()`, where the R package
 expresses a preference, on behalf of the user, to use the `r-tensorflow`
-environment if it exists.
+environment if it exists. Inside the package, these two parts work
+together to create a "pit of success":
 
 ``` r
 install_tensorflow <- function(..., envname = "r-tensorflow") {
@@ -72,26 +68,33 @@ tf <- NULL
   tf <<- reticulate::import("tensorflow", delay_load = list(
     environment = "r-tensorflow"
   ))
-}
-
+}a
 ```
 
-With this setup, after the user has successfully called
-`install_tensorflow()` once, then a user call to `library(tensorflow)`
-will cause reticulate to use the `r-tensorflow` environment, unless has
-explicitly expressed preference for another python installation (e.g, by
-calling `use_python()`). In other words, the R package provides hints to
-reticulate, on what environment to use if it exists, and an easy way for
-users to opt-in to making that hints actionable, by creating the
-environment.
+The R package expresses to reticulate a soft preference for an
+environment named "r-tensorflow", and users can make that optional hint
+actionable by actually creating the "r-tensorflow" environment.
 
-One downside of this isolated-package-environments approach is that if
-multiple R packages that use reticulate are in the same R session, then
-those packages won't all be able to use their preferred environment in
-the same R session (since there can only be one active Python
-environment at a time within an R session). To resolve this, it's
-encouraged for users to resolve this explicitly by taking a more active
-role in managing their python environments.
+With this setup, the default experience is for the user to call
+`install_tensorflow()` once (creating a "r-tensorflow" environment).
+Subsequently, calls to `library(tensorflow)` will cause reticulate to
+use the `r-tensorflow` environment, and for everything to "just-work".
+The risk of the Python environment disrupting or being disrupted is
+minimal, since the environment is designated for the R package. At the
+same time, if the environment is disrupted at some time later (perhaps
+because something with conflicting python dependencies was manually
+installed by the user), the user can easily revert to a working state by
+just calling `install_tensorflow()`.
+
+## Managing Multiple Package Dependencies.
+
+One drawback of the isolated-package-environments approach is that if
+multiple R packages using reticulate are used, then those packages won't
+all be able to use their preferred Python environment in the same R
+session (since there can only be one active Python environment at a time
+within an R session). To resolve this, users will have to take a
+slightly more active role in managing their python environments.
+However, this can be as simple as supplying a unique environment name.
 
 The most straightforward approach is for users to create a dedicated
 python environment for a specific project. For example, a user can can
@@ -104,56 +107,68 @@ sparklyr::install_sparklyr(envname = envname)
 use_virtualenv(envname)
 ```
 
-This approach minimizes the risk that an already working environments
-will accidentally be broken.
+This approach minimizes the risk that an already working Python
+environments will accidentally be broken by installing packages, which
+may inadvertently upgrade or downgrade other packages already installed
+in the environment.
 
 Another approach is for users to install your packages Python
-dependencies into another Python environment already on the search path.
-For example, users can *opt-in* to installing everything into the
+dependencies into another Python environment that is already on the
+search path. For example, users can *opt-in* to installing into the
 default `r-reticulate` venv:
 
 ``` r
 tensorflow::install_tensorflow(envname = "r-reticulate")
 ```
 
-Or they can install spark into the default "r-tensorflow" environment:
+Or they can install one packages dependencies into another packages
+default environment. For example, installing spark into the default
+"r-tensorflow" environment:
 
 ``` r
-tensorflow::install_tensorflow()
+tensorflow::install_tensorflow() # creates an "r-tensorflow" env
 sparklyr::install_spark(envname = "r-tensorflow")
 ```
 
-This approach empower users to configure and select the virtualenv as
-they see fit, declaring their preferences by taking advantage of the
-reticulates order of python discovery, while encouraging a default
-workflow that is robust and reliable.
+This approach---exporting a installation helper function that defaults
+to a particular environment, and a hint in `.onLoad()` to use that
+environment---is one way to create a "pit-of-success". It encourages a
+default workflow that is robust and reliable, especially for users
+not-yet familiar with the mechanics of Python installation management.
+At the same time, it still empowers users to configure and select a
+Python environments through a variety of ways as they see fit, either
+implicitly by creating the appropriately named environments and taking
+advantage of the reticulates order of Python discovery, or explicitly
+through function calls like `use_python()`.
 
 ## Automatic Configuration
 
-It's possible for client packages to declare their Python dependencies
-in such a way that they are automatically installed in the actived
-python environment. This is a maximally convenient approach; when it
-works it can feel a little bit magical, but it is also potentially
-dangerous and can result in frustration. You can opt-in to this behavior
-as a package author through your packages `DESCRIPTION` file, with the
-use of the `Config/reticulate` field.
+An alternative approach to the one describe above it to do automatic
+configuration. It's possible for client packages to declare their Python
+dependencies in such a way that they are automatically installed in the
+currently activated Python environment. This is a maximally convenient
+approach; when it works it can feel a little bit magical, but it is also
+potentially dangerous and can result in frustration if something goes
+wrong. You can opt-in to this behavior as a package author through your
+packages `DESCRIPTION` file, with the use of the `Config/reticulate`
+field.
 
 With automatic configuration, `reticulate` envisions a world wherein
 different R packages wrapping Python packages can live together in the
 same Python environment / R session. This approach only works when the
 Python packages being wrapped don't have conflicting dependencies.
 
-You must be a judge of the python dependencies your R package
+You must be a judge of the Python dependencies your R package
 requires--if automatically bootstrapping an installation of the python
 package into the users active python environment, whatever it may
 contain, is a safe action to perform by default. For example, this is
-most likely a safe action for a python package like "requests", but
-perhaps not for a frequently updated package with many dependencies,
-like torch or tensorflow (e.g., it's not uncommon for torch and
-tensorflow to have conflicting version requirements for dependencies
-like numpy or cuda). Keep in mind that, unlike CRAN, PyPI does not
-perform any compatibility or consistency checks across the package
-repository.
+most likely a safe action for a Python package like "requests", but
+perhaps not a safe choice for a frequently updated package with many
+dependencies, like torch or tensorflow (e.g., it's not uncommon for
+torch and tensorflow to have conflicting version requirements for
+dependencies like numpy or cuda). Keep in mind that, unlike CRAN, PyPI
+does not perform any compatibility or consistency checks across the
+package repository.
 
 ### Using Config/reticulate
 
@@ -181,7 +196,8 @@ Config/reticulate/autoconfigure:
 With this, `reticulate` will take care of automatically configuring a
 Python environment for the user when the `rscipy` package is loaded and
 used (i.e. it's no longer necessary to provide the user with a special
-`install_tensorflow()` type function).
+`install_tensorflow()` type function, though it's still recommended to
+do so).
 
 Specifically, after the `rscipy` package is loaded, the following will
 occur:

--- a/vignettes/python_packages.Rmd
+++ b/vignettes/python_packages.Rmd
@@ -50,7 +50,7 @@ There are also functions available for directly managing both Conda and virtuale
 The following functions are available for managing Python virtualenvs:
 
 | Function               | Description                                        |
-|---------------|---------------------------------------------------------|
+|------------------------|----------------------------------------------------|
 | `virtualenv_list()`    | List all available virtualenvs                     |
 | `virtualenv_create()`  | Create a new virtualenv                            |
 | `virtualenv_install()` | Install a package within a virtualenv              |
@@ -100,7 +100,7 @@ At anytime, you can see all the available virtualenv starters on your system by 
 The following functions are available for managing Conda environments:
 
 | Function          | Description                                               |
-|---------------|---------------------------------------------------------|
+|-------------------|-----------------------------------------------------------|
 | `conda_list()`    | List all available conda environments                     |
 | `conda_create()`  | Create a new conda environment                            |
 | `conda_install()` | Install a package within a conda environment              |

--- a/vignettes/python_packages.Rmd
+++ b/vignettes/python_packages.Rmd
@@ -8,35 +8,35 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(eval = FALSE)
 ```
-
 
 ## Overview
 
 Python packages are typically installed from one of two package repositories:
 
-1) [PyPI](https://pypi.org/); or
+1)  [PyPI](https://pypi.org/); or
 
-2) [Conda](https://conda.io/docs/) 
+2)  [Conda](https://conda.io/docs/)
 
-Any Python package you install from PyPI or Conda can be used from R with reticulate. 
+Any Python package you install from PyPI or Conda can be used from R with reticulate.
 
-Each version of Python on your system has its own set of packages and reticulate will automatically find a version of Python that contains the first package that you import from R. If need be you can also configure reticulate to use a [specific version](versions.html) of Python.
+Each installation of Python on your system has its own set of packages. How reticulate selects a python installation, and how you can configure the behavior, is described in the [version](versions.html) vignette.
 
 ### Python environments
 
-When installing Python packages it's typically a good practice to isolate them within a Python environment (a named Python installation that exists for a specific project or purpose). This provides a measure of isolation, so that updating a Python package for one project doesn't impact other projects.
+When installing Python packages it's best practice to isolate them within a Python environment (a named Python installation that exists for a specific project or purpose). This provides a measure of isolation, so that updating a Python package for one project doesn't impact other projects. The risk for package incompatibilities is significantly higher with Python packages than it is with R packages, because unlike CRAN, PyPI does not enforce, or even check, if the current versions of packages currently available are compatible.
 
-The reticulate package includes functions for creating Python environments (either virtualenvs or conda envs) and installing packages within them. Using virtualenvs is supported on Linux and Mac OS X, using Conda environments is supported on all platforms including Windows.
+The reticulate package includes functions for creating Python environments (either virtualenvs or conda envs) and installing packages within them. Both virtual environments and conda environments are supported on all platforms (Linux, macOS, and Windows).
+
+Note that facilities to create and manage virtual environments (commonly refereed to as a "venv") come with the Python standard library, and are the recommended way to create isolated python installations. Conda environments are supported as well, but be aware that there is the potential for binary incompatibilities between packages built by conda and packages built outside of conda (e.g., [CRAN](https://cran.r-project.org/), or [PPM](https://packagemanager.posit.co/)).
 
 ## Simple Installation
 
 The reticulate package includes a `py_install()` function that can be used to install one or more Python packages. The packages will be by default be installed within a virtualenv or Conda environment named "r-reticulate". For example:
 
-```r
+``` r
 library(reticulate)
 py_install("pandas")
 ```
@@ -45,54 +45,16 @@ This provides a straightforward high-level interface to package installation and
 
 There are also functions available for directly managing both Conda and virtualenvs for situations where you want more control over how packages are installed. These functions are covered in the sections below.
 
-## Conda installation
-
-The following functions are available for managing Conda environments:
-
-| Function | Description                                    |
-| ------ | ----------------------------------------- |
-| `conda_list()` | List all available conda environments |
-| `conda_create()` | Create a new conda environment |
-| `conda_install()` | Install a package within a conda environment |
-| `conda_remove()` | Remove individual packages or an entire conda environment |
-
-Here's an example of using these functions to create an environment, install packages within it, then use the environment from R:
-
-```{r}
-library(reticulate)
-
-# create a new environment 
-conda_create("r-reticulate")
-
-# install SciPy
-conda_install("r-reticulate", "scipy")
-
-# import SciPy (it will be automatically discovered in "r-reticulate")
-scipy <- import("scipy")
-```
-
-Note that you may have a given Python package installed in multiple Conda environments, in that case you may want to call the `use_condaenv()` function to ensure that a specific Conda environment is utilized by reticulate:
-
-```{r}
-library(reticulate)
-
-# indicate that we want to use a specific condaenv
-use_condaenv("r-reticulate")
-
-# import SciPy (will use "r-reticulate" as per call to use_condaenv)
-scipy <- import("scipy")
-```
-
-## virtualenv installation
+## Virtualenv installation
 
 The following functions are available for managing Python virtualenvs:
 
-| Function | Description                                    |
-| ------ | ----------------------------------------- |
-| `virtualenv_list()` | List all available virtualenvs |
-| `virtualenv_create()` | Create a new virtualenv |
-| `virtualenv_install()` | Install a package within a virtualenv |
-| `virtualenv_remove()` | Remove individual packages or an entire virtualenv |
+| Function               | Description                                        |
+|---------------|---------------------------------------------------------|
+| `virtualenv_list()`    | List all available virtualenvs                     |
+| `virtualenv_create()`  | Create a new virtualenv                            |
+| `virtualenv_install()` | Install a package within a virtualenv              |
+| `virtualenv_remove()`  | Remove individual packages or an entire virtualenv |
 
 Virtual environments are by default located at `~/.virtualenvs`. You can change this behavior by defining the `WORKON_HOME` environment variable.
 
@@ -123,11 +85,59 @@ use_virtualenv("r-reticulate")
 scipy <- import("scipy")
 ```
 
+Virtual environments are typically derived from (created using) a "starter" python installation. That is, there must be a python installation already installed on the system before you can create virtual environments. You can install a "venv starter" python in a variety of ways, however is most convenient:
+
+-   On macOS and Windows, visit <https://www.python.org/downloads/> and install a suitable version for your system.
+-   On Linux, you can use prebuilt python binaries from <https://github.com/rstudio/python-builds>
+-   On all platforms, you can use `reticulate::install_python()`. Note that on macOS and Linux, this will build Python from source on your system, which may take up to a few minutes.
+
+There can be multiple versions of Python installed along-side each other on a system (for example, Python versions 3.9, 3.10, and 3.11). By default, reticulate will use the latest version installed on the system for creating the virtualenv. If you have specific version constraints on the version of Python required, you can supply those to the `version` argument--for example: `virtualenv_create(version = ">=3.9")`
+
+At anytime, you can see all the available virtualenv starters on your system by calling `virtualenv_starter(all = TRUE)`. If you have Python venv starters installed in non-standard locations, you can inform reticulate where to look by setting the environment variable `RETICULATE_VIRTUALENV_STARTER`.
+
+## Conda installation
+
+The following functions are available for managing Conda environments:
+
+| Function          | Description                                               |
+|---------------|---------------------------------------------------------|
+| `conda_list()`    | List all available conda environments                     |
+| `conda_create()`  | Create a new conda environment                            |
+| `conda_install()` | Install a package within a conda environment              |
+| `conda_remove()`  | Remove individual packages or an entire conda environment |
+
+Here's an example of using these functions to create an environment, install packages within it, then use the environment from R:
+
+```{r}
+library(reticulate)
+
+# create a new environment 
+conda_create("r-reticulate")
+
+# install SciPy
+conda_install("r-reticulate", "scipy")
+
+# import SciPy (it will be automatically discovered in "r-reticulate")
+scipy <- import("scipy")
+```
+
+Note that you may have a given Python package installed in multiple Conda environments, in that case you may want to call the `use_condaenv()` function to ensure that a specific Conda environment is utilized by reticulate:
+
+```{r}
+library(reticulate)
+
+# indicate that we want to use a specific condaenv
+use_condaenv("r-reticulate")
+
+# import SciPy (will use "r-reticulate" as per call to use_condaenv)
+scipy <- import("scipy")
+```
+
 ## Shell installation
 
 You can also use standard shell installation utilities (`pip` or `conda`) to install Python packages:
 
-```bash
+``` bash
 # install into system level Python
 $ sudo pip install SciPy
 
@@ -137,3 +147,8 @@ $ conda install SciPy
 
 When doing this, be sure to make note of which version of Python your package has been installed within, and call `use_python()` functions as appropriate to ensure that this version is used by reticulate.
 
+Alternatively, within `repl_python()`, you can prefix `!` to send a shell command, and the version of `pip` or `conda` used will already be configured for the Python installation reticulate is currently using.
+
+``` shell
+!pip install scipy
+```

--- a/vignettes/python_packages.Rmd
+++ b/vignettes/python_packages.Rmd
@@ -22,7 +22,7 @@ Python packages are typically installed from one of two package repositories:
 
 Any Python package you install from PyPI or Conda can be used from R with reticulate.
 
-Each installation of Python on your system has its own set of packages. How reticulate selects a python installation, and how you can configure the behavior, is described in the [version](versions.html) vignette.
+Each installation of Python on your system has its own set of packages. How reticulate selects a Python installation, and how you can configure the behavior, is described in the [version](versions.html) vignette.
 
 ### Python environments
 
@@ -50,7 +50,7 @@ There are also functions available for directly managing both Conda and virtuale
 The following functions are available for managing Python virtualenvs:
 
 | Function               | Description                                        |
-|------------------------|----------------------------------------------------|
+|-----------------------|-------------------------------------------------|
 | `virtualenv_list()`    | List all available virtualenvs                     |
 | `virtualenv_create()`  | Create a new virtualenv                            |
 | `virtualenv_install()` | Install a package within a virtualenv              |
@@ -100,7 +100,7 @@ At anytime, you can see all the available virtualenv starters on your system by 
 The following functions are available for managing Conda environments:
 
 | Function          | Description                                               |
-|-------------------|-----------------------------------------------------------|
+|-------------------|-----------------------------------------------------|
 | `conda_list()`    | List all available conda environments                     |
 | `conda_create()`  | Create a new conda environment                            |
 | `conda_install()` | Install a package within a conda environment              |

--- a/vignettes/versions.Rmd
+++ b/vignettes/versions.Rmd
@@ -8,15 +8,17 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(eval = FALSE)
 ```
 
-
 ## Locating Python
 
-It is not uncommon for several version of Python (and several conda or virtualenv environments within a given version) to be available on a given system. The **reticulate** package can bind to any of these versions, and in all cases will attempt to locate a version which includes the first Python package imported via the `import()` function. Consider the following code:
+It is not uncommon for several versions of Python (and several conda or virtualenv environments derived from a given version) to be available on a given system. The **reticulate** package can bind to any of these python installations, and provides a variety of convenient ways to allow the user to implicitly or explicitly specify which python installation to select.
+
+Note that for reticulate to bind to a version of Python it must have been compiled with shared library support (i.e. with the `--enable-shared` flag).
+
+Consider the following code:
 
 ```{r}
 library(reticulate)
@@ -24,25 +26,21 @@ scipy <- import("scipy")
 scipy$amin(c(1,3,5,7))
 ```
 
-In this case, the various versions of Python installed on the system will be scanned to see whether one of them includes the "scipy" Python package (the first version found that satisfies this requirement will be used).
-
-By default, the version of Python found on the system `PATH` is checked first, and then some other conventional location for Py Python (e.g. `/usr/local/bin/python`, `/opt/local/bin/python`, etc.) are checked.
-
-Note that for reticulate to bind to a version of Python it must be compiled with shared library support (i.e. with the `--enable-shared` flag).
+In this case, reticulate will search for a suitable python installation. In the absence of other hints, reticulate will first look for an environment named "r-scipy", and if that doesn't exist, it will fallback to the environment named "r-reticulate".
 
 ## Providing Hints
 
 There are two ways you can provide hints as to which version of Python should be used:
 
-1. By setting the value of the `RETICULATE_PYTHON` environment variable to a Python binary. Note that if you set this environment variable, then the specified version of Python will always be used (i.e. this is prescriptive rather than advisory). To set the value of `RETICULATE_PYTHON`, insert `Sys.setenv(RETICULATE_PYTHON = PATH)` into your project's .Rprofile, where `PATH` is your preferred Python binary.
+1.  By setting the value of the `RETICULATE_PYTHON` environment variable to a Python binary. Note that if you set this environment variable, then the specified version of Python will always be used (i.e. this is prescriptive rather than advisory). To set the value of `RETICULATE_PYTHON`, insert `Sys.setenv(RETICULATE_PYTHON = PATH)` into your project's .Rprofile, where `PATH` is your preferred Python binary.
 
-2. By calling one of the these functions:
+2.  By calling one of the these functions:
 
-  | Function  | Description | 
-  |----------------|------------------------------------------------------------------|
-  | `use_python()` | Specify the path a specific Python binary. | 
-  | `use_virtualenv()` | Specify the directory containing a Python virtualenv. | 
-  | `use_condaenv()` | Specify the name of a Conda environment. | 
+| Function           | Description                                           |
+|-----------------------|-------------------------------------------------|
+| `use_python()`     | Specify the path a specific Python binary.            |
+| `use_virtualenv()` | Specify the name of (or path to) a Python virtualenv. |
+| `use_condaenv()`   | Specify the name of a Conda environment.              |
 
 For example:
 
@@ -53,13 +51,15 @@ use_virtualenv("~/myenv")
 use_condaenv("myenv")
 ```
 
-The `use_condaenv` function will use whatever conda binary is found on the system PATH. If you want to use a specific alternate version you can use the `conda` parameter. For example:
+If the `use_virtualenv()` function is supplied a name of a virtual environment (as opposed to a path), it will look in the virtualenv root directory, by default `~/.virtualenvs`, and configurable by setting the environment variable `WORKON_HOME`.
+
+The `use_condaenv` function will use whatever conda binary is found on the `PATH`. If you want to use a specific alternate version you can use the `conda` parameter. For example:
 
 ```{r}
 use_condaenv(condaenv = "r-nlp", conda = "/opt/anaconda3/bin/conda")
 ```
 
-Note that the `use` functions are by default considered only hints as to where to find Python (i.e. they don't produce errors if the specified version doesn't exist). You can add the `required` parameter to ensure that the specified version of Python is always used (it will be an error if the specified version doesn't exist):
+Note that the `use` functions take an optional `required` argument. By default, a value of `required = NULL` is equivalent to `required = TRUE` in most circumstances, excepting if the call is made from within an R packages `.onLoad()` hook. If `required = FALSE` is supplied (or implicitly when the call is made from within a packages `.onLoad()`), then the call is considered only as a hint as to where to find Python (i.e. it doesn't produce an error if the specified version doesn't exist). You can add the `required` parameter to ensure that the specified version of Python is always used (it will be an error if the specified version doesn't exist):
 
 ```{r}
 use_virtualenv("~/myenv", required = TRUE)
@@ -67,31 +67,35 @@ use_virtualenv("~/myenv", required = TRUE)
 
 ## Order of Discovery
 
-The order in which versions of Python will be discovered and used is as follows:
+The order in which Python installation will be discovered and used is as follows:
 
-1.  If specified, at the location referenced by the `RETICULATE_PYTHON` environment variable.
+1.  If specified, the location referenced by the `RETICULATE_PYTHON` environment variable. (Path to a python binary)
 
-2.  If specified, at the locations referenced by calls to `use_python()`, `use_virtualenv()`, and `use_condaenv()`.
+2.  If specified, the location referenced by the `RETICULATE_PYTHON_ENV` environment variable. (Path to or name of a virtual environment or conda environment)
 
-3. Within virtualenvs and conda envs that carry the same name as the first module imported. For example, if you execute `import("nltk")` then the following locations (among other similar ones) would be scanned for a version of Python with the **nltk** module installed:
+3.  If specified, the location referenced by calls to `use_python()`, `use_virtualenv()`, and `use_condaenv()`, excepting if the call is made with `required = FALSE`, or is from within a package `.onLoad()` call.
 
-    - $WORKON_HOME/nltk
-    - ~/.virtualenvs/nltk
-    - ~/anaconda/envs/nltk
-    - ~/nltk
+4.  If the current working directory contains a pyproject.toml file from a poetry environment, the python installation from the poetry environment is used.
 
-4.  At the location of the Python binary discovered on the system `PATH` (via the `Sys.which` function).
+5.  If the current working directory contains a Pipfile associated with a pipenv, the python installation from the pipenv is used.
 
-5.  At other customary locations for Python including `/usr/local/bin/python`, `/opt/local/bin/python`, etc.
+6.  If there was a call (typically from within a package using reticulate), `import("bar", delay_load = list(environment = "r-barlyr")`, and there exists a virtual environment or conda environment named `"r-barlyr"`, it is used.
 
-The scanning for and binding to a version of Python typically occurs at the time of the first call to `import()` within an R session. As a result, priority will be given to versions of Python that include the module specified within the call to `import()` (i.e. versions that don't include it will be skipped).
+7.  If there was a call to `import("bar")`, and there exists a virtual environment or conda environment named `"r-bar"`, it is used.
+
+8.  If any calls to `use_python()`, `use_virtualenv()`, and `use_condaenv()` were made from within a package `.onLoad()` call, or with `required = FALSE` supplied, those locations are used.
+
+9.  If the environment variable `VIRTUAL_ENV` is defined (typically from running an `activate` script before R started), that python from the activated environment is used.
+
+10. If specified, the location referenced by the `RETICULATE_PYTHON_FALLBACK` environment variable. (Path to a python binary)
+
+11. In the absence of any expression of preference via one of the ways outlined above, reticulate falls back to using a virtual environment named `"r-reticulate"`. If one does not exist, reticulate will offer to create one.
+
+12. If the "r-reticulate" environment is not available and cannot be created, then we fall back to using the python on the `PATH`.
 
 ## Python Packages
 
-Each version of Python on your system has its own set of packages and as described above reticulate will automatically find a version of Python that contains the first package that you import from R. 
-
 You can learn more about installing Python packages into virtualenvs or Conda environments in the article on [Installing Python Packages](python_packages.html).
-
 
 ## Configuration Info
 
@@ -106,4 +110,3 @@ You can also use the `py_discover_config()` function to see what version of Pyth
 ```{r}
 py_discover_config()
 ```
-

--- a/vignettes/versions.Rmd
+++ b/vignettes/versions.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "Python Version Configuration"
-output: 
+output:
   rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Python Version Configuration}
@@ -81,9 +81,9 @@ The order in which Python installation will be discovered and used is as follows
 
 6.  If there was a call (typically from within a package using reticulate), `import("bar", delay_load = list(environment = "r-barlyr")`, and there exists a virtual environment or conda environment named `"r-barlyr"`, it is used.
 
-7.  If there was a call to `import("bar")`, and there exists a virtual environment or conda environment named `"r-bar"`, it is used.
+7.  If any calls to `use_python()`, `use_virtualenv()`, and `use_condaenv()` were made from within a package `.onLoad()` call, or with `required = FALSE` supplied, those locations are used.
 
-8.  If any calls to `use_python()`, `use_virtualenv()`, and `use_condaenv()` were made from within a package `.onLoad()` call, or with `required = FALSE` supplied, those locations are used.
+8.  If there was a call to `import("bar")`, and there exists a virtual environment or conda environment named `"r-bar"`, it is used.
 
 9.  If the environment variable `VIRTUAL_ENV` is defined (typically from running an `activate` script before R started), that python from the activated environment is used.
 

--- a/vignettes/versions.Rmd
+++ b/vignettes/versions.Rmd
@@ -14,7 +14,7 @@ knitr::opts_chunk$set(eval = FALSE)
 
 ## Locating Python
 
-It is not uncommon for several versions of Python (and several conda or virtualenv environments derived from a given version) to be available on a given system. The **reticulate** package can bind to any of these python installations, and provides a variety of convenient ways to allow the user to implicitly or explicitly specify which python installation to select.
+It is not uncommon for several installations of Python to be available on a given system. The **reticulate** package can bind to almost any Python installations, and provides a variety of convenient ways to allow the user to implicitly or explicitly specify which Python installation to select.
 
 Note that for reticulate to bind to a version of Python it must have been compiled with shared library support (i.e. with the `--enable-shared` flag).
 
@@ -22,22 +22,31 @@ Consider the following code:
 
 ```{r}
 library(reticulate)
+py_eval("1+1")
+```
+
+In this case, reticulate will search for a suitable Python installation. In the absence of other hints (detailed below), reticulate will fallback to an environment named "r-reticulate", creating it if necessary.
+
+Consider another case:
+
+```{r}
+library(reticulate)
 scipy <- import("scipy")
 scipy$amin(c(1,3,5,7))
 ```
 
-In this case, reticulate will search for a suitable python installation. In the absence of other hints, reticulate will first look for an environment named "r-scipy", and if that doesn't exist, it will fallback to the environment named "r-reticulate".
+In this case, reticulate will first look for an environment named "r-scipy", and if that doesn't exist, it will fallback to the environment named "r-reticulate".
 
 ## Providing Hints
 
-There are two ways you can provide hints as to which version of Python should be used:
+There are a few ways you can provide hints as to which version of Python should be used:
 
 1.  By setting the value of the `RETICULATE_PYTHON` environment variable to a Python binary. Note that if you set this environment variable, then the specified version of Python will always be used (i.e. this is prescriptive rather than advisory). To set the value of `RETICULATE_PYTHON`, insert `Sys.setenv(RETICULATE_PYTHON = PATH)` into your project's .Rprofile, where `PATH` is your preferred Python binary.
 
 2.  By calling one of the these functions:
 
 | Function           | Description                                           |
-|-----------------------|-------------------------------------------------|
+|--------------------|-------------------------------------------------------|
 | `use_python()`     | Specify the path a specific Python binary.            |
 | `use_virtualenv()` | Specify the name of (or path to) a Python virtualenv. |
 | `use_condaenv()`   | Specify the name of a Conda environment.              |
@@ -53,39 +62,35 @@ use_condaenv("myenv")
 
 If the `use_virtualenv()` function is supplied a name of a virtual environment (as opposed to a path), it will look in the virtualenv root directory, by default `~/.virtualenvs`, and configurable by setting the environment variable `WORKON_HOME`.
 
-The `use_condaenv` function will use whatever conda binary is found on the `PATH`. If you want to use a specific alternate version you can use the `conda` parameter. For example:
+The `use_condaenv()` function will use whatever conda binary is found on the `PATH`. If you want to use a specific alternate version you can use the `conda` parameter. For example:
 
 ```{r}
 use_condaenv(condaenv = "r-nlp", conda = "/opt/anaconda3/bin/conda")
 ```
 
-Note that the `use` functions take an optional `required` argument. By default, a value of `required = NULL` is equivalent to `required = TRUE` in most circumstances, excepting if the call is made from within an R packages `.onLoad()` hook. If `required = FALSE` is supplied (or implicitly when the call is made from within a packages `.onLoad()`), then the call is considered only as a hint as to where to find Python (i.e. it doesn't produce an error if the specified version doesn't exist). You can add the `required` parameter to ensure that the specified version of Python is always used (it will be an error if the specified version doesn't exist):
-
-```{r}
-use_virtualenv("~/myenv", required = TRUE)
-```
+Note that the `use_*()` functions take an optional `required` argument. By default, a value of `required = NULL` is equivalent to `required = TRUE` in most circumstances. If `required = FALSE` is supplied, then the call is considered an optional hint as to where to find Python (i.e. it doesn't produce an error if the specified version doesn't exist).
 
 ## Order of Discovery
 
 The order in which Python installation will be discovered and used is as follows:
 
-1.  If specified, the location referenced by the `RETICULATE_PYTHON` environment variable. (Path to a python binary)
+1.  If specified, the location referenced by the `RETICULATE_PYTHON` environment variable. (Path to a Python binary)
 
 2.  If specified, the location referenced by the `RETICULATE_PYTHON_ENV` environment variable. (Path to or name of a virtual environment or conda environment)
 
 3.  If specified, the location referenced by calls to `use_python()`, `use_virtualenv()`, and `use_condaenv()`, excepting if the call is made with `required = FALSE`, or is from within a package `.onLoad()` call.
 
-4.  If the current working directory contains a pyproject.toml file from a poetry environment, the python installation from the poetry environment is used.
+4.  If the current working directory contains a pyproject.toml file from a poetry environment, the Python installation from the poetry environment is used.
 
-5.  If the current working directory contains a Pipfile associated with a pipenv, the python installation from the pipenv is used.
+5.  If the current working directory contains a Pipfile associated with a pipenv, the Python installation from the pipenv is used.
 
-6.  If there was a call (typically from within a package using reticulate), `import("bar", delay_load = list(environment = "r-barlyr")`, and there exists a virtual environment or conda environment named `"r-barlyr"`, it is used.
+6.  If there was a call (typically from within a package using reticulate), of the form: `import("bar", delay_load = list(environment = "r-barlyr")`, and there exists a virtual environment or conda environment named `"r-barlyr"`, it is used.
 
 7.  If any calls to `use_python()`, `use_virtualenv()`, and `use_condaenv()` were made from within a package `.onLoad()` call, or with `required = FALSE` supplied, those locations are used.
 
 8.  If there was a call to `import("bar")`, and there exists a virtual environment or conda environment named `"r-bar"`, it is used.
 
-9.  If the environment variable `VIRTUAL_ENV` is defined (typically from running an `activate` script before R started), that python from the activated environment is used.
+9.  If the environment variable `VIRTUAL_ENV` is defined (typically from running an `activate` script before R started), then the Python from the activated environment is used.
 
 10. If specified, the location referenced by the `RETICULATE_PYTHON_FALLBACK` environment variable. (Path to a python binary)
 


### PR DESCRIPTION
This PR adjusts the logic that reticulate uses to determine which python installation to load. The changes are mostly related to the choices reticulate makes in the absence of any concrete preference expressed by the user via `use_python()`, `RETICULATE_PYTHON`, or similar.

Previously, reticulate would prompt the user to install miniconda, bootstrap a "r-reticulate" conda environment, or go searching through all known venvs and conda envs for the presence of a requested module.

New behavior highlights:

-   No longer prompt to install miniconda. Instead, at a similar point in the order of discovery, we prompt the user to instead create a default "r-reticulate" venv.

-   We give higher precedence now to explicitly provided hints of the form:

    -   `import("bar", delay_load = list(environment = "r-barlyr")`
    -   `use_python("/path/to/bin/python", required = FALSE)`

-   We give higher precedence to module derived env names when we're initializing because of a call to import that module. In other words, in the absence of more a more concrete expression of preference (`RETICULATE_PYTHON` env var, `use_python(required = TRUE)`, etc) if the user calls `import("scipy")`, and there exists an environment `"r-scipy"`, we use it.

-   If there is no suitable python installation to create a venv from, we ask the user to install python manually, suggesting options:

    -   on all platforms, `reticulate::install_python()`,
    -   on macOS and Windows, `www.python.org/downloads/`,
    -   on Linux, https://github.com/rstudio/python-builds.
    -   There is also a new environment variable `RETICULATE_VIRTUALENV_STARTER` and `option("reticulate.virtualenv.starter")` which users can use for pointing reticulate at suitable venv starters, encoded in the function `virtualenv_starter()`, though this should be not needed by most users.
    
-  We no longer scan all known pythons. Absent any expression of preference for a particular python from the user, we fall back to a `r-reticulate` venv, or if user explicitly opts out of that, to the python on the PATH. 
- The previous approach went to great lengths to succeed in finding a Python that satisfied a particular `import()` call, and often did. However, the search behavior made predicting which python installation would be found very difficult, and subject to change as the environments on the system changed. Now we no longer use the presence of an installed module as criteria for selecting a particular python installation.

This is the new order of precedence for selecting a python:

1.  `RETICULATE_PYTHON` env var (path to python binary)

2.  `RETICULATE_PYTHON_ENV` env var (path to venv or condaenv directory, or bare name of venv or conda env) (previously this only accepted a full path)

3.  `use_python(required = TRUE)` call (and related, `use_virtualenv()`, `use_condaenv()`)

4.  Presence of a `pyproject.toml` file from a poetry environment in the current working directory

5.  Presence of a pipfile associated with a pipenv in the current working directory

6.  If there was a call `import("bar", delay_load = list(environment = "r-barlyr")`, and there exists an environment named "r-barlyr", use it.

7.  `use_python(required = FALSE)`

8.  If there was a call `import("bar")`, and there exists an environment named `r-bar` , use that.

10. If we're running under an activated virtualenv (i.e., the `python` on the PATH is a virtualenv, use that).

11.  env var `RETICULATE_PYTHON_FALLBACK`

12. In the absence of any expression of preference from the user, (via one of the ways outlined above) we fallback to using a `r-reticulate` virtual environment. If one does not exist, we prompt the user to create one.

13. If the user declines to use the "r-reticulate" environment, then we fall back to using the python on the PATH.
