### PR TITLE
Fix error when encountering Windows App Store Python

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # reticulate (development version)
 
+- Fixed error where `py_discover_config()` attempted to detect
+  Windows App Store Python installations, which are now excluded
+  from discovery by both `py_discover_config()` and `virtualenv_starter()`
+  (#1656, #1673).
+
 - Fixed error when converting an empty NumPy char array to R (#1662).
 
 - Fixed error when using reticulate with radian (#1668, #1670).

--- a/R/config.R
+++ b/R/config.R
@@ -368,11 +368,16 @@ py_discover_config <- function(required_module = NULL, use_environment = NULL) {
     # path translation going to and from msys2 currently not implemented.
     # E.g.: "C:\foo\bar" -> "/c/foo/bar" and  "/foo/bar" -> "C:\rtools43\foo\bar"
     # https://github.com/rstudio/reticulate/issues/1325
-    python_sys_platforms <- vapply(
-      python_versions, system2, "",
-      args = c("-c", shQuote("import sys; print(sys.platform)")),
-      stdout = TRUE)
+    get_platform <- function(python) {
+      tryCatch({
+        system2(python,
+                args = c("-c", shQuote("import sys; print(sys.platform)")),
+                stdout = TRUE, stderr = FALSE)
+      }, warning = function(w) "", error = function(e) "")
+    }
+    python_sys_platforms <- vapply(python_versions, get_platform, "")
 
+    python_versions <- python_versions[python_sys_platforms != ""]
     python_versions <- python_versions[python_sys_platforms != "cygwin"]
   }
 

--- a/R/config.R
+++ b/R/config.R
@@ -364,6 +364,11 @@ py_discover_config <- function(required_module = NULL, use_environment = NULL) {
     size <- ifelse(is.na(info$size), 0, info$size)
     python_versions <- python_versions[size != 0]
 
+
+    # We should not automatically discover windows app store python
+    python_versions <-
+      python_versions[!is_windows_app_store_python(python_versions)]
+
     # remove msys2 / cygwin python executables.
     # path translation going to and from msys2 currently not implemented.
     # E.g.: "C:\foo\bar" -> "/c/foo/bar" and  "/foo/bar" -> "C:\rtools43\foo\bar"
@@ -1240,3 +1245,14 @@ py_session_initialized_binary <- function() {
   # return
   python_binary
 }
+
+
+is_windows_app_store_python <- function(python) {
+  # There is probably a better way, but don't currently have
+  # access to a windows machine with the app store installed.
+  python <- normalizePath(python, winslash = "/", mustWork = FALSE)
+  grepl("/Program Files/WindowsApps/PythonSoftwareFoundation.Python",
+        python, fixed = TRUE)
+}
+
+

--- a/R/config.R
+++ b/R/config.R
@@ -1256,3 +1256,8 @@ is_windows_app_store_python <- function(python) {
 }
 
 
+find_all_pythons <- function(root = "/") {
+  cmd <- sprintf("find %s -type f -regex '.*/python[0-9.]*$' -executable 2>/dev/null",
+                 root)
+  as.character(suppressWarnings(system(cmd, intern = TRUE)))
+}

--- a/R/virtualenv.R
+++ b/R/virtualenv.R
@@ -648,6 +648,11 @@ virtualenv_starter <- function(version = NULL, all = FALSE) {
     rownames(starters) <- NULL
   }
 
+  if (is_windows()) {
+    # Windows App Store Python should never be used.
+    starters <- starters[!is_windows_app_store_python(starters$path), ]
+  }
+
   if (all)
     starters
   else if (nrow(starters))


### PR DESCRIPTION
Closes #1656

- Fixed an error where `py_discover_config()` attempted to check if a Windows App Store Python could be used.
- `py_discover_config()` will no longer automatically discover Windows App Store Python installations.
- `virtualenv_starter()` will also no longer discover Windows App Store Python installations.