### PR TITLE
Include signals.h on Windows ARM64

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - Print method for Python callables now includes the callable’s signature (#1605, #1607)
 
+- Reticulate now installs successfully on Windows ARM64 (#1609, contributed by @andrjohns).
+
 - `virtualenv_starter()` no longer warns when encountering broken symlinks (#1598).
 
 - Fixed issue where a configured `mamba` binary was overriden with `conda` (#1608).

--- a/src/tinythread.h
+++ b/src/tinythread.h
@@ -84,6 +84,9 @@ extern "C" void Rf_error(const char* fmt, ...);
     #undef WIN32_LEAN_AND_MEAN
     #undef __UNDEF_LEAN_AND_MEAN
   #endif
+  #ifdef __aarch64__
+    #include <csignal>
+  #endif
 #else
   #include <pthread.h>
   #include <signal.h>

--- a/src/tinythread.h
+++ b/src/tinythread.h
@@ -85,7 +85,7 @@ extern "C" void Rf_error(const char* fmt, ...);
     #undef __UNDEF_LEAN_AND_MEAN
   #endif
   #ifdef __aarch64__
-    #include <csignal>
+    #include <signal.h>
   #endif
 #else
   #include <pthread.h>


### PR DESCRIPTION
Attempting to install `reticulate` on Windows ARM64 fails with the error:

```
* installing *source* package 'reticulate' ...
** using staged installation
** libs
using C++ compiler: 'clang version 17.0.6'
clang++ -std=gnu++17  -I"C:/PROGRA~1/R-AARC~1/R-devel/include" -DNDEBUG  -I'C:/Users/andrew/AppData/Local/R/aarch64-library/4.5/Rcpp/include' -w  -I"C:/rtools44-aarch64/aarch64-w64-mingw32.static.posix/include"     -O2 -Wall    -c RcppExports.cpp -o RcppExports.o
clang++ -std=gnu++17  -I"C:/PROGRA~1/R-AARC~1/R-devel/include" -DNDEBUG  -I'C:/Users/andrew/AppData/Local/R/aarch64-library/4.5/Rcpp/include' -w  -I"C:/rtools44-aarch64/aarch64-w64-mingw32.static.posix/include"     -O2 -Wall    -c event_loop.cpp -o event_loop.o
event_loop.cpp:40:10: error: unknown type name 'sig_atomic_t'
   40 | volatile sig_atomic_t s_pollingRequested;
```

It appears that the `signals.h` header is additionally required for Windows ARM64