### PR TITLE
`delay_load` support for `import_builtins` and `import_main`

### DIFF
--- a/R/import.R
+++ b/R/import.R
@@ -157,19 +157,14 @@ register_delay_load_import <- function(module, delay_load = NULL) {
 
 #' @rdname import
 #' @export
-import_main <- function(convert = TRUE) {
-  ensure_python_initialized()
-  import("__main__", convert = convert)
+import_main <- function(convert = TRUE, delay_load = FALSE) {
+  import("__main__", convert = convert, delay_load = delay_load)
 }
 
 #' @rdname import
 #' @export
-import_builtins <- function(convert = TRUE) {
-  ensure_python_initialized()
-  if (is_python3())
-    import("builtins", convert = convert)
-  else
-    import("__builtin__", convert = convert)
+import_builtins <- function(convert = TRUE, delay_load = FALSE) {
+  import("builtins", convert = convert, delay_load = delay_load)
 }
 
 

--- a/man/import.Rd
+++ b/man/import.Rd
@@ -9,9 +9,9 @@
 \usage{
 import(module, as = NULL, convert = TRUE, delay_load = FALSE)
 
-import_main(convert = TRUE)
+import_main(convert = TRUE, delay_load = FALSE)
 
-import_builtins(convert = TRUE)
+import_builtins(convert = TRUE, delay_load = FALSE)
 
 import_from_path(module, path = ".", convert = TRUE, delay_load = FALSE)
 }


### PR DESCRIPTION
The intent of this PR is to fix #223.

Add support for `delay_load` for `main` and `builtins` helping package devlopers.

I don't think this is super urgent as users can use an active binding or other technique to delay loading, but it makes sense for consistency.

This PR removed the python 2 branch of the code. But I don't think we have Python2 support anymore as we don't test it at all.