### PR TITLE
Fix duplicate prompts to create a default venv.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,9 @@
 - Fixed an issue where reticulate would error when using a conda environment
   where the original conda binary that was used to create the environment
   is no longer available (#1555)
+  
+- Fixed an issue where the would be unable to accept the prompt to create
+  the default "r-reticulate" venv (#1557).
 
 # reticulate 1.35.0
 


### PR DESCRIPTION
This fixes an issue where a user could be prompted to create the default "r-reticulate" venv multiple times. For example:

```r
reticulate::py_eval("")
Would you like to create a default python environment for the reticulate package? (Yes/no/cancel) y
Would you like to create a default python environment for the reticulate package? (Yes/no/cancel) y
Would you like to create a default python environment for the reticulate package? (Yes/no/cancel) y
...
```