### PR TITLE
fix `import asyncio` on Windows in RStudio

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # reticulate (development version)
 
+- Fixed issue where `asyncio`, (and modules that use `asyncio`) would error on 
+  Windows when running under RStudio (#1478, #1479).
+
 # reticulate 1.32.0
 
 - reticulate now supports casting R data.frames to Pandas data.frames using nullable

--- a/inst/python/rpytools/subprocess.py
+++ b/inst/python/rpytools/subprocess.py
@@ -6,4 +6,4 @@ def patch_subprocess_Popen():
   import subprocess
   from functools import partial
 
-  subprocess.Popen = partial(subprocess.Popen, stdin = subprocess.DEVNULL)
+  subprocess.Popen.__init__ = partial(subprocess.Popen.__init__, stdin = subprocess.DEVNULL)

--- a/tests/testthat/test-subprocess.R
+++ b/tests/testthat/test-subprocess.R
@@ -16,3 +16,11 @@ test_that("subprocess.Popen works", {
   })
 
 })
+
+test_that("modules that subclass Popen work", {
+
+  expect_no_error({
+    import("asyncio")
+  })
+
+})


### PR DESCRIPTION
asyncio.windows_utils subclasses/aliases `subprocess.Popen` like this:

```python
class Popen(subprocess.Popen)
  def __init__(...):
    ...
    try:
      super().__init__(...)
    ...

```

Calling `partial()` on `Popen` directly works when
using it like a function, but breaks when
subclassing Popen (like asyncio does).

This means that any modules that attempt to import asyncio will
fail as well, like tensorflow.

Closes https://github.com/rstudio/keras/issues/1375 Closes #1478