### PR TITLE
Fix: find `libpython` for venvs created by `uv`

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -831,7 +831,8 @@ python_config <- function(python,
 
       # try to resolve libpython in this location
       pattern <- sprintf("^libpython%sd?m?%s", version, ext)
-      candidates <- list.files(src, pattern = pattern, full.names = TRUE)
+      candidates <- list.files(c(src, file.path(src, "lib")),
+                               pattern = pattern, full.names = TRUE)
       if (length(candidates)) {
         libpython <- candidates
         break


### PR DESCRIPTION
This allows using reticulate with a venv created with `uv`.

Reported in https://github.com/rstudio/reticulate/issues/1669#issuecomment-2395492798

Tested interactively with: 

```python
uv <- function(...) {
  reticulate:::system2t("uv", paste(c(...), collapse = " "))
}

uv_install <- function(..., python = py_exe()) {
  uv("pip install",
     "--python", shQuote(python),
     c(...))
}

uv_venv_create <- function(envname = NULL, python_version = "3.11",
                           packages = "numpy", ..., force = FALSE) {
  path <- path.expand(reticulate:::virtualenv_path(envname))
  if (force)
    unlink(path, recursive = TRUE, force = TRUE)
  dir.create(path, showWarnings = FALSE, recursive = TRUE)

  uv(
    "venv",
    "--no-project",
    "--seed",
    "--no-config",
    "--python-preference only-managed",
    "--python", python_version,
    ...,
    shQuote(path)
  )

  if (length(packages))
    uv_install(packages, python = reticulate:::virtualenv_python(path))

  invisible(path)
}

uv_venv_create(
  force = TRUE,
  packages = c(
    "docutils",
    "pandas",
    "scipy",
    "matplotlib",
    "ipython",
    "tabulate",
    "plotly",
    "psutil",
    "kaleido",
    "wrapt"
  )
)
```

All reticulate tests pass except for one, which precipitated upstream PR https://github.com/astral-sh/uv/pull/7978.