### PR TITLE
Remove warning about unused `use_python(,required=FALSE)` calls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,10 +25,12 @@
 - Fixed an issue where calling `py_set_item()` on a subclassed dict would
   not invoke a custom `__setitem__` method.
 
-- `py_del_attr(x, name)` now returns x invisibly
+- `py_del_attr(x, name)` now returns `x` invisibly
 
 - `source_python()` no longer exports assigns the `r` symbol to the R globalenv().
   (the "R Interface object" that is used by python code get a reference to the R globalenv)
+
+- Reticulate will no longer warn about ignored `use_python(,required = FALSE)` calls.
 
 - `iterate(simplify=TRUE)` rewritten in C for speed improvements.
 

--- a/R/package.R
+++ b/R/package.R
@@ -271,40 +271,6 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
   # https://github.com/rstudio/reticulate/issues/586
   py_set_qt_qpa_platform_plugin_path(config)
 
-  # notify the user if the loaded version of Python isn't the same
-  # as the requested version of python
-  local({
-
-    # nothing to do if user didn't request any version
-    requested_versions <- reticulate_python_versions()
-    if (length(requested_versions) == 0)
-      return()
-
-    # if we loaded one of the requested versions, everything is ok
-    actual <- normalizePath(config$python, winslash = "/", mustWork = FALSE)
-    requested <- normalizePath(requested_versions, winslash = "/", mustWork = FALSE)
-    if (actual %in% requested)
-      return()
-
-    # otherwise, warn that we were unable to honor their request
-    if (length(requested_versions) == 1) {
-      fmt <- paste(
-        "Python '%s' was requested but '%s' was loaded instead",
-        "(see reticulate::py_config() for more information)"
-      )
-      msg <- sprintf(fmt, requested_versions[[1]], config$python)
-      warning(msg, call. = FALSE)
-    } else {
-      fmt <- paste(
-        "could not honor request to load desired versions of Python; '%s' was loaded instead",
-        "(see reticulate::py_config() for more information)"
-      )
-      msg <- sprintf(fmt, config$python)
-      warning(msg, call. = FALSE)
-    }
-
-  })
-
   # return config
   config
 }


### PR DESCRIPTION
Packages may want to place multiple `use_python()` calls in `.onLoad()`, e.g., tensorflow might do:

```r
.onLoad <- function(...)
  use_virtualenv("r-tensorflow", required = FALSE)
  use_virtualenv("r-keras", required = FALSE)
}
```

This patch removes the warning issued by reticulate if a soft Python environment preference like was ignored. 