### PR TITLE
avoid sys.version in config.py

### DIFF
--- a/inst/config/config.py
+++ b/inst/config/config.py
@@ -5,14 +5,14 @@ import os
 
 # The 'sysconfig' module is only available with Python 2.7 and newer, but
 # an equivalent module in 'distutils' is available for Python 2.6.
-if sys.version < '2.7':
+if sys.version_info < (2, 7):
   from distutils import sysconfig
 else:
   import sysconfig
 
 # The 'imp' module is deprecated since Python 3.4, and the use of
 # 'importlib' is recommended instead.
-if sys.version < '3.4':
+if sys.version_info < (3, 4):
   import imp
   def module_path(name):
     if name in sys.builtin_module_names:


### PR DESCRIPTION
Previous logic breaks when Python 3.10+ is used. Replace with proper version check, as per [documentation](https://docs.python.org/3/library/sys.html#sys.version)