### PR TITLE
Print Python callables with their signature

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,20 +2,22 @@
 
 - Interrupting Python no longer leads to segfaults (#1601, fixed in #1602).
 
+- Print method for Python callables now includes the callable’s signature (#1605)
+
 - `virtualenv_starter()` no longer warns when encountering broken symlinks (#1598).
 
 # reticulate 1.36.1
 
-- Fix issue where `py_to_r()` method for Pandas DataFrames would error 
-  if `py_to_r()` S3 methods were defined for Pandas subtypes, 
+- Fix issue where `py_to_r()` method for Pandas DataFrames would error
+  if `py_to_r()` S3 methods were defined for Pandas subtypes,
   (as done by {anndata}) (#1591).
-  
+
 - "Python Dependencies" vignette edits (@salim-b, #1586)
 
-- Added an option for extra command-line arguments in 
+- Added an option for extra command-line arguments in
   `conda_create()` and `conda_install()` (#1585).
 
-- Fixed issue where `conda_install()` would ignore user-specified 
+- Fixed issue where `conda_install()` would ignore user-specified
   channels during Python installation (#1594).
 
 # reticulate 1.36.0


### PR DESCRIPTION
closes #1604

Example output:
```r
> py_eval("print")
<builtin_function_or_method builtins.print(*args, sep=' ', end='\n', file=None, flush=False)>

> py_eval("RuntimeError")
<type builtins.RuntimeError(*args, **kwargs)>

> keras <- import("keras")
> keras$layers$Dense
<type keras.src.layers.core.dense.Dense(
  units, 
  activation=None, 
  use_bias=True, 
  kernel_initializer='glorot_uniform', 
  bias_initializer='zeros', 
  kernel_regularizer=None, 
  bias_regularizer=None, 
  activity_regularizer=None, 
  kernel_constraint=None, 
  bias_constraint=None, 
  lora_rank=None, 
  **kwargs
)>
```