### PR TITLE
Fix pandas conversion if external packages define `py_to_r()` S3 methods for pandas subobjects. 

### DIFF
--- a/R/conversion.R
+++ b/R/conversion.R
@@ -267,7 +267,7 @@ py_to_r.datatable.Frame <- function(x) {
 
 #' @export
 py_to_r.pandas.core.frame.DataFrame <- function(x) {
-  local_conversion_scope(x, TRUE)
+  local_conversion_scope(x, FALSE)
 
   np <- import("numpy", convert = TRUE)
   pandas <- import("pandas", convert = TRUE)
@@ -282,12 +282,12 @@ py_to_r.pandas.core.frame.DataFrame <- function(x) {
   })
 
   # assign colnamnes
-  columns <- py_set_convert(x$columns, FALSE)$values
+  columns <- x$columns$values
   columns <- as.character(bt$list(x$columns$map(bt$str)))
   names(converted) <- columns
 
   df <- converted
-  attr(df, "row.names") <- c(NA_integer_, -x$shape[[1L]])
+  attr(df, "row.names") <- c(NA_integer_, py_to_r(-x$shape[[0L]]))
   class(df) <- "data.frame"
 
   # attempt to copy over index, and set as rownames when appropriate

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -3610,7 +3610,7 @@ SEXP py_convert_pandas_series(PyObjectRef series) {
   } else {
 
     PyObjectPtr values(PyObject_GetAttrString(series, "values"));
-    R_obj = py_to_r(values, series.convert());
+    R_obj = py_to_r(values, true);
 
   }
 
@@ -3643,7 +3643,7 @@ SEXP py_convert_pandas_df(PyObjectRef df) {
     PyObjectPtr series(PySequence_GetItem(tuple, 1));
 
     // delegate to py_convert_pandas_series
-    PyObjectRef series_ref(series.detach(), df.convert());
+    PyObjectRef series_ref(series.detach(), true);
     RObject R_obj = py_convert_pandas_series(series_ref);
 
     list.push_back(R_obj);


### PR DESCRIPTION
Closes #1591 