### PR TITLE
Allow users to pass extra command-line arguments for conda create, install.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# reticulate 1.36.0.9000
+
+- Added an option for extra command-line arguments in `conda_create()`,
+  `conda_install()` (#1585).
+
 # reticulate 1.36.0
 
 - Internal refactoring and optimization now give a faster experience,

--- a/R/conda.R
+++ b/R/conda.R
@@ -61,6 +61,12 @@
 #'
 #' @param all Boolean; report all instances of Python found?
 #'
+#' @param additional_create_arguments An optional character vector of
+#'   additional arguments to use in the call to `conda create`. 
+#'
+#' @param additional_install_arguments An optional character vector of
+#'   additional arguments to use in the call to `conda install`. 
+#'
 #' @param ... Optional arguments, reserved for future expansion.
 #'
 #'
@@ -195,7 +201,8 @@ conda_create <- function(envname = NULL,
                          channel = character(),
                          environment = NULL,
                          conda = "auto",
-                         python_version = miniconda_python_version())
+                         python_version = miniconda_python_version(),
+                         additional_create_args = character())
 {
   check_forbidden_install("Conda Environments")
 
@@ -205,7 +212,7 @@ conda_create <- function(envname = NULL,
 
   # if environment is provided, use it directly
   if (!is.null(environment))
-    return(conda_create_env(envname, environment, conda))
+    return(conda_create_env(envname, environment, conda, additional_create_args))
 
   # resolve environment name
   envname <- condaenv_resolve(envname)
@@ -237,6 +244,9 @@ conda_create <- function(envname = NULL,
   for (ch in channels)
     args <- c(args, "-c", ch)
 
+  # add additional arguments
+  args <- c(args, additional_create_args)
+
   # invoke conda
   result <- system2t(conda, maybe_shQuote(args))
   if (result != 0L) {
@@ -248,7 +258,7 @@ conda_create <- function(envname = NULL,
   conda_python(envname = envname, conda = conda)
 }
 
-conda_create_env <- function(envname, environment, conda) {
+conda_create_env <- function(envname, environment, conda, additional_create_args) {
 
   check_forbidden_install("Conda Environments")
 
@@ -263,7 +273,8 @@ conda_create_env <- function(envname, environment, conda) {
       c("--prefix", maybe_shQuote(envname))
     else
       c("--name", maybe_shQuote(envname)),
-    "-f", maybe_shQuote(environment)
+    "-f", maybe_shQuote(environment),
+    additional_create_args
   )
 
   result <- system2t(conda, args)
@@ -394,6 +405,8 @@ conda_install <- function(envname = NULL,
                           pip_ignore_installed = FALSE,
                           conda = "auto",
                           python_version = NULL,
+                          additional_create_args = character(),
+                          additional_install_args = character(),
                           ...)
 {
   check_forbidden_install("Python packages")
@@ -445,7 +458,8 @@ conda_install <- function(envname = NULL,
       packages = python_package %||% "python",
       forge = forge,
       channel = channel,
-      conda = conda
+      conda = conda,
+      additional_create_args = additional_create_args
     )
 
     python <- conda_python(envname = envname, conda = conda)
@@ -457,6 +471,7 @@ conda_install <- function(envname = NULL,
   # (should be no-op if that copy of Python already installed)
   if (!is.null(python_version)) {
     args <- conda_args("install", envname, python_package)
+    args <- c(args, additional_install_args)
     status <- system2t(conda, maybe_shQuote(args))
     if (status != 0L) {
       fmt <- "installation of '%s' into environment '%s' failed [error code %i]"
@@ -493,7 +508,7 @@ conda_install <- function(envname = NULL,
   for (ch in channels)
     args <- c(args, "-c", ch)
 
-  args <- c(args, python_package, packages)
+  args <- c(args, python_package, packages, additional_install_args)
   result <- system2t(conda, maybe_shQuote(args))
 
   # check for errors

--- a/R/conda.R
+++ b/R/conda.R
@@ -61,11 +61,11 @@
 #'
 #' @param all Boolean; report all instances of Python found?
 #'
-#' @param additional_create_arguments An optional character vector of
-#'   additional arguments to use in the call to `conda create`. 
+#' @param additional_create_args An optional character vector of additional
+#'   arguments to use in the call to `conda create`. 
 #'
-#' @param additional_install_arguments An optional character vector of
-#'   additional arguments to use in the call to `conda install`. 
+#' @param additional_install_args An optional character vector of additional
+#'   arguments to use in the call to `conda install`. 
 #'
 #' @param ... Optional arguments, reserved for future expansion.
 #'

--- a/man/conda-tools.Rd
+++ b/man/conda-tools.Rd
@@ -109,6 +109,9 @@ and other arguments will be ignored.}
 you'd like to change the version of Python associated with a particular
 conda environment.}
 
+\item{additional_create_args}{An optional character vector of additional
+arguments to use in the call to \verb{conda create}.}
+
 \item{clone}{The name of the conda environment to be cloned.}
 
 \item{file}{The path where the conda environment definition will be written.}
@@ -129,15 +132,12 @@ for situations where you don't want a pip install to attempt an overwrite of
 a conda binary package (e.g. SciPy on Windows which is very difficult to
 install via pip due to compilation requirements).}
 
+\item{additional_install_args}{An optional character vector of additional
+arguments to use in the call to \verb{conda install}.}
+
 \item{all}{Boolean; report all instances of Python found?}
 
 \item{matchspec}{A conda MatchSpec query string.}
-
-\item{additional_create_arguments}{An optional character vector of
-additional arguments to use in the call to \verb{conda create}.}
-
-\item{additional_install_arguments}{An optional character vector of
-additional arguments to use in the call to \verb{conda install}.}
 }
 \value{
 \code{conda_list()} returns an \R \code{data.frame}, with \code{name} giving the name of

--- a/man/conda-tools.Rd
+++ b/man/conda-tools.Rd
@@ -27,7 +27,8 @@ conda_create(
   channel = character(),
   environment = NULL,
   conda = "auto",
-  python_version = miniconda_python_version()
+  python_version = miniconda_python_version(),
+  additional_create_args = character()
 )
 
 conda_clone(envname, ..., clone = "base", conda = "auto")
@@ -52,6 +53,8 @@ conda_install(
   pip_ignore_installed = FALSE,
   conda = "auto",
   python_version = NULL,
+  additional_create_args = character(),
+  additional_install_args = character(),
   ...
 )
 
@@ -129,6 +132,12 @@ install via pip due to compilation requirements).}
 \item{all}{Boolean; report all instances of Python found?}
 
 \item{matchspec}{A conda MatchSpec query string.}
+
+\item{additional_create_arguments}{An optional character vector of
+additional arguments to use in the call to \verb{conda create}.}
+
+\item{additional_install_arguments}{An optional character vector of
+additional arguments to use in the call to \verb{conda install}.}
 }
 \value{
 \code{conda_list()} returns an \R \code{data.frame}, with \code{name} giving the name of


### PR DESCRIPTION
Fixes #1583 with additional optional arguments. The same general approach could possibly could be extended to all `conda` calls (e.g., `conda clone`, `conda export`), but I've kept the scope limited to `create` and `install` for now.