### PR TITLE
Update print method for Python callables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 - Interrupting Python no longer leads to segfaults (#1601, fixed in #1602).
 
-- Print method for Python callables now includes the callable’s signature (#1605)
+- Print method for Python callables now includes the callable’s signature (#1605, #1607)
 
 - `virtualenv_starter()` no longer warns when encountering broken symlinks (#1598).
 


### PR DESCRIPTION
This is a followup to #1605, updates the printed output. We no longer discard the default `x.__repr__()` output, and we present typed instances a little more intuitively. 

New example output:

```r
> keras <- reticulate::import("keras")
> builtins <- reticulate::import("builtins")

> keras$losses$BinaryCrossentropy
<class 'keras.src.losses.losses.BinaryCrossentropy'>
 signature: (
   from_logits=False, 
   label_smoothing=0.0, 
   axis=-1, 
   reduction='sum_over_batch_size', 
   name='binary_crossentropy'
)

> keras$losses$BinaryCrossentropy()
<keras.src.losses.losses.BinaryCrossentropy object at 0x710d39fe5e90>
 signature: (y_true, y_pred, sample_weight=None)

> builtins$print
<built-in function print>
 signature: (*args, sep=' ', end='\n', file=None, flush=False)

> builtins$repr
<built-in function repr>
 signature: (obj, /)

> builtins$hash
<built-in function hash>
 signature: (obj, /)

> builtins$RuntimeError
<class 'RuntimeError'>
 signature: (*args, **kwargs)
```