### PR TITLE
Moving into R's C API compliance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # reticulate (development version)
 
+- Internal updates for compliance with R's upcoming formalized C API. (#1625)
+
 - Added support for converting NumPy StringDType arrays to R character arrays. (#1623)
 
 - Internal updates for NumPy 2.0 (#1621)

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -502,20 +502,11 @@ SEXP current_env(void) {
     // are looking for to begin with. We use instead this workaround:
     // Call `sys.frame()` from a closure to push a new frame on the
     // stack, and use negative indexing to get the previous frame.
-    ParseStatus status;
-    SEXP code = PROTECT(Rf_mkString("sys.frame(-1)"));
-    SEXP parsed = PROTECT(R_ParseVector(code, -1, &status, R_NilValue));
-    SEXP body = VECTOR_ELT(parsed, 0);
-
-    SEXP fn = PROTECT(Rf_allocSExp(CLOSXP));
-    SET_FORMALS(fn, R_NilValue);
-    SET_BODY(fn, body);
-    SET_CLOENV(fn, R_BaseEnv);
-
+    SEXP fn = PROTECT(R_ParseEvalString("function() sys.frame(-1)", R_BaseEnv));
     SEXP call = Rf_lang1(fn);
     R_PreserveObject(call);
 
-    UNPROTECT(3);
+    UNPROTECT(1);
     return call;
   }();
 
@@ -808,20 +799,13 @@ bool traceback_enabled() {
 
 SEXP get_current_call(void) {
   static SEXP call = []() {
-    ParseStatus status;
-    SEXP code = PROTECT(Rf_mkString("sys.call(-1)"));
-    SEXP parsed = PROTECT(R_ParseVector(code, -1, &status, R_NilValue));
-    SEXP body = VECTOR_ELT(parsed, 0);
 
-    SEXP fn = PROTECT(Rf_allocSExp(CLOSXP));
-    SET_FORMALS(fn, R_NilValue);
-    SET_BODY(fn, body);
-    SET_CLOENV(fn, R_BaseEnv);
+    SEXP fn = PROTECT(R_ParseEvalString("function() sys.call(-1)", R_BaseEnv));
 
     SEXP call = Rf_lang1(fn);
     R_PreserveObject(call);
 
-    UNPROTECT(3);
+    UNPROTECT(1);
     return call;
   }();
 


### PR DESCRIPTION
This PR fixes the current NOTE on R devel CRAN machines about usage of non-API C entry points.

```
Version: 1.37.0
Check: compiled code
Result: NOTE 
  File ‘reticulate/libs/reticulate.so’:
    Found non-API calls to R: ‘SET_BODY’, ‘SET_CLOENV’, ‘SET_FORMALS’
  
  Compiled code should not call non-API entry points in R.
  
  See ‘Writing portable packages’ in the ‘Writing R Extensions’ manual.
Flavors: [r-devel-linux-x86_64-debian-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-gcc/reticulate-00check.html), [r-devel-linux-x86_64-fedora-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-clang/reticulate-00check.html), [r-devel-linux-x86_64-fedora-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-gcc/reticulate-00check.html)
```

Replace usage `SET_{FORMALS,BODY,CLOENV}` and `Rf_allocSExp` with `R_ParseEvalString`.

(This is different from what's recommended in 
https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Moving-into-C-API-compliance)