### PR TITLE
Handle invalid conda-meta/history value

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,9 @@
 - Fixed segfault encountered in RStudio when rapidly switching 
   between R and Python chunks in a Quarto document (#1665).
 
+- Improved behavior when the conda binary used to create an environment
+  could not be resolved (contributed by @tl-hbk, #1654, #1659)
+
 # reticulate 1.39.0
 
 - Python background threads can now run in parallel with the R session (#1641).

--- a/R/python-tools.R
+++ b/R/python-tools.R
@@ -144,7 +144,7 @@ python_info_condaenv <- function(path) {
   python <- file.path(path, suffix)
 
   # find path to conda associated with this env
-  conda <- python_info_condaenv_find(path)
+  conda <- get_python_conda_info(python)$conda
 
   list(
     python = python,
@@ -152,56 +152,6 @@ python_info_condaenv <- function(path) {
     root   = path,
     conda  = conda
   )
-
-}
-
-python_info_condaenv_find <- function(path) {
-
-  # first, check if we have a condabin
-  exe <- if (is_windows()) "conda.exe" else "conda"
-  conda <- file.path(path, "condabin", exe)
-  if (file.exists(conda))
-    return(conda)
-
-  if (is_windows()) {
-    # in Anaconda base env, conda.exe lives under Scripts
-    conda <- file.path(path, "Scripts", exe)
-    if (file.exists(conda))
-      return(conda)
-
-    # in ArcGIS env, conda.exe lives in a parent directory
-    conda <- file.path(path, "../..", "Scripts", exe)
-    conda <- normalizePath(conda, winslash = "/", mustWork = FALSE)
-    if (file.exists(conda))
-      return(conda)
-
-  }
-
-  # read history file
-  histpath <- file.path(path, "conda-meta/history")
-  if (!file.exists(histpath))
-    return(NULL)
-
-  history <- readLines(histpath, warn = FALSE)
-
-  # look for cmd line
-  pattern <- "^[[:space:]]*#[[:space:]]*cmd:[[:space:]]*"
-  lines <- grep(pattern, history, value = TRUE)
-  if (length(lines) == 0)
-    return(NULL)
-
-  # get path to conda script used
-  script <- sub(
-    "^#\\s+cmd: (.+?)\\s+(env\\s+create|create|rename)\\s+.*",
-    "\\1", lines[[1]], perl = TRUE
-  )
-  # on Windows, a wrapper script is recorded in the history,
-  # so instead attempt to find the real conda binary
-  if(is_windows())
-    conda <- file.path(dirname(script), exe)
-  else
-    conda <- script
-  normalizePath(conda, winslash = "/", mustWork = FALSE)
 
 }
 


### PR DESCRIPTION
Resolves https://github.com/rstudio/reticulate/issues/1654

`python_info_condaenv_find` was only being used by `get_python_conda_info` and `python_info_condaenv` so I combined it with `get_python_conda_info` and just repointed `python_info_condaenv` at `get_python_conda_info` so it also gets the fix.