### PR TITLE
allow delay_load list to list multiple environments

### DIFF
--- a/R/import.R
+++ b/R/import.R
@@ -137,14 +137,13 @@ register_delay_load_import <- function(module, delay_load = NULL) {
 
   } else if (is.list(delay_load)) {
 
-    spec$priority <- delay_load$priority %||% 0L
-    spec$environment <- delay_load$environment %||% NA_character_
+    spec$priority <- as.integer(delay_load$priority %||% 0L)
+    spec$environment <- as.character(delay_load$environment %||% NA_character_)
     hooks <- delay_load
 
   }
-
-  storage.mode(spec$priority) <- "integer"
-  storage.mode(spec$environment) <- "character"
+  # maybe recycle 'module', 'priority' if length(environment) > 1
+  spec <- as.data.frame(spec, stringsAsFactors = FALSE)
 
   df <- .globals$delay_load_imports
   df <- rbind(df, spec, stringsAsFactors = FALSE)


### PR DESCRIPTION
This is an internal change allowing usage like this in tensorflow, where `length(environment) > 1`:

```r
tf <- NULL
.onLoad <- function(libname, pkgname) {
   ...
   tf <<- import("tensorflow", delay_load = list(
     priority = 5, # keras sets priority = 10
     environment = c("r-tensorflow", "r-keras"),
     ...
```

No doc changes because this mechanism for expressing soft import preferences is overly complex because of legacy support for both conda and virtual envs, (and the `priority` mechanism is not exposed intentionally). 

Most package authors looking to accomplish something similar would be better served by multiple calls to `use_python(,required = FALSE)`, e.g.

```r
tf <- NULL
.onLoad <- function(libname, pkgname) {
   ...
   use_virtualenv("r-tensorflow", required = FALSE)
   use_virtualenv("r-keras", required = FALSE)
   use_condaenv("r-tensorflow", required = FALSE)
   use_condaenv("r-keras", required = FALSE)

   tf <<- import("tensorflow", delay_load = TRUE)
   ...
```