### PR TITLE
disable auto conversion of subclassed dicts and lists

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # reticulate (development version)
 
+- Subclassed Python list and dict objects are no longer automatically converted
+  to R vectors. Additionally, the S3 R `class` attribute for Python objects is
+  now constructed using the Python `type(object)` directly, rather than from the 
+  `object.__class__` attribute. See #1531 for details and context.
+
 - The knitr python engine now formats captured python exceptions to include the
   exception type and any exception notes when chunk options
   `error = TRUE` is set (reported in #1520, fixed in #1527).

--- a/tests/testthat/test-python-objects.R
+++ b/tests/testthat/test-python-objects.R
@@ -37,7 +37,6 @@ class M:
 })
 
 
-
 test_that("py_id() returns unique strings; #1216", {
   skip_if_no_python()
 
@@ -50,8 +49,6 @@ test_that("py_id() returns unique strings; #1216", {
   expect_false(py_id(py_eval("object()")) == py_id(py_eval("object()")))
   expect_true(py_id(py_eval("object")) == py_id(py_eval("object")))
 })
-
-
 
 
 
@@ -75,7 +72,14 @@ class List(Sequence, list):
     return len(self._storage)
 ")$List
 
-  expect_identical(List(1,2,3), list(1,2,3))
+  expect_contains(class(List(1,2,3)),
+                  c("__main__.List",
+                    "collections.abc.Sequence",
+                    "python.builtin.list",
+                    "python.builtin.object"))
+
+  py_bt_list <- import_builtins()$list
+  expect_identical(py_bt_list(List(1, 2, "3")), list(1, 2, "3"))
 
 })
 
@@ -96,11 +100,16 @@ assert isinstance(Dict({}), dict)
 
 ")$Dict
 
-  expect_identical(Dict(dict()), structure(list(), names = character(0)))
-  expect_identical(Dict(list("abc" = 1:3)), list("abc" = 1:3))
+  expect_contains(class(Dict(dict())),
+                  c("__main__.Dict",
+                    "python.builtin.ObjectProxy",
+                    "python.builtin.object"))
+
+  x <- list("abc" = 1:3)
+  py_bt_dict <- import_builtins()$dict
+  expect_identical(py_bt_dict(Dict(x)), x)
 
 })
-
 
 
 test_that("capsules can be freed by other threads", {


### PR DESCRIPTION
This PR:
- disables auto-conversion of subclassed Python dict and list types to R objects.
- Changes how the S3 `class` attribute is constructed for Python objects, from using `object.__class__` to using `type(object)`. In almost all scenarios, this should be a no-change, unless there is Python "magic", where the `__class__` attribute is explicitly modified after the Python object is constructed. Specifically, this is motivated by TensorFlow's usage of [`wrapt.ObjectProxy`](https://wrapt.readthedocs.io/en/latest/wrappers.html)

If the old behavior is desired, you can define an S3 method which casts the subclassed object type in Python using the built-in `list` or `dict` function. E.g.,:

```r
py_to_r.my_py_subclassed_list <- function(x) {
  reticulate::import_builtins()$list(x)
}
```

Closes: #1510, #1429, #1360