### PR TITLE
Do not add outputs when results = 'hide' is set

### DIFF
--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -349,10 +349,11 @@ eng_python <- function(options) {
       plt$show()
   }
 
-  for (plot in .engine_context$pending_plots$data())
-    outputs_target$push(plot)
-  .engine_context$pending_plots$clear()
-
+  if (!is_hidden && is_include) {
+    for (plot in .engine_context$pending_plots$data())
+      outputs_target$push(plot)
+    .engine_context$pending_plots$clear()
+  }
 
   # if we were using held outputs, we just inject the source in now
   if (is_hold) {

--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -197,6 +197,7 @@ eng_python <- function(options) {
 
   # Stash some options.
   is_hold <- identical(options$results, "hold")
+  is_hidden <- identical(options$results, "hide")
   is_include <- isTRUE(options$include)
   jupyter_compat <- isTRUE(options$jupyter_compat)
 
@@ -306,7 +307,7 @@ eng_python <- function(options) {
       }
 
       # append captured outputs (respecting 'include' option)
-      if (is_include) {
+      if (!is_hidden && is_include) {
         # append captured output
         if (!identical(captured, ""))
           outputs_target$push(captured)

--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -198,7 +198,6 @@ eng_python <- function(options) {
   # Stash some options.
   is_hold <- identical(options$results, "hold")
   is_hidden <- identical(options$results, "hide")
-  is_include <- isTRUE(options$include)
   jupyter_compat <- isTRUE(options$jupyter_compat)
 
   # line index from which source should be emitted
@@ -306,8 +305,8 @@ eng_python <- function(options) {
         outputs$push(output)
       }
 
-      # append captured outputs (respecting 'include' option)
-      if (!is_hidden && is_include) {
+      # append captured outputs (respecting 'results = "hide"' option)
+      if (!is_hidden) {
         # append captured output
         if (!identical(captured, ""))
           outputs_target$push(captured)
@@ -349,7 +348,7 @@ eng_python <- function(options) {
       plt$show()
   }
 
-  if (!is_hidden && is_include) {
+  if (!is_hidden) {
     for (plot in .engine_context$pending_plots$data())
       outputs_target$push(plot)
     .engine_context$pending_plots$clear()

--- a/tests/testthat/_snaps/python-knitr-engine/knitr-results-hide.md
+++ b/tests/testthat/_snaps/python-knitr-engine/knitr-results-hide.md
@@ -1,0 +1,5 @@
+    class MyClass:
+        def _repr_html_(self):
+            return "<p>uh-oh</p>"
+
+    MyClass()

--- a/tests/testthat/resources/knitr-results-hide.Rmd
+++ b/tests/testthat/resources/knitr-results-hide.Rmd
@@ -1,0 +1,16 @@
+---
+title: "Hide and include"
+output: md_document
+---
+
+```{python, results = 'hide'}
+class MyClass:
+    def _repr_html_(self):
+        return "<p>uh-oh</p>"
+
+MyClass()
+```
+
+```{python, include = FALSE}
+1 + 1
+```

--- a/tests/testthat/test-python-knitr-engine.R
+++ b/tests/testthat/test-python-knitr-engine.R
@@ -86,6 +86,23 @@ test_that("knitr 'warning=FALSE' option", {
 
 })
 
+test_that("knitr results='hide' and include = FALSE options", {
+
+  skip_on_cran()
+  skip_if_not_installed("rmarkdown")
+
+  local_edition(3) # needed for expect_snapshot_file()
+
+  owd <- setwd(test_path("resources"))
+  rmarkdown::render("knitr-results-hide.Rmd", quiet = TRUE)
+  setwd(owd)
+
+  rendered <- test_path("resources", "knitr-results-hide.md")
+
+  expect_snapshot_file(rendered)
+
+})
+
 test_that("Output streams are remaped when kniting", {
 
   skip_on_cran()


### PR DESCRIPTION
closes #1599 

As mentioned, `include` is handled by **knitr** directly since a long time 
https://github.com/yihui/knitr/blob/44a7bee566afff3eb4c8b13fd6fa64487e12981f/R/block.R#L350

so I replaced by `results = 'hide'` information. 

It also seems that there are two places where output is handled (because of specific handling for matplotlib, so I added the if check there too 

I think this is all that is missing for results to be supported. 

If you prefer to keep `is_include` for safety, then we can add it back in each `if`

