### PR TITLE
Respect user-specified channels when installing Python in conda_install().

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,9 @@
 - Added an option for extra command-line arguments in `conda_create()`,
   `conda_install()` (#1585).
 
+- Fixed issue where `conda_install()` ignores user-specified channels during
+  Python installation (#1594).
+
 # reticulate 1.36.0
 
 - Internal refactoring and optimization now give a faster experience,

--- a/R/conda.R
+++ b/R/conda.R
@@ -466,12 +466,22 @@ conda_install <- function(envname = NULL,
 
   }
 
+  # prepare user-requested channels
+  channels <- if (length(channel))
+    channel
+  else if (forge)
+    "conda-forge"
+
+  channel_args <- character()
+  for (ch in channels)
+    channel_args <- c(channel_args, "-c", ch)
+
   # if the user has requested a specific version of Python, ensure that
   # version of Python is installed into the requested environment
   # (should be no-op if that copy of Python already installed)
   if (!is.null(python_version)) {
     args <- conda_args("install", envname, python_package)
-    args <- c(args, additional_install_args)
+    args <- c(args, channel_args, additional_install_args)
     status <- system2t(conda, maybe_shQuote(args))
     if (status != 0L) {
       fmt <- "installation of '%s' into environment '%s' failed [error code %i]"
@@ -500,13 +510,7 @@ conda_install <- function(envname = NULL,
   args <- conda_args("install", envname)
 
   # add user-requested channels
-  channels <- if (length(channel))
-    channel
-  else if (forge)
-    "conda-forge"
-
-  for (ch in channels)
-    args <- c(args, "-c", ch)
+  args <- c(args, channel_args)
 
   args <- c(args, python_package, packages, additional_install_args)
   result <- system2t(conda, maybe_shQuote(args))


### PR DESCRIPTION
As discussed in #1585, this ensures that Python installation inside `conda_install()` respects the user-defined channels.