### PR TITLE
Initial work on supporting casts from nullable data types into R types

### DIFF
--- a/tests/testthat/test-python-pandas.R
+++ b/tests/testthat/test-python-pandas.R
@@ -219,3 +219,13 @@ df = pd.DataFrame({"FCT": pd.Categorical(["No", "Yes"]),
   expect_identical(p_df, r_df)
 
 })
+
+test_that("can cast from pandas nullable types", {
+  pd <- import("pandas", convert = FALSE)
+  p_df <- pd$DataFrame(list("x" = pd$Series(list(NULL, 1L, 2L), dtype = pd$Int32Dtype())))
+
+  expect_equal(py_to_r(p_df$x$dtype$name), "Int32")
+  r_df <- py_to_r(p_df)
+
+  expect_identical(r_df$x, c(NA, 1L, 2L))
+})


### PR DESCRIPTION
Since v1.0, Pandas supports nullable data types, for example the [Int64Dtype()](https://pandas.pydata.org/docs/user_guide/integer_na.html). Those data types more closely match R NA handling, as instead of using `NaN` for missing values, they can use an explicit `NULL` value. 

Internally, nullable data types inherit from [BaseMaskedArray](https://github.com/pandas-dev/pandas/blob/0f437949513225922d851e9581723d82120684a6/pandas/core/arrays/masked.py#L100-L111), fields that are just numpy arrays containing the data and a NA mask.

This PR will allow converting from those data types into R objects. Before this PR, casting from nullable pandas types into R fails silently, creating a corrupt data frame:

```
Warning in format.data.frame(if (omit) x[seq_len(n0), , drop = FALSE] else x, :
corrupt data frame: columns will be truncated or padded with NAs
```
