### PR TITLE
Render markdown quietly to avoid flooding tests

### DIFF
--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -625,7 +625,9 @@ eng_python_autoprint <- function(captured, options) {
 
   } else if (isHtml && py_has_method(value, "_repr_html_")) {
 
-    data <- as_r_value(value$`_repr_html_`())
+    py_capture_output({
+      data <- as_r_value(value$`_repr_html_`())
+    })
     .engine_context$pending_plots$push(knitr::raw_html(data))
     return("")
 

--- a/tests/testthat/resources/eng-reticulate-example.Rmd
+++ b/tests/testthat/resources/eng-reticulate-example.Rmd
@@ -173,7 +173,7 @@ fig = px.scatter(x=[1, 2, 3], y=[5, 4, 6])
 ```
 
 ```{python}
-fig
+# fig
 ```
 
 `_repr_html_()` methods are not called with unbound `__self__`

--- a/tests/testthat/resources/eng-reticulate-example.Rmd
+++ b/tests/testthat/resources/eng-reticulate-example.Rmd
@@ -173,7 +173,7 @@ fig = px.scatter(x=[1, 2, 3], y=[5, 4, 6])
 ```
 
 ```{python}
-# fig
+fig
 ```
 
 `_repr_html_()` methods are not called with unbound `__self__`

--- a/tests/testthat/test-python-knitr-engine.R
+++ b/tests/testthat/test-python-knitr-engine.R
@@ -37,7 +37,7 @@ test_that("In Rmd chunks, comments and output attach to code correctly", {
   # TODO: update the full testsuite to testthat edition 3
 
   owd <- setwd(test_path("resources"))
-  rmarkdown::render("test-chunking.Rmd")
+  rmarkdown::render("test-chunking.Rmd", quiet = TRUE)
 
   expect_snapshot_file("test-chunking.md")
   setwd(owd)
@@ -53,7 +53,7 @@ test_that("knitr 'warning=FALSE' option", {
   local_edition(3) # needed for expect_snapshot_file()
 
   owd <- setwd(test_path("resources"))
-  rmarkdown::render("knitr-warn.Rmd")
+  rmarkdown::render("knitr-warn.Rmd", quiet = TRUE)
   setwd(owd)
 
   rendered <- test_path("resources", "knitr-warn.md")


### PR DESCRIPTION
Should make testthat output less verbose.