### PR TITLE
Improves data frame handling

### DIFF
--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -676,8 +676,25 @@ eng_python_autoprint <- function(captured, options) {
 
   } else if (inherits(value, "pandas.core.frame.DataFrame")) {
 
-    return(captured)
+    # this comes from https://github.com/yihui/knitr/blob/7bc8b393e261c88f299bccc7eee40b4e952ebd57/R/output.R#L197
+    isQuarto <- !is.null(knitr::opts_knit$get('quarto.version'))
+    renderPandas <- getOption("reticulate.engine.render_pandas", default = TRUE)
 
+    # Quarto documents running Python with the Jupyter engine return richly rendered
+    # data.frames and we want keep the same behavior for documents rendered with
+    # the knitr engine
+    if (isQuarto && renderPandas) {
+      return(eng_python_generic_autoprint(captured, value))
+    }
+
+    # we respect the Rmarkdown `df_print` option that allows to control how
+    # to display data.frames in the document. In the case it's not the default,
+    # we cast into an R data.frame and let knitr handle the rendering.
+    if (knitr::opts_knit$get("rmarkdown.df_print") != "default" && renderPandas) {
+      return(knitr::knit_print(py_to_r(value)))
+    }
+
+    return(captured)
   } else if (isHtml && py_has_method(value, "_repr_html_")) {
 
     py_capture_output({
@@ -730,7 +747,13 @@ eng_python_autoprint <- function(captured, options) {
 
     return("")
 
-  } else if (py_has_method(value, "_repr_markdown_")) {
+  } else {
+    return(eng_python_generic_autoprint(captured, value))
+  }
+}
+
+eng_python_generic_autoprint <- function(captured, value) {
+  if (py_has_method(value, "_repr_markdown_")) {
 
     data <- as_r_value(value$`_repr_markdown_`())
     .engine_context$pending_plots$push(knitr::asis_output(data))
@@ -748,5 +771,4 @@ eng_python_autoprint <- function(captured, options) {
     return(captured)
 
   }
-
 }

--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -678,19 +678,19 @@ eng_python_autoprint <- function(captured, options) {
 
     # this comes from https://github.com/yihui/knitr/blob/7bc8b393e261c88f299bccc7eee40b4e952ebd57/R/output.R#L197
     isQuarto <- !is.null(knitr::opts_knit$get('quarto.version'))
-    renderPandas <- getOption("reticulate.engine.render_pandas", default = TRUE)
+    renderDF <- getOption("reticulate.engine.render_df", default = TRUE)
 
     # Quarto documents running Python with the Jupyter engine return richly rendered
     # data.frames and we want keep the same behavior for documents rendered with
     # the knitr engine
-    if (isQuarto && renderPandas) {
+    if (isQuarto && renderDF) {
       return(eng_python_generic_autoprint(captured, value))
     }
 
     # we respect the Rmarkdown `df_print` option that allows to control how
     # to display data.frames in the document. In the case it's not the default,
     # we cast into an R data.frame and let knitr handle the rendering.
-    if (knitr::opts_knit$get("rmarkdown.df_print") != "default" && renderPandas) {
+    if (knitr::opts_knit$get("rmarkdown.df_print") != "default" && renderDF) {
       return(knitr::knit_print(py_to_r(value)))
     }
 


### PR DESCRIPTION
Improves how the reticulate engine handles pandas data frames rendering.
This PR is an attempt to fix #783 

In summary it adresses two problems:

1. Quarto documents rendered with the Jupyter engine will by default use rich data.frame rendering, which is not the case if they use the reticulate/knitr engine. 
   
   We prefer not having such difference between engines, so this PR will special case Quarto rendered documents and use `.to_html()` or `._repr_markdown()` when appropriate when out-printing data.frames into documents in Quarto rendered documents.

2. The reticulate engine doesn't honor RMarkdown's `df_print` option and always uses `print(df)` to display pandas data.frames. 

    
   This PR adds support for such option and we now respect the `df_print` option when auto-printing pandas data.frames. When not using the `'default'` value, we convert the pandas data frame into an R data frame and then delegate to knitr for printing.

Both changes are breaking changes, in the sense that they will now be the default. One should set `reticulate.engine.render_df` to `FALSE` in order to get back the old behavior.