### PR TITLE
Updates for NumPy 2.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - Python background threads can now run in parallel with
   the R session (#1641).
+  
+- Internal updates for NumPy 2.1 (#1651)
 
 - Fixed error when importing a module named `config` (#1628)
 

--- a/R/array.R
+++ b/R/array.R
@@ -91,9 +91,8 @@ length.numpy.ndarray <- function(x) {
 array_reshape <- function(x, dim, order = c("C", "F")) {
   np <- import("numpy", convert = FALSE)
   order <- match.arg(order)
-  reshaped <- np$reshape(x, as.integer(dim), order)
+  reshaped <- np$reshape(x, as.integer(dim), order = order)
   if (!is_py_object(x))
     reshaped <- py_to_r(reshaped)
   reshaped
 }
-


### PR DESCRIPTION
- update `array_reshape()` for NumPy 2.1