### PR TITLE
Fix issue with unsorted indices in csc_matrix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 - Fixed issue where `virtualenv_create()` would error on Ubuntu 22.04 when
   using the system python as a base. (#1495, fixed in #1496).
 
+- Fixed issue where `csc_matrix` objects with unsorted indices could not be converted to a dgCMatrix. (related to #727, fixed in #1524, contributed by @rcannood).
+
 # reticulate 1.34.0
 
 # reticulate 1.33.0

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -517,6 +517,7 @@ r_to_py.dgCMatrix <- function(x, convert = FALSE) {
 py_to_r.scipy.sparse.csc.csc_matrix <- function(x) {
   disable_conversion_scope(x)
 
+  x <- x$sorted_indices()
   new(
     "dgCMatrix",
     i = as.integer(as_r_value(x$indices)),

--- a/tests/testthat/test-python-scipy-sparse-matrix.R
+++ b/tests/testthat/test-python-scipy-sparse-matrix.R
@@ -190,3 +190,108 @@ test_that("Conversion between R sparse matrices without specific conversion func
   expect_true(is(result, "scipy.sparse.csc.csc_matrix") || is(result, "scipy.sparse._csc.csc_matrix"))
   check_matrix_conversion(x, result)
 })
+
+test_that("Conversion with unsorted values works in csc", {
+  skip_on_cran()
+  skip_if_no_scipy()
+
+  sp <- import("scipy.sparse", convert = FALSE)
+
+  # Test data
+  indices <- c(1L, 0L, 2L, 1L, 0L)
+  indptr <- c(0L, 3L, 5L)
+  data <- c(2, 1, 3, 5, 4)
+
+  # create csr matrix and try to convert
+  mat_py <- sp$csc_matrix(
+    tuple(
+      np_array(data),
+      np_array(indices),
+      np_array(indptr),
+      convert = FALSE
+    ),
+    shape = c(3L, 2L)
+  )
+
+  mat_py_to_r <- py_to_r(mat_py)
+
+  mat_r <- Matrix::sparseMatrix(
+    i = indices + 1,
+    p = indptr,
+    x = data,
+    dims = c(3L, 2L)
+  )
+
+  expect_equal(as.matrix(mat_py_to_r), as.matrix(mat_r))
+})
+
+test_that("Conversion with unsorted values works in csr", {
+  skip_on_cran()
+  skip_if_no_scipy()
+
+  sp <- import("scipy.sparse", convert = FALSE)
+
+  # Test data
+  indices <- c(1L, 0L, 2L, 1L, 0L)
+  indptr <- c(0L, 3L, 5L)
+  data <- c(2, 1, 3, 5, 4)
+
+  # create csr matrix and try to convert
+  mat_py <- sp$csr_matrix(
+    tuple(
+      np_array(data),
+      np_array(indices),
+      np_array(indptr),
+      convert = FALSE
+    ),
+    shape = c(2L, 3L)
+  )
+
+  mat_py_to_r <- py_to_r(mat_py)
+
+  mat_r <- Matrix::sparseMatrix(
+    j = indices + 1,
+    p = indptr,
+    x = data,
+    dims = c(2L, 3L)
+  )
+
+  expect_equal(as.matrix(mat_py_to_r), as.matrix(mat_r))
+})
+
+
+test_that("Conversion with unsorted values works in coo", {
+  skip_on_cran()
+  skip_if_no_scipy()
+
+  sp <- import("scipy.sparse", convert = FALSE)
+
+  # Test data
+  row <- c(1L, 0L, 2L, 1L, 0L)
+  col <- c(1L, 0L, 0L, 0L, 1L)
+  data <- c(5, 1, 3, 2, 4)
+
+  # create csr matrix and try to convert
+  mat_py <- sp$coo_matrix(
+    tuple(
+      np_array(data),
+      tuple(
+        np_array(row),
+        np_array(col)
+      ),
+      convert = FALSE
+    ),
+    shape = c(3L, 2L)
+  )
+
+  mat_py_to_r <- py_to_r(mat_py)
+
+  mat_r <- Matrix::sparseMatrix(
+    i = row + 1,
+    j = col + 1,
+    x = data,
+    dims = c(3L, 2L)
+  )
+
+  expect_equal(as.matrix(mat_py_to_r), as.matrix(mat_r))
+})


### PR DESCRIPTION
This PR solves an issue with converting csc matrices with unsorted indices, similar to #727.

* Add test to check whether reticulate can convert csc_matrix, csr_matrix and coo_matrix with unsorted indices
* Sort indices of csc_matrix before converting to dgCMatrix

In https://github.com/rcannood/reticulate/pull/1, the CI checks fails for the first commit (in which I added a test to detect this problem), but the CI checks succeed for the second commit (in which I added the fix).