### PR TITLE
fix regex to support environments created with conda env create

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,9 @@
 - Fixed an issue where `py_discover_config()` would discover `python` (v2) on the PATH
   in preference of `python3` on the PATH. (#1547)
 
+- Fixed an issue where reticulate would error when using conda environments created
+  with the (new) `conda env create` command. (#1535, #1543)
+
 # reticulate 1.35.0
 
 - Subclassed Python list and dict objects are no longer automatically converted

--- a/R/python-tools.R
+++ b/R/python-tools.R
@@ -186,7 +186,9 @@ python_info_condaenv_find <- function(path) {
     return(NULL)
 
   # get path to conda script used
-  script <- sub("^#\\s+cmd: (.+)\\s+(create|rename)\\s+.*", "\\1", lines[[1]])
+  script <- sub(
+    "^#\\s+cmd: (.+)\\s+(env)?\\s+(create|rename)\\s+.*", "\\1", lines[[1]]
+  )
 
   # on Windows, a wrapper script is recorded in the history,
   # so instead attempt to find the real conda binary

--- a/R/python-tools.R
+++ b/R/python-tools.R
@@ -187,9 +187,9 @@ python_info_condaenv_find <- function(path) {
 
   # get path to conda script used
   script <- sub(
-    "^#\\s+cmd: (.+)\\s+(env)?\\s+(create|rename)\\s+.*", "\\1", lines[[1]]
+    "^#\\s+cmd: (.+?)\\s+(env\\s+create|create|rename)\\s+.*",
+    "\\1", lines[[1]], perl = TRUE
   )
-
   # on Windows, a wrapper script is recorded in the history,
   # so instead attempt to find the real conda binary
   if(is_windows())


### PR DESCRIPTION
Looks like the previous regex only supported environments created with the `conda create` or `conda rename` commands, this adds support for `conda env create`.