### PR TITLE
Ignore broken links encountered by `virtualenv_starter()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # reticulate (development version)
 
+- `virtualenv_starter()` no longer warns when encountering broken symlinks (#1598).
+
 # reticulate 1.36.1
 
 - Fix issue where `py_to_r()` method for Pandas DataFrames would error 

--- a/R/virtualenv.R
+++ b/R/virtualenv.R
@@ -533,8 +533,10 @@ virtualenv_starter <- function(version = NULL, all = FALSE) {
                suffix)
     }
 
-    p <- unique(normalizePath(Sys.glob(glob), winslash = "/"))
+    p <- unique(normalizePath(Sys.glob(glob), winslash = "/", mustWork = FALSE))
     p <- p[grep("^python[0-9.]*(\\.exe)?$", basename(p))]
+    p <- p[utils::file_test("-x", p)]
+    p <- p[utils::file_test("-f", p)]
     v <- numeric_version(vapply(p, function(python_path)
       tryCatch({
         v <- suppressWarnings(system2(


### PR DESCRIPTION
Fixes a warning observed in https://github.com/rstudio/tensorflow/issues/597

This silences a warning if, for example, `/usr/local/bin/python3` is a broken symlink on the user's system.