### PR TITLE
Preserve NAs when casting R data.frames to pandas.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # reticulate (development version)
 
+- reticulate now supports casting R data.frames to Pandas data.frames using nullable
+  data types allowing users to preserve NA's from R atomic vectors. This feature is
+  opt-in and can be enabled by setting the R option `reticulate.pandas_use_nullable_dtypes`
+  to `TRUE`. (#1439)
+
 # reticulate 1.31
 
 ## Python Installation Management

--- a/src/libpython.h
+++ b/src/libpython.h
@@ -552,6 +552,9 @@ LIBPYTHON_EXTERN void **PyArray_API;
           (*(PyObject * (*)(PyTypeObject *, int, npy_intp *, int, npy_intp *, void *, int, int, PyObject *)) \
              PyArray_API[93])
 
+#define PyArray_SimpleNew(nd, dims, typenum) \
+          PyArray_New(&PyArray_Type, nd, dims, typenum, NULL, NULL, 0, 0, NULL)
+
 inline void* PyArray_DATA(PyArrayObject *arr) {
   return ((PyArrayObject_fields *)arr)->data;
 }

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -3476,7 +3476,7 @@ PyObject* r_to_py_pandas_nullable_series (const RObject& column, const bool conv
     // the minimum pandas version.
     // we show a warning and force the numpy construction.
     Rcpp::warning(
-      "Nullable data types require pandas version >= 1.0.0. "
+      "Nullable data types require pandas version >= 1.2.0. "
       "Forcing numpy cast. Use `options(reticulate.pandas_force_numpy = TRUE)` "
       "to disable this warning."
     );

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -3477,7 +3477,7 @@ PyObject* r_to_py_pandas_nullable_series (const RObject& column, const bool conv
     // we show a warning and force the numpy construction.
     Rcpp::warning(
       "Nullable data types require pandas version >= 1.2.0. "
-      "Forcing numpy cast. Use `options(reticulate.pandas_force_numpy = TRUE)` "
+      "Forcing numpy cast. Use `options(reticulate.pandas_use_nullable_dtypes = FALSE)` "
       "to disable this warning."
     );
 
@@ -3499,7 +3499,7 @@ PyObject* r_to_py_pandas_nullable_series (const RObject& column, const bool conv
       // we force the old cast method after a warning.
       Rcpp::warning(
         "String nullable data types require pandas version >= 1.5.0. "
-        "Forcing numpy cast. Use `options(reticulate.pandas_force_numpy = TRUE)` "
+        "Forcing numpy cast. Use `options(reticulate.pandas_use_nullable_dtypes = FALSE)` "
         "to disable this warning."
       );
 

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -3530,7 +3530,7 @@ PyObjectRef r_convert_dataframe(RObject dataframe, bool convert) {
   CharacterVector names = dataframe.attr("names");
   // when this is set we cast R atomic vectors to numpy arrays and don't
   // use pandas dtypes that can handle missing values.
-  bool pandas_force_numpy = option_is_true("reticulate.pandas_force_numpy");
+  bool nullable_dtypes = option_is_true("reticulate.pandas_use_nullable_dtypes");
 
   for (R_xlen_t i = 0, n = Rf_xlength(dataframe); i < n; i++)
   {
@@ -3566,7 +3566,7 @@ PyObjectRef r_convert_dataframe(RObject dataframe, bool convert) {
 
     // We are sure it's an atomic vector:
     // Atomic values STRSXP, INTSXP, REALSXP and CPLSXP
-    if (pandas_force_numpy || TYPEOF(column) == CPLXSXP) {
+    if (!nullable_dtypes || TYPEOF(column) == CPLXSXP) {
       PyObjectPtr value(r_to_py_numpy(column, convert));
       status = PyDict_SetItem(dict, name, value);
     } else {

--- a/tests/testthat/test-python-pandas.R
+++ b/tests/testthat/test-python-pandas.R
@@ -303,7 +303,7 @@ test_that("Round strip for string columns with NA's work correctly", {
   df <- data.frame(string = c(NA, letters[1:10]))
   p <- r_to_py(df)
 
-  expect_null(py_to_r(p$string[0]))
+  expect_true(py_to_r(p$string$isna()[0]))
 
   r <- py_to_r(p)
   expect_true(is.na(r$string[1]))

--- a/vignettes/calling_python.Rmd
+++ b/vignettes/calling_python.Rmd
@@ -240,6 +240,32 @@ R data frames can be automatically converted to and from [Pandas](https://pandas
 
 If the R data frame has row names, the generated Pandas DataFrame will be re-indexed using those row names (and vice versa). Special handling is also available for a `DatetimeIndex` associated with a Pandas DataFrame; however, because R only supports character vectors for row names they are converted to character first.
 
+### Using Pandas nullable data types
+
+Pandas has experimental support for nullable data types. Those data types have built-in
+support for missing values, represented by `pd.NA` and using them allows us to better
+represent R `NA` values.
+
+Users can opt-in to use Pandas nullable data types instead of numpy arrays by setting
+the `reticulate.pandas_use_nullable_dtypes` to `TRUE`. For example:
+
+```r
+df <- data.frame(
+  int = c(NA, 1:4),
+  num = c(NA, rnorm(4)),
+  lgl = c(NA, rep(c(TRUE, FALSE), 2)),
+  string = c(NA, letters[1:4])
+)
+options(reticulate.pandas_use_nullable_data_types = TRUE)
+r_to_py(df)
+#>     int       num    lgl string
+#> 0  <NA>      <NA>   <NA>   <NA>
+#> 1     1 -0.697855   True      a
+#> 2     2 -0.253042  False      b
+#> 3     3  0.385421   True      c
+#> 4     4  0.519933  False      d
+```
+
 ## Sparse Matrices
 
 Sparse matrices created by [Matrix R package](https://CRAN.R-project.org/package=Matrix) can be converted [Scipy CSC matrix](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csc_matrix.html), and vice versa. This is often useful when you want to pass sparse matrices to Python functions that accepts Scipy CSC matrix to take advantage of this format, such as efficient column slicing and fast matrix vector products. 


### PR DESCRIPTION
Related #197 and #207

This PR adds an optional behavior for handling of R data.frame atomic columns when converting into pandas data.frames. The main motivation for this PR is to better handle R data frames that contain columns with `NA`s.

If the `reticulate.pandas_use_nullable_dtypes` is set, instead of converting into raw numpy data types, we use (newish) pandas [nullable data types](https://pandas.pydata.org/docs/user_guide/integer_na.html), that have built-in support for NA`s .

With the new behavior, doing:

```
df <- data.frame(
  int = c(NA, 1:4),
  num = c(NA, rnorm(4)),
  lgl = c(NA, rep(c(TRUE, FALSE), 2)),
  string = c(NA, letters[1:4])
)
options(reticulate.pandas_use_nullable_dtypes = TRUE)
r_to_py(df)
```

Results in:

```
    int       num    lgl string
0  <NA>      <NA>   <NA>   <NA>
1     1  0.491903   True      a
2     2   1.54789  False      b
3     3  0.470248   True      c
4     4  0.125063  False      d
```

While with old behavior we get:

```
          int       num    lgl string
0 -2147483648       NaN   True   None
1           1  0.282169   True      a
2           2 -0.001555  False      b
3           3 -0.190735   True      c
4           4  0.678618  False      d
```

Preserving NA`s helps making round trip casts more reliable.

Benchmark shows twice as slow for a 100k row df, which is somewhat expected as we need to build a boolean mask for each column.

```
# A tibble: 2 × 13
  expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result memory              time       gc      
  <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list> <list>              <list>     <list>  
1 old           3.2ms   3.49ms      280.    54.8KB     2.95    95     1      339ms <NULL> <Rprofmem [22 × 3]> <bench_tm> <tibble>
2 new          6.72ms   6.97ms      143.    54.8KB     0       72     0      504ms <NULL> <Rprofmem [22 × 3]> <bench_tm> <tibble>
```

<details>
<summary>Code</summary>

```
df <- data.frame(
  int = c(NA, 1:4),
  num = c(NA, rnorm(4)),
  lgl = c(NA, rep(c(TRUE, FALSE), 2)),
  string = c(NA, letters[1:4])
)


library(dplyr)
devtools::load_all()

set.seed(100)
x <- df %>% sample_n(100000, replace = TRUE)

bench::mark(check = FALSE,
  old = withr::with_options(c(reticulate.pandas_force_numpy = TRUE), r_to_py(x)),
  new = withr::with_options(c(reticulate.pandas_force_numpy = FALSE), r_to_py(x))
)
```

</details>
