### PR TITLE
Still include the stdout output captured before the autoprint mechanism.

### DIFF
--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -196,11 +196,15 @@ eng_python <- function(options) {
     # clear the last value object (so we can tell if it was updated)
     py_compile_eval("'__reticulate_placeholder__'")
 
+    # use trailing semicolon to suppress output of return value
+    suppress <- grepl(";\\s*$", snippet) || (jupyter_compat & !last_range)
+    compile_mode <- if (suppress) "exec" else "single"
+
     # run code and capture output
     captured_stdout <- if (capture_errors)
-      tryCatch(py_compile_eval(snippet, 'single'), error = identity)
+      tryCatch(py_compile_eval(snippet, compile_mode), error = identity)
     else
-      py_compile_eval(snippet, 'single')
+      py_compile_eval(snippet, compile_mode)
 
     # handle matplotlib plots and other special output
     captured <- eng_python_autoprint(
@@ -210,7 +214,7 @@ eng_python <- function(options) {
 
     # A trailing ';' suppresses output.
     # In jupyter mode, only the last expression in a chunk has repr() output.
-    if (grepl(";\\s*$", snippet) | (jupyter_compat & !last_range))
+    if (suppress)
       captured <- captured_stdout
 
     # emit outputs if we have any

--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -197,21 +197,21 @@ eng_python <- function(options) {
     py_compile_eval("'__reticulate_placeholder__'")
 
     # run code and capture output
-    captured <- if (capture_errors)
+    captured_stdout <- if (capture_errors)
       tryCatch(py_compile_eval(snippet, 'single'), error = identity)
     else
       py_compile_eval(snippet, 'single')
 
     # handle matplotlib plots and other special output
     captured <- eng_python_autoprint(
-      captured = captured,
+      captured = captured_stdout,
       options  = options
     )
 
     # A trailing ';' suppresses output.
     # In jupyter mode, only the last expression in a chunk has repr() output.
     if (grepl(";\\s*$", snippet) | (jupyter_compat & !last_range))
-      captured <- ""
+      captured <- captured_stdout
 
     # emit outputs if we have any
     has_outputs <-

--- a/tests/testthat/_snaps/python-knitr-engine/knitr-print.md
+++ b/tests/testthat/_snaps/python-knitr-engine/knitr-print.md
@@ -2,3 +2,42 @@
     bt$print("Hello world")
 
     ## Hello world
+
+Both in `jupyter_compat = TRUE` and `jupyter_compat = FALSE` we should
+see the results, because a `print` was called:
+
+    print(1)
+
+    ## 1
+
+    print(2)
+
+    ## 2
+
+    print(1)
+
+    ## 1
+
+    print(2)
+
+    ## 2
+
+For the `jupyter_compat = FALSE` mode we should see the output of both
+expressions. In `jupyter_compat`, we should only see the output for the
+last expression.
+
+    1 + 0
+
+    ## 1
+
+    1 + 1
+
+    ## 2
+
+    1 + 0
+
+    ## 1
+
+    1 + 1
+
+    ## 2

--- a/tests/testthat/_snaps/python-knitr-engine/knitr-print.md
+++ b/tests/testthat/_snaps/python-knitr-engine/knitr-print.md
@@ -68,3 +68,18 @@ output
 
     1 + 0;
     1 + 1;
+
+## `jupyter_compat` works with interleaved expressions
+
+    print('first_stdout')
+
+    ## first_stdout
+
+    'first_expression'
+    print('second_stdout')
+
+    ## second_stdout
+
+    'final_expression'
+
+    ## 'final_expression'

--- a/tests/testthat/_snaps/python-knitr-engine/knitr-print.md
+++ b/tests/testthat/_snaps/python-knitr-engine/knitr-print.md
@@ -3,6 +3,8 @@
 
     ## Hello world
 
+## Print statements should always be captured
+
 In `jupyter_compat = FALSE`: we should only see the output of both
 expressions.
 
@@ -25,6 +27,8 @@ expressions.
 
     ## 2
 
+## Only outputs of last expressions are captured in jupyter compat
+
 In `jupyter_compat = FALSE`: we should only see the output of both
 expressions.
 
@@ -43,3 +47,24 @@ expression.
     1 + 1
 
     ## 2
+
+## One can disable outputs by using `;`
+
+In `jupyter_compat = FALSE`: we should only see the print statement
+output
+
+    print("hello");
+
+    ## hello
+
+    1 + 0;
+    1 + 1;
+
+`jupyter_compat = TRUE`: we should only see the print statement output
+
+    print("hello");
+
+    ## hello
+
+    1 + 0;
+    1 + 1;

--- a/tests/testthat/_snaps/python-knitr-engine/knitr-print.md
+++ b/tests/testthat/_snaps/python-knitr-engine/knitr-print.md
@@ -3,8 +3,8 @@
 
     ## Hello world
 
-Both in `jupyter_compat = TRUE` and `jupyter_compat = FALSE` we should
-see the results, because a `print` was called:
+In `jupyter_compat = FALSE`: we should only see the output of both
+expressions.
 
     print(1)
 
@@ -14,6 +14,9 @@ see the results, because a `print` was called:
 
     ## 2
 
+In `jupyter_compat = TRUE`: we should only see the output of both
+expressions.
+
     print(1)
 
     ## 1
@@ -22,9 +25,8 @@ see the results, because a `print` was called:
 
     ## 2
 
-For the `jupyter_compat = FALSE` mode we should see the output of both
-expressions. In `jupyter_compat`, we should only see the output for the
-last expression.
+In `jupyter_compat = FALSE`: we should only see the output of both
+expressions.
 
     1 + 0
 
@@ -34,10 +36,10 @@ last expression.
 
     ## 2
 
+`jupyter_compat = TRUE`: we should only see the output of the last
+expression.
+
     1 + 0
-
-    ## 1
-
     1 + 1
 
     ## 2

--- a/tests/testthat/_snaps/python-knitr-engine/knitr-print2.md
+++ b/tests/testthat/_snaps/python-knitr-engine/knitr-print2.md
@@ -2,3 +2,36 @@
     bt$print("Hello world")
 
     ## Hello world
+
+Both in `jupyter_compat = TRUE` and `jupyter_compat = FALSE` we should
+see the results, because a `print` was called:
+
+    print(1)
+
+    ## 1
+
+    print(2)
+
+    ## 2
+
+    print(1)
+    print(2)
+
+    ## 2
+
+For the `jupyter_compat = FALSE` mode we should see the output of both
+expressions. In `jupyter_compat`, we should only see the output for the
+last expression.
+
+    1 + 0
+
+    ## 1
+
+    1 + 1
+
+    ## 2
+
+    1 + 0
+    1 + 1
+
+    ## 2

--- a/tests/testthat/_snaps/python-knitr-engine/knitr-print2.md
+++ b/tests/testthat/_snaps/python-knitr-engine/knitr-print2.md
@@ -3,8 +3,8 @@
 
     ## Hello world
 
-Both in `jupyter_compat = TRUE` and `jupyter_compat = FALSE` we should
-see the results, because a `print` was called:
+In `jupyter_compat = FALSE`: we should only see the output of both
+expressions.
 
     print(1)
 
@@ -14,14 +14,19 @@ see the results, because a `print` was called:
 
     ## 2
 
+In `jupyter_compat = TRUE`: we should only see the output of both
+expressions.
+
     print(1)
+
+    ## 1
+
     print(2)
 
     ## 2
 
-For the `jupyter_compat = FALSE` mode we should see the output of both
-expressions. In `jupyter_compat`, we should only see the output for the
-last expression.
+In `jupyter_compat = FALSE`: we should only see the output of both
+expressions.
 
     1 + 0
 
@@ -30,6 +35,9 @@ last expression.
     1 + 1
 
     ## 2
+
+`jupyter_compat = TRUE`: we should only see the output of the last
+expression.
 
     1 + 0
     1 + 1

--- a/tests/testthat/_snaps/python-knitr-engine/knitr-print2.md
+++ b/tests/testthat/_snaps/python-knitr-engine/knitr-print2.md
@@ -68,3 +68,18 @@ output
 
     1 + 0;
     1 + 1;
+
+## `jupyter_compat` works with interleaved expressions
+
+    print('first_stdout')
+
+    ## first_stdout
+
+    'first_expression'
+    print('second_stdout')
+
+    ## second_stdout
+
+    'final_expression'
+
+    ## 'final_expression'

--- a/tests/testthat/_snaps/python-knitr-engine/knitr-print2.md
+++ b/tests/testthat/_snaps/python-knitr-engine/knitr-print2.md
@@ -3,6 +3,8 @@
 
     ## Hello world
 
+## Print statements should always be captured
+
 In `jupyter_compat = FALSE`: we should only see the output of both
 expressions.
 
@@ -25,6 +27,8 @@ expressions.
 
     ## 2
 
+## Only outputs of last expressions are captured in jupyter compat
+
 In `jupyter_compat = FALSE`: we should only see the output of both
 expressions.
 
@@ -43,3 +47,24 @@ expression.
     1 + 1
 
     ## 2
+
+## One can disable outputs by using `;`
+
+In `jupyter_compat = FALSE`: we should only see the print statement
+output
+
+    print("hello");
+
+    ## hello
+
+    1 + 0;
+    1 + 1;
+
+`jupyter_compat = TRUE`: we should only see the print statement output
+
+    print("hello");
+
+    ## hello
+
+    1 + 0;
+    1 + 1;

--- a/tests/testthat/resources/knitr-print.Rmd
+++ b/tests/testthat/resources/knitr-print.Rmd
@@ -8,3 +8,28 @@ bt <- reticulate::import_builtins()
 bt$print("Hello world")
 ```
 
+Both in `jupyter_compat = TRUE` and `jupyter_compat = FALSE` we should see the
+results, because a `print` was called:
+
+```{python}
+print(1)
+print(2)
+```
+
+```{python, jupyter_compat = TRUE}
+print(1)
+print(2)
+```
+
+For the `jupyter_compat = FALSE` mode we should see the output of both expressions.
+In `jupyter_compat`, we should only see the output for the last expression. 
+
+```{python}
+1 + 0
+1 + 1
+```
+
+```{python, jupyter_compat = TRUE}
+1 + 0
+1 + 1
+```

--- a/tests/testthat/resources/knitr-print.Rmd
+++ b/tests/testthat/resources/knitr-print.Rmd
@@ -8,28 +8,53 @@ bt <- reticulate::import_builtins()
 bt$print("Hello world")
 ```
 
-Both in `jupyter_compat = TRUE` and `jupyter_compat = FALSE` we should see the
-results, because a `print` was called:
+## Print statements should always be captured
+
+In `jupyter_compat = FALSE`: we should only see the output of both expressions.
 
 ```{python}
 print(1)
 print(2)
 ```
 
+In `jupyter_compat = TRUE`: we should only see the output of both expressions.
+
 ```{python, jupyter_compat = TRUE}
 print(1)
 print(2)
 ```
 
-For the `jupyter_compat = FALSE` mode we should see the output of both expressions.
-In `jupyter_compat`, we should only see the output for the last expression. 
+## Only outputs of last expressions are captured in jupyter compat
+
+In `jupyter_compat = FALSE`: we should only see the output of both expressions.
 
 ```{python}
 1 + 0
 1 + 1
 ```
 
+`jupyter_compat = TRUE`: we should only see the output of the last expression.
+
 ```{python, jupyter_compat = TRUE}
 1 + 0
 1 + 1
 ```
+
+## One can disable outputs by using `;`
+
+In `jupyter_compat = FALSE`: we should only see the print statement output
+
+```{python}
+print("hello");
+1 + 0;
+1 + 1;
+```
+
+`jupyter_compat = TRUE`: we should only see the print statement output
+
+```{python, jupyter_compat = TRUE}
+print("hello");
+1 + 0;
+1 + 1;
+```
+

--- a/tests/testthat/resources/knitr-print.Rmd
+++ b/tests/testthat/resources/knitr-print.Rmd
@@ -58,3 +58,13 @@ print("hello");
 1 + 1;
 ```
 
+## `jupyter_compat` works with interleaved expressions
+
+```{python, jupyter_compat=TRUE}
+print('first_stdout')
+'first_expression'
+print('second_stdout')
+'final_expression'
+```
+
+


### PR DESCRIPTION
Should fix: https://github.com/rstudio/reticulate/issues/1387#issuecomment-1645724902
@matthew-brett Can you confirm this is the expected behavior?