### PR TITLE
Save plot images in different formats with `opts_chunks$dev`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,18 +1,21 @@
 # reticulate (development version)
 
-- The knitr python engine now formats captured python exceptions to include the 
-  exception type and any exception notes when chunk options 
+- The knitr python engine now formats captured python exceptions to include the
+  exception type and any exception notes when chunk options
   `error = TRUE` is set (reported in #1520, fixed in #1527).
 
-- R external pointers (EXTPTRSXP objects) now round-trip through 
+- R external pointers (EXTPTRSXP objects) now round-trip through
   `py_to_r(r_to_py(x))` successfully.
   (reported in #1511, fixed in #1519, contributed by @llaniewski).
 
 - Fixed issue where `virtualenv_create()` would error on Ubuntu 22.04 when
   using the system python as a base. (#1495, fixed in #1496).
 
-- Fixed issue where `csc_matrix` objects with unsorted indices could not be 
+- Fixed issue where `csc_matrix` objects with unsorted indices could not be
   converted to a dgCMatrix. (related to #727, fixed in #1524, contributed by @rcannood).
+
+- knitr engine gains the ability to save chunk figures in multiple files/formats
+  (Contributed by @Rumengol in #1507)
 
 # reticulate 1.34.0
 

--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -411,32 +411,35 @@ eng_python_knit_figure_path <- function(options, suffix = NULL) {
   # construct plot path
   plot_counter <- yoink("knitr", "plot_counter")
   number <- plot_counter()
-  path <- knitr::fig_path(
+  paths <- knitr::fig_path(
     suffix  = suffix %||% options$dev,
     options = options,
     number  = number
   )
 
   # ensure parent path exists
-  dir.create(dirname(path), recursive = TRUE, showWarnings = FALSE)
+  lapply(paths, function(path){dir.create(dirname(path), recursive = TRUE, showWarnings = FALSE)})
 
   # return path
-  path
+  paths
 
 }
 
 eng_python_matplotlib_show <- function(plt, options) {
 
   # get figure path
-  path <- eng_python_knit_figure_path(options)
+  paths <- eng_python_knit_figure_path(options)
 
-  # save the current figure
-  dir.create(dirname(path), recursive = TRUE, showWarnings = FALSE)
-  plt$savefig(path, dpi = options$dpi)
+  # save the current figure to all requested devices
+  lapply(paths, function(path){
+    dir.create(dirname(path), recursive = TRUE, showWarnings = FALSE)
+    plt$savefig(path, dpi = options$dpi)
+  })
+
   plt$close()
 
   # include the requested path
-  knitr::include_graphics(path)
+  knitr::include_graphics(paths[1])
 
 }
 
@@ -669,9 +672,12 @@ eng_python_autoprint <- function(captured, options) {
   } else if (eng_python_is_seaborn_output(value)) {
 
     # get figure path
-    path <- eng_python_knit_figure_path(options)
-    value$savefig(path)
-    .engine_context$pending_plots$push(knitr::include_graphics(path))
+    paths <- eng_python_knit_figure_path(options)
+    lapply(paths, function(path) {
+      value$savefig(path)
+    })
+
+    .engine_context$pending_plots$push(knitr::include_graphics(paths[1]))
     return("")
 
   } else if (inherits(value, "pandas.core.frame.DataFrame")) {
@@ -690,13 +696,15 @@ eng_python_autoprint <- function(captured, options) {
              py_module_available("psutil") &&
              py_module_available("kaleido")) {
 
-    path <- eng_python_knit_figure_path(options)
-    value$write_image(
+    paths <- eng_python_knit_figure_path(options)
+    lapply(paths, function(path) {
+      value$write_image(
       file   = path,
       width  = options$out.width.px,
       height = options$out.height.px
     )
-    .engine_context$pending_plots$push(knitr::include_graphics(path))
+    })
+    .engine_context$pending_plots$push(knitr::include_graphics(paths[1]))
     return("")
 
   } else if (eng_python_is_altair_chart(value)) {
@@ -723,9 +731,9 @@ eng_python_autoprint <- function(captured, options) {
       data <- as_r_value(value$to_html(output_div = id))
       .engine_context$pending_plots$push(knitr::raw_html(data))
     } else {
-      path <- eng_python_knit_figure_path(options)
-      value$save(path)
-      .engine_context$pending_plots$push(knitr::include_graphics(path))
+      paths <- eng_python_knit_figure_path(options)
+      lapply(paths, function(path){value$save(path)})
+      .engine_context$pending_plots$push(knitr::include_graphics(paths[1]))
     }
 
     return("")

--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -732,7 +732,9 @@ eng_python_autoprint <- function(captured, options) {
       .engine_context$pending_plots$push(knitr::raw_html(data))
     } else {
       paths <- eng_python_knit_figure_path(options)
-      lapply(paths, function(path){value$save(path)})
+      lapply(paths, function(path){
+        value$save(path)
+      })
       .engine_context$pending_plots$push(knitr::include_graphics(paths[1]))
     }
 


### PR DESCRIPTION
The [knitr documentation](https://yihui.org/knitr/options/#plots) indicates that it is possible to pass a vector of target devices to save the same plot in different formats. Reticulate uses `dir.create()` to create the destination directory if it doesn't exist, however this function can only accept one path and will fail with multiple target devices, as `knitr::fig_path()` will return a vector of 2 paths.

This PR solves the issue by considering the return type of `knitr::fig_path()` as a vector of strings rather than a single string and calling `lapply` on functions that relies on a single element.