### PR TITLE
refactor `py_get_attr()` / `py_get_item()`

### DIFF
--- a/R/python-item.R
+++ b/R/python-item.R
@@ -72,13 +72,11 @@ py_get_item <- function(x, key, silent = FALSE) {
   if (py_is_module_proxy(x))
     py_resolve_module_proxy(x)
 
-  # NOTE: for backwards compatibility, we make sure to return an R NULL on error
-  if (silent) {
-    tryCatch(py_get_item_impl(x, key, FALSE), error = function(e) NULL)
-  } else {
-    py_get_item_impl(x, key, FALSE)
-  }
-
+  res <- py_get_item_impl(x, key, silent)
+  if(silent && identical(emptyenv(), res))
+    NULL
+  else
+    res
 }
 
 #' @rdname py_get_item

--- a/R/python.R
+++ b/R/python.R
@@ -962,7 +962,7 @@ py_get_attr <- function(x, name, silent = FALSE) {
   if (py_is_module_proxy(x))
     py_resolve_module_proxy(x)
   res <- py_get_attr_impl(x, name, silent)
-  if(silent && py_is_none(res) && !py_has_attr(x, name))
+  if(silent && identical(res, emptyenv()))
     NULL
   else
     res


### PR DESCRIPTION
- use C++ scope guard for PyErr restoration
- speed up case when `silent = TRUE`
  - avoid invoking python getattr/getitem method twice due to use of R py_has_*()
  - avoid overhead of R condition handlers
  - use emptyenv() as sentinel instead of py_none()