### PR TITLE
Update capture output streams

### DIFF
--- a/R/python.R
+++ b/R/python.R
@@ -1060,7 +1060,7 @@ py_capture_output <- function(expr, type = c("stdout", "stderr")) {
   capture_stdout <- "stdout" %in% type
   capture_stderr <- "stderr" %in% type
 
-  context_manager <- output_tools$CaptureOutputStreams(
+  context_manager <- output_tools$OutputCaptureContext(
     capture_stdout, capture_stderr
   )
 

--- a/inst/python/rpytools/output.py
+++ b/inst/python/rpytools/output.py
@@ -54,7 +54,7 @@ def _override_logger_streams(
                 _setStream(handler, new_stderr)
 
 
-class CaptureOutputStreams:
+class OutputCaptureContext:
     def __init__(self, capture_stdout, capture_stderr):
         self._capture_stdout = bool(capture_stdout)
         self._capture_stderr = bool(capture_stderr)


### PR DESCRIPTION
Small followup to #1564, making it safe to call `ctxt.collect_output()` before `ctxt.__exit__()` (enabling usage in ``on.exit(ctxt$`__exit__`())``

Also, a variable rename, for clarity. 