### PR TITLE
fix pandas v2.2 FutureWarning

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # reticulate (development version)
 
+- Update for Pandas 2.2 deprecation of `Index.format()` (#1537, #1538).
+
+- Updates for CRAN R-devel (R 4.4).
+
 # reticulate 1.35.0
 
 - Subclassed Python list and dict objects are no longer automatically converted

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -226,7 +226,8 @@ py_to_r.pandas.core.series.Series <- function(x) {
   disable_conversion_scope(x)
   values <- py_to_r(x$values)
   index <- py_to_r(x$index)
-  names(values) <- index$format()
+  bt <- import("builtins")
+  names(values) <- as.character(bt$list(index$astype(bt$str)))
   values
 }
 
@@ -326,13 +327,14 @@ py_to_r.pandas.core.frame.DataFrame <- function(x) {
 
   np <- import("numpy", convert = TRUE)
   pandas <- import("pandas", convert = TRUE)
+  bt <- import("builtins", convert = TRUE)
 
   # extract numpy arrays associated with each column
   columns <- x$columns$values
 
   # delegate to c++
   converted <- py_convert_pandas_df(x)
-  names(converted) <- py_to_r(x$columns$format())
+  names(converted) <- as.character(bt$list(x$columns$astype(bt$str)))
 
   # clean up converted objects
   for (i in seq_along(converted)) {

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -227,7 +227,7 @@ py_to_r.pandas.core.series.Series <- function(x) {
   values <- py_to_r(x$values)
   index <- py_to_r(x$index)
   bt <- import("builtins")
-  names(values) <- as.character(bt$list(index$astype(bt$str)))
+  names(values) <- as.character(bt$list(index$map(bt$str)))
   values
 }
 
@@ -334,7 +334,7 @@ py_to_r.pandas.core.frame.DataFrame <- function(x) {
 
   # delegate to c++
   converted <- py_convert_pandas_df(x)
-  names(converted) <- as.character(bt$list(x$columns$astype(bt$str)))
+  names(converted) <- as.character(bt$list(x$columns$map(bt$str)))
 
   # clean up converted objects
   for (i in seq_along(converted)) {

--- a/tests/testthat/test-python-pandas.R
+++ b/tests/testthat/test-python-pandas.R
@@ -113,7 +113,11 @@ test_that("complex names are handled", {
 
   p <- pd$DataFrame(data = d)
   r <- py_to_r(p)
-  expect_equal(names(r), c("col1", "(col1, col2)"))
+  expect_equal(names(r)[1], "col1")
+  # pandas 2.2 removed index.format(), and users must pass custom formatters now,
+  # we default to using __str__ for formatting, which given a tuple, falls back
+  # to __repr__ (which prints strings with quotes).
+  expect_in(names(r)[2], c("(col1, col2)", "('col1', 'col2')"))
 
 })
 


### PR DESCRIPTION
Pandas 2.2 emits a warning when using the `Index.format()` method, which is used by reticulate py_to_r conversion routines. This PR updates usage from `index.format()` to `list(index.astype(str))` 

```
sys:1: FutureWarning: Index.format is deprecated and will be removed in a future version. Convert using index.astype(str) or index.map(formatter) instead.
```

closes #1537