### PR TITLE
Call `PyErr_Clear()` instead of `PyErr_Restore()` in `py_get_attr_impl(silent = TRUE)`

### DIFF
--- a/src/python.cpp
+++ b/src/python.cpp
@@ -2763,21 +2763,16 @@ PyObjectRef py_get_attr_impl(PyObjectRef x,
 {
 
   ensure_python_initialized();
-  PyObject *attr;
 
-  if (silent) {
-    PyErrorScopeGuard _g;
+  PyObject *attr = PyObject_GetAttrString(x, key.c_str()); // new ref
 
-    attr = PyObject_GetAttrString(x, key.c_str());
-    if (attr == NULL)
+  if (attr == NULL) {
+    if (silent) {
+      PyErr_Clear();
       return PyObjectRef(R_NilValue, false);
-
-  } else {
-
-    attr = PyObject_GetAttrString(x, key.c_str());
-    if (attr == NULL)
+    } else {
       throw PythonException(py_fetch_error());
-
+    }
   }
 
   return py_ref(attr, x.convert());


### PR DESCRIPTION
This is a workaround for an issue encountered on Windows, where calling `py_get_attr(silent = TRUE)` raised an exception. 

https://github.com/rstudio/tensorflow/actions/runs/8439823909/job/23115333998?pr=594
```
── Error ('test-as_tensor.R:6:5'): as_tensor works ─────────────────────────────
<python.builtin.SystemError/python.builtin.Exception/python.builtin.BaseException/python.builtin.object/error/condition>
Error in `py_get_attr_impl(x, name, TRUE)`: SystemError: _PyEval_EvalFrameDefault returned a result with an error set
Run `reticulate::py_last_error()` for details.
Backtrace:
     ▆
  1. ├─tensorflow (local) test_is_tensor(as_tensor(3, tf$int64), tf$int64) at test-as_tensor.R:32:3
  2. │ ├─testthat::expect(...) at test-as_tensor.R:6:5
  3. │ └─"tensorflow.tensor" %in% class(x)
  4. ├─tensorflow::as_tensor(3, tf$int64)
  5. ├─tensorflow:::as_tensor.double(3, tf$int64) at tensorflow/R/generics.R:752:14
  6. ├─base::NextMethod() at tensorflow/R/generics.R:835:3
  7. └─tensorflow:::as_tensor.default(3, tf$int64)
  8.   ├─tf$convert_to_tensor at tensorflow/R/generics.R:782:3
  9.   └─reticulate:::`$.python.builtin.module`(tf, "convert_to_tensor") at tensorflow/R/generics.R:782:3
 10.     └─reticulate:::py_get_attr_impl(x, name, TRUE) at reticulate/R/python.R:359:3
```

Most likely, a previous Python expression had left an exception set but not raised, but it is not caught / checked until the guardrails in `_PyEval_EvalFrameDefault` checks the return value from `PyObject_GetAttrString()`.

Ideally we would track down what was leaving an exception set, but this patch should result in a more reliable experience for users too. 