### PR TITLE
patch `sys.executable` not just on windows

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -861,7 +861,8 @@ python_config <- function(python,
     base_exec_prefix     = config$BaseExecPrefix,
     virtualenv           = virtualenv,
     virtualenv_activate  = virtualenv_activate,
-    base_executable      = config$BaseExecutable, # points to the virtualenv starter for virtualenvs
+    executable           = config$Executable, # sys.executable
+    base_executable      = config$BaseExecutable, # sys._base_executable; exe for venv starter
     version_string       = version_string,
     version              = version,
     architecture         = architecture,

--- a/R/package.R
+++ b/R/package.R
@@ -249,10 +249,12 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
 
   }
 
-  if (is_windows()) {
+  local({
     # patch sys.executable to point to python.exe, not Rterm.exe or rsession-utf8.exe, #1258
-    py_run_string_impl("import sys; sys.executable = sys.argv[0]", local = TRUE)
-  }
+    patch <- sprintf("import sys; sys.executable  = r'''%s'''",
+                     config$executable)
+    py_run_string_impl(patch, local = TRUE)
+  })
 
   if (nzchar(config$base_executable)) local({
     # just like sys.executable, patch to point to python.exe, not Rterm.exe

--- a/inst/config/config.py
+++ b/inst/config/config.py
@@ -43,7 +43,8 @@ config = {
   "LIBPL"            : sysconfig.get_config_var("LIBPL"),
   "LIBDIR"           : sysconfig.get_config_var("LIBDIR"),
   "SharedLibrary"    : sysconfig.get_config_var("Py_ENABLE_SHARED"),
-  "BaseExecutable"   : getattr(sys, "_base_executable", "")
+  "Executable"       : getattr(sys, "executable", ""),
+  "BaseExecutable"   : getattr(sys, "_base_executable", ""),
 }
 
 # detect if this is a conda managed python


### PR DESCRIPTION
Minor change to initialization routine, while working on #1461.

When patching `sys.executable`, we now fetch the actual value when probing config, instead of relying on the (potentially transformed) the path
 used from reticulates init codepath.

Motivated by: on Windows, observed inconsistent usage of `/` and `\` as the path sep between "real" and "reticulate-set" values for this.

Also, I see no reason to confine this to windows only: `sys.executable` should be set properly on all platforms.