### PR TITLE
Reading the value of `py` forces python initialization

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -22,8 +22,7 @@
       return(main)
 
     # attempt to initialize main
-    if (is_python_initialized())
-      main <<- import_main(convert = TRUE)
+    main <<- import_main(convert = TRUE)
 
     # return value of main
     main


### PR DESCRIPTION
This PR fixes #1334 

It fixes by forcing `py` to initialize Python. We could save objects to a temporary environment until Python is initialized, but this could delay some `r_to_py()` cast errors which would be hard to debug.

`py` has been added in https://github.com/rstudio/reticulate/pull/107 and there doesn't seem to be any discussions about why it would be undesirable for it to start python.