### PR TITLE
`use_condaenv()` fixes

### DIFF
--- a/R/conda.R
+++ b/R/conda.R
@@ -80,7 +80,7 @@
 #' To force `reticulate` to use a particular `conda` binary, we recommend
 #' setting:
 #'
-#' ```
+#' ```r
 #' options(reticulate.conda_binary = "/path/to/conda")
 #' ```
 #'
@@ -1053,7 +1053,7 @@ get_python_conda_info <- function(python) {
     conda <- NA
 
   list(
-    conda = NA,
+    conda = conda,
     root = normalizePath(root, winslash = "/", mustWork = TRUE)
   )
 

--- a/R/conda.R
+++ b/R/conda.R
@@ -511,7 +511,7 @@ conda_install <- function(envname = NULL,
 conda_binary <- function(conda = "auto") {
 
   # automatic lookup if requested
-  if (identical(conda, "auto")) {
+  if (identical(conda, "auto") || isTRUE(is.na(conda))) {
     conda <- find_conda()
     if (is.null(conda))
       stop("Unable to find conda binary. Is Anaconda installed?", call. = FALSE)
@@ -1048,8 +1048,12 @@ get_python_conda_info <- function(python) {
     conda <- python_info_condaenv_find(root)
   }
 
+  conda <- normalizePath(conda, winslash = "/", mustWork = FALSE)
+  if(!file.exists(conda))
+    conda <- NA
+
   list(
-    conda = normalizePath(conda, winslash = "/", mustWork = TRUE),
+    conda = NA,
     root = normalizePath(root, winslash = "/", mustWork = TRUE)
   )
 

--- a/man/conda-tools.Rd
+++ b/man/conda-tools.Rd
@@ -171,7 +171,7 @@ The following locations are searched, in order:
 To force \code{reticulate} to use a particular \code{conda} binary, we recommend
 setting:
 
-\if{html}{\out{<div class="sourceCode">}}\preformatted{options(reticulate.conda_binary = "/path/to/conda")
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{options(reticulate.conda_binary = "/path/to/conda")
 }\if{html}{\out{</div>}}
 
 This can be useful if your conda installation lives in a location that


### PR DESCRIPTION
This patch allows reticulate to bind to a condaenv where the original conda binary that was used to create the condaenv is no longer available. In that case, reticulate will fall back to the same search path as `conda_binary("auto")`. 

Note, we still require that a conda binary is available on the system to use a condaenv. Reticulate uses this to call the `conda activate` command. 
The relevant "Finding Conda" section in `?conda_binary` is reproduced here: 

> When conda = "auto", reticulate will attempt to automatically find a conda installation. The following locations are searched, in order:
> 
> 1. The location specified by the `reticulate.conda_binary` \R option,
> 2. The location specified by the `RETICULATE_CONDA` environment variable,
> 3. The [miniconda_path()] location (if it exists),
> 4. The program `PATH`,
> 5. A set of pre-defined locations where conda is typically installed.
> 
> To force `reticulate` to use a particular `conda` binary, we recommend
> setting:
> ```r
> options(reticulate.conda_binary = "/path/to/conda")
> ```


Closes #1542, #1460
Related #1176