### PR TITLE
Fix `python3-venv` detection on Ubuntu 22.04

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # reticulate (development version)
 
+- Fixed issue where `virtualenv_create()` would error on Ubuntu 22.04 when
+  using the system python as a base. (#1495, fixed in #1496).
+
 # reticulate 1.34.0
 
 # reticulate 1.33.0

--- a/R/virtualenv.R
+++ b/R/virtualenv.R
@@ -429,7 +429,7 @@ virtualenv_module <- function(python) {
         # `apt install python3` makes an importable venv module, but not one
         # capable of actually creating a venv unless python3-venv is installed.
         # if python3-venv is not installed, move on and maybe discover virtualenv.
-        if (!any(grepl("^python[0-9.]*-venv$", system("dpkg -l", intern = TRUE))))
+        if (!any(grepl("\\bpython[0-9.]*-venv\\b", system("dpkg -l", intern = TRUE))))
           next
       }
       return(module)


### PR DESCRIPTION
Update regex for `dpkg -l` output.

closes #1495