### PR TITLE
Support non-conda binaries

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 - `virtualenv_starter()` no longer warns when encountering broken symlinks (#1598).
 
+- Fixed issue where a configured `mamba` binary was overriden with `conda` (#1608).
+
 # reticulate 1.36.1
 
 - Fix issue where `py_to_r()` method for Pandas DataFrames would error

--- a/R/conda.R
+++ b/R/conda.R
@@ -546,7 +546,7 @@ conda_binary <- function(conda = "auto") {
   # we rely on other tools typically bundled in the 'bin' folder
   # https://github.com/rstudio/keras/issues/691
   if (!is_windows()) {
-    altpath <- file.path(dirname(conda), "../bin/conda")
+    altpath <- file.path(dirname(conda), "../bin", basename(conda))
     if (file.exists(altpath))
       return(normalizePath(altpath, winslash = "/", mustWork = TRUE))
   } else {


### PR DESCRIPTION
Allow using a `mamba` binary instead of `conda`.
Currently, the `mamba` binary gets overriden with `conda`, even if using the version of `mamba` in the `bin` directory. We preserve the behavior of overriding `condabin` with `bin` if an executable exists in that folder