### PR TITLE
refactor interrupt and exception handling

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -24,16 +24,7 @@
                                           environment = character(),
                                           stringsAsFactors = FALSE)
 .globals$suppress_warnings_handlers <- list()
-.globals$class_filters <- list(
-
-  function(classes) {
-    if ("python.builtin.BaseException" %in% classes) {
-      classes <- unique(c(classes, "error", "condition"))
-    }
-    classes
-  }
-
-)
+.globals$class_filters <- list()
 .globals$py_repl_active <- FALSE
 
 is_python_initialized <- function() {

--- a/R/python.R
+++ b/R/python.R
@@ -1376,13 +1376,14 @@ py_inject_hooks <- function() {
 
   builtins <- import_builtins(convert = TRUE)
 
-  input <- function(prompt = "") {
-
-    readline(prompt)
-  }
-
   # override input function
   if (interactive() && was_python_initialized_by_reticulate()) {
+    # PyOS_ReadlineFunctionPointer() is not part of the stable ABI.
+    # PyOS_InputHook() only has one slot - used by other thigns like tkinter.
+    input <- function(prompt = "") {
+      readline(prompt)
+    }
+
     name <- if (is_python3()) "input" else "raw_input"
     builtins[[name]] <- input
   }

--- a/inst/python/rpytools/call.py
+++ b/inst/python/rpytools/call.py
@@ -1,26 +1,11 @@
-import rpycall
+from rpycall import call_r_function
 
 
 def make_python_function(f, name=None):
     def python_function(*args, **kwargs):
-        # call the function
-        value, error = rpycall.call_r_function(f, *args, **kwargs)
+        return call_r_function(f, *args, **kwargs)
 
-        if error:
-            if isinstance(error, str) and error == "KeyboardInterrupt":
-                # Only reachable if a C++ exception was caught in call_r_function()
-                # otherwise error is always an Exception object
-                raise KeyboardInterrupt()
-
-            if isinstance(error, BaseException):
-                raise error
-
-            # basically unreachable since R errors get automatically
-            # converted to python Exceptions, but just in case
-            raise RuntimeError(error)
-        return value
-
-    if not name is None:
+    if name is not None:
         python_function.__name__ = name
 
     return python_function

--- a/src/event_loop.cpp
+++ b/src/event_loop.cpp
@@ -85,10 +85,12 @@ int pollForEvents(void*) {
   // Some guarantees for code that runs in this function scope:
   //
   // 1. We are on the main thread, we have the Python GIL, no other code is
-  // concurrently accessing R. i.e., we can safely use the full Python and R APIs.
+  // concurrently accessing R. i.e., we can safely use the full Python and R
+  // APIs.
   //
-  // 2. The Python interpreter is running and currently on a byte
-  // code boundary (R is waiting on Python to finish).
+  // 2. The Python interpreter is currently on a byte code boundary
+  // (R is waiting on Python to finish). This mean that it is *not* safe to
+  // raise an Exception, risk an R/C lngjmp, or throw a C++ exception.
 
   // Request that the background thread schedule us to be called again
   // (this is delegated to a background thread so that these requests

--- a/src/event_loop.cpp
+++ b/src/event_loop.cpp
@@ -82,6 +82,13 @@ void processEvents(void* data) {
 int pollForEvents(void*) {
 
   DBG("Polling for events.");
+  // Some guarantees for code that runs in this function scope:
+  //
+  // 1. We are on the main thread, we have the Python GIL, no other code is
+  // concurrently accessing R. i.e., we can safely use the full Python and R APIs.
+  //
+  // 2. The Python interpreter is running and currently on a byte
+  // code boundary (R is waiting on Python to finish).
 
   // Request that the background thread schedule us to be called again
   // (this is delegated to a background thread so that these requests

--- a/src/event_loop.cpp
+++ b/src/event_loop.cpp
@@ -52,7 +52,7 @@ void eventPollingWorker(void *) {
   while (true) {
 
     // Throttle via sleep
-    tthread::this_thread::sleep_for(tthread::chrono::milliseconds(200));
+    tthread::this_thread::sleep_for(tthread::chrono::milliseconds(500));
 
     // Schedule polling on the main thread if the interpeter is still running.
     // Note that Py_AddPendingCall is documented to be callable from a background

--- a/src/libpython.cpp
+++ b/src/libpython.cpp
@@ -158,6 +158,7 @@ void initialize_type_objects(bool python3) {
   PyObject* builtins = PyImport_AddModule(python3 ? "builtins" : "__builtin__"); // borrowed ref
   if (builtins == NULL) goto error;
   PyExc_KeyboardInterrupt = PyObject_GetAttrString(builtins, "KeyboardInterrupt"); // new ref
+  PyExc_RuntimeError = PyObject_GetAttrString(builtins, "RuntimeError"); // new ref
 
   if (PyErr_Occurred()) { error:
      // Should never happen. If you see this please report a bug
@@ -226,6 +227,8 @@ bool LibPython::loadSymbols(bool python3, std::string* pError)
   LOAD_PYTHON_SYMBOL(PyErr_Restore)
   LOAD_PYTHON_SYMBOL(PyErr_Occurred)
   LOAD_PYTHON_SYMBOL(PyErr_SetNone)
+  LOAD_PYTHON_SYMBOL(PyErr_SetString)
+  LOAD_PYTHON_SYMBOL(PyErr_SetObject)
   LOAD_PYTHON_SYMBOL(PyErr_BadArgument)
   LOAD_PYTHON_SYMBOL(PyErr_NormalizeException)
   LOAD_PYTHON_SYMBOL(PyErr_ExceptionMatches)
@@ -282,6 +285,7 @@ bool LibPython::loadSymbols(bool python3, std::string* pError)
   LOAD_PYTHON_SYMBOL(PyType_IsSubtype)
   LOAD_PYTHON_SYMBOL(PyType_GetFlags)
   LOAD_PYTHON_SYMBOL(PyMapping_Items)
+  LOAD_PYTHON_SYMBOL(PyOS_getsig)
   LOAD_PYTHON_SYMBOL(PyOS_setsig)
   LOAD_PYTHON_SYMBOL(PySys_WriteStderr)
   LOAD_PYTHON_SYMBOL(PySys_GetObject)
@@ -295,6 +299,7 @@ bool LibPython::loadSymbols(bool python3, std::string* pError)
   LOAD_PYTHON_SYMBOL(PyObject_IsTrue)
   LOAD_PYTHON_SYMBOL(PyCapsule_Import)
   LOAD_PYTHON_SYMBOL(PyUnicode_AsUTF8)
+  LOAD_PYTHON_SYMBOL(PyUnicode_CompareWithASCIIString)
 
   // PyUnicode_AsEncodedString may have several different names depending on the Python
   // version and the UCS build type

--- a/src/libpython.h
+++ b/src/libpython.h
@@ -145,6 +145,7 @@ LIBPYTHON_EXTERN PyObject* Py_Tuple;
 LIBPYTHON_EXTERN PyObject* Py_Complex;
 LIBPYTHON_EXTERN PyObject* Py_ByteArray;
 LIBPYTHON_EXTERN PyObject* PyExc_KeyboardInterrupt;
+LIBPYTHON_EXTERN PyObject* PyExc_RuntimeError;
 LIBPYTHON_EXTERN PyObject* PyExc_ValueError;
 
 void initialize_type_objects(bool python3);
@@ -193,6 +194,9 @@ void initialize_type_objects(bool python3);
 #define PyBool_Check(o)      ((o == Py_False) || (o == Py_True))
 #define PyFunction_Check(op) ((PyTypeObject*)(Py_TYPE(op)) == PyFunction_Type)
 #define PyMethod_Check(op)   ((PyTypeObject *)(Py_TYPE(op)) == PyMethod_Type)
+#define PyExceptionClass_Check(x)                                       \
+    (PyType_Check((x)) &&                                               \
+     PyType_FastSubclass((PyTypeObject*)(x), Py_TPFLAGS_BASE_EXC_SUBCLASS))
 
 LIBPYTHON_EXTERN void (*Py_InitializeEx)(int);
 LIBPYTHON_EXTERN int (*Py_IsInitialized)();
@@ -278,6 +282,7 @@ LIBPYTHON_EXTERN int (*PyString_AsStringAndSize)(
 
 LIBPYTHON_EXTERN PyObject* (*PyString_FromString)(const char *);
 LIBPYTHON_EXTERN PyObject* (*PyString_FromStringAndSize)(const char *, Py_ssize_t);
+LIBPYTHON_EXTERN int (*PyUnicode_CompareWithASCIIString)(PyObject *unicode, const char *string);
 
 LIBPYTHON_EXTERN PyObject* (*PyUnicode_EncodeLocale)(PyObject *unicode, const char *errors);
 LIBPYTHON_EXTERN PyObject* (*PyUnicode_AsEncodedString)(PyObject *unicode, const char *encoding, const char *errors);
@@ -307,6 +312,8 @@ LIBPYTHON_EXTERN void (*PyErr_PrintEx)(int set_sys_last_vars);
 LIBPYTHON_EXTERN void (*PyErr_Fetch)(PyObject **, PyObject **, PyObject **);
 LIBPYTHON_EXTERN void (*PyErr_Restore)(PyObject *, PyObject *, PyObject *);
 LIBPYTHON_EXTERN void (*PyErr_SetNone)(PyObject*);
+LIBPYTHON_EXTERN void (*PyErr_SetObject)(PyObject*, PyObject*);
+LIBPYTHON_EXTERN void (*PyErr_SetString)(PyObject*, const char *);
 LIBPYTHON_EXTERN void (*PyErr_BadArgument)();
 LIBPYTHON_EXTERN PyObject* (*PyErr_Occurred)(void);
 LIBPYTHON_EXTERN void (*PyErr_NormalizeException)(PyObject**, PyObject**, PyObject**);
@@ -376,6 +383,7 @@ LIBPYTHON_EXTERN void (*Py_SetProgramName_v3)(wchar_t *);
 LIBPYTHON_EXTERN void (*Py_SetPythonHome)(char *);
 LIBPYTHON_EXTERN void (*Py_SetPythonHome_v3)(wchar_t *);
 
+LIBPYTHON_EXTERN PyOS_sighandler_t (*PyOS_getsig)(int i);
 LIBPYTHON_EXTERN PyOS_sighandler_t (*PyOS_setsig)(int i, PyOS_sighandler_t h);
 
 LIBPYTHON_EXTERN void (*PySys_SetArgv)(int, char **);

--- a/src/signals.cpp
+++ b/src/signals.cpp
@@ -1,7 +1,4 @@
 
-#include "signals.h"
-#include "common.h"
-
 #ifndef _WIN32
 # include <string.h>
 # include <signal.h>
@@ -10,6 +7,13 @@
 #endif
 
 #include "libpython.h"
+#include "signals.h"
+
+// import "common.h" last, so that <R_ext/Boolean.h> last,
+// otherwise, windows.h has a different definition of TRUE and FALSE
+// that is not an Rboolean.
+#include "common.h"
+
 using namespace reticulate::libpython;
 
 extern "C" {

--- a/src/signals.cpp
+++ b/src/signals.cpp
@@ -24,7 +24,7 @@ LibExtern int UserBreak;
 // flag indicating if interrupts are suspended
 // note that R doesn't use this on Windows when checking
 // for interrupts in R_ProcessEvents
-LibExtern int R_interrupts_suspended;
+LibExtern Rboolean R_interrupts_suspended;
 
 }
 
@@ -55,7 +55,7 @@ bool getInterruptsSuspended() {
 }
 
 void setInterruptsSuspended(bool value) {
-  R_interrupts_suspended = value ? 1 : 0;
+  R_interrupts_suspended = value ? TRUE : FALSE;
 }
 
 } // end namespace signals

--- a/src/signals.cpp
+++ b/src/signals.cpp
@@ -9,9 +9,9 @@
 #include "libpython.h"
 #include "signals.h"
 
-// import "common.h" last, so that <R_ext/Boolean.h> last,
-// otherwise, windows.h has a different definition of TRUE and FALSE
-// that is not an Rboolean.
+// import "common.h" last, so that <R_ext/Boolean.h> is included last.
+// Otherwise, windows.h defines TRUE and FALSE to values that are not
+// Rboolean types, leading to compilation failures.
 #include "common.h"
 
 using namespace reticulate::libpython;


### PR DESCRIPTION
This is a followup to #1602, split off to keep #1602 small and readable. This PR includes some refactoring of `py_to_r(<python.builtin.Exception>)` conversion, and `call_r_function()` exception handling. S