### PR TITLE
hand-roll wrapper for `Popen.__init__`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: reticulate
 Type: Package
 Title: Interface to 'Python'
-Version: 1.32.0.9001
+Version: 1.32.0.9002
 Authors@R: c(
   person("Tomasz", "Kalinowski", role = c("ctb", "cre"),
          email = "tomasz@posit.co"),

--- a/inst/python/rpytools/subprocess.py
+++ b/inst/python/rpytools/subprocess.py
@@ -3,7 +3,15 @@
 
 
 def patch_subprocess_Popen():
-    from subprocess import Popen, DEVNULL
-    from functools import partialmethod
+    from functools import wraps
+    import subprocess
 
-    Popen.__init__ = partialmethod(Popen.__init__, stdin=DEVNULL)
+    og_Popen__init__ = subprocess.Popen.__init__
+
+    @wraps(subprocess.Popen.__init__)
+    def __init__(self, *args, **kwargs):
+        if kwargs.get("stdin") is None:
+            kwargs["stdin"] = subprocess.DEVNULL
+        return og_Popen__init__(self, *args, **kwargs)
+
+    subprocess.Popen.__init__ = __init__


### PR DESCRIPTION
... instead of using `fuctools.partialmethod()`

Modules like asyncio that wrap Popen will pass `stdin=None`, bypassing the partial'ed default.

Closes #1484