### PR TITLE
Simplify pandas Series of strings that contain missing values

### DIFF
--- a/tests/testthat/test-python-pandas.R
+++ b/tests/testthat/test-python-pandas.R
@@ -219,3 +219,18 @@ df = pd.DataFrame({"FCT": pd.Categorical(["No", "Yes"]),
   expect_identical(p_df, r_df)
 
 })
+
+test_that("NA in string columns don't prevent simplification", {
+
+  pd <- import("pandas", convert = FALSE)
+  np <- import("numpy", convert = FALSE)
+
+  x <- pd$Series(list("a", pd$`NA`, NULL, np$nan))
+  expect_equal(py_to_r(x$dtype$name), "object")
+
+  r <- py_to_r(x)
+
+  expect_equal(typeof(r), "character")
+  expect_equal(is.na(r), c(FALSE< TRUE, TRUE, TRUE))
+
+})


### PR DESCRIPTION
Improves string arrays simplification by automatically handling common missing value types from pandas.
The following is now simplified into an R character vector. 

```
pd <- import("pandas", convert = FALSE)
x <- pd$Series(list("a", pd$`NA`, NULL, np$nan))
```

It's very common for pandas series containg any of `pd.NA`, `None` and `np.nan` and strings otherwise are using those types as missing values indicators. Also, `.isna()` reports True for all of them.

```
>   x$isna()
0    False
1     True
2     True
3     True
dtype: bool
```