### PR TITLE
Updates for Python 3.13

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -21,26 +21,26 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { os: macOS-latest  , r: 'release', python: '3.10' }
-          - { os: windows-latest, r: 'release', python: '3.10' }
-          - { os: ubuntu-latest , r: 'release', python: '3.10' }
+          - { os: macOS-latest  , r: 'release', python: '3.11' }
+          - { os: windows-latest, r: 'release', python: '3.11' }
+          - { os: ubuntu-latest , r: 'release', python: '3.11' }
 
           # test R oldrel on mac too: https://github.com/RcppCore/RcppArmadillo/issues/447
-          - { os: macOS-latest , r: 'oldrel'  , python: '3.10' }
+          - { os: macOS-latest , r: 'oldrel'  , python: '3.11' }
 
-          - { os: ubuntu-latest, r: 'oldrel-1', python: '3.9' }
-          - { os: ubuntu-latest, r: 'oldrel-2', python: '3.9' }
-          - { os: ubuntu-20.04,  r: 'oldrel-3', python: '3.8' }
-          - { os: ubuntu-20.04,  r: 'oldrel-4', python: '3.8' }
+          - { os: ubuntu-latest, r: 'oldrel-1', python: '3.10' }
+          - { os: ubuntu-latest, r: 'oldrel-2', python: '3.10' }
+          - { os: ubuntu-20.04,  r: 'oldrel-3', python: '3.9' }
+          - { os: ubuntu-20.04,  r: 'oldrel-4', python: '3.9' }
           # https://api.r-hub.io/rversions/resolve/oldrel/4
 
-          - { os: ubuntu-latest, r: 'release', python: '3.7'  }
           - { os: ubuntu-latest, r: 'release', python: '3.8'  }
           - { os: ubuntu-latest, r: 'release', python: '3.9' }
           - { os: ubuntu-latest, r: 'release', python: '3.11' }
           - { os: ubuntu-latest, r: 'release', python: '3.12' }
+          - { os: ubuntu-latest, r: 'release', python: '3.13' }
 
-          - { os: ubuntu-latest, r: 'devel', python: '3.12', http-user-agent: 'release' }
+          - { os: ubuntu-latest, r: 'devel', python: '3.13', http-user-agent: 'release' }
 
           # test with one debug build of python
           # disabled; failing presently

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,15 +2,17 @@
 
 - The S3 classes for some (rarely encountered) Python objects have changed.
   Only Python objects with non-standard `__module__` values are affected.
-  If a Python class's `__module__` does not resolve to a string, reticulate:
-    - Attempts to resolve it from the class's class, if it's a metaclass
+  If a Python object’s parent class’s `__module__` attribute does not resolve to a string,
+  reticulate:
+    - Attempts to resolve it from the class's class, if it's a metaclass.
     - If no string can be resolved, reticulate no longer implicitly prepends
       'python.builtin.' as the class prefix, instead it uses just the `__name__`.
+  (See #1686 for more context)
 
-- Added preliminary support for Python 3.13. Note that the behavior of class descriptors
-  has changed in Python 3.13, which affects how metaclasses are constructed
-  and may change the S3 class of some Python objects that make heavy use of metaclasses to
-  resolve a classes `__module__` or `__name__` attribute. (#1686)
+- Added support for Python 3.13. Note that Python 3.13 removed support
+  for `classmethod` descriptors, which may affect the S3 class of
+  some Python objects that use metaclass properties to resolve a class’s
+  `__module__` or `__name__` attribute. (#1686)
 
 - `py_is_null_xptr()` and `[[` now load delayed modules (#1688).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # reticulate (development version)
 
+- Added preliminary support for Python 3.13 (#1686)
+
 - Fixed error when attempting to use a python venv created with `uv` (#1678)
 
 - Fixed error where `py_discover_config()` attempted to detect

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,16 @@
 # reticulate (development version)
 
-- Added preliminary support for Python 3.13 (#1686)
+- The S3 classes for some (rarely encountered) Python objects have changed.
+  Only Python objects with non-standard `__module__` values are affected.
+  If a Python class's `__module__` does not resolve to a string, reticulate:
+    - Attempts to resolve it from the class's class, if it's a metaclass
+    - If no string can be resolved, reticulate no longer implicitly prepends
+      'python.builtin.' as the class prefix, instead it uses just the `__name__`.
+
+- Added preliminary support for Python 3.13. Note that the behavior of class descriptors
+  has changed in Python 3.13, which affects how metaclasses are constructed
+  and may change the S3 class of some Python objects that make heavy use of metaclasses to
+  resolve a classes `__module__` or `__name__` attribute. (#1686)
 
 - `py_is_null_xptr()` and `[[` now load delayed modules (#1688).
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -102,8 +102,8 @@ py_clear_error <- function() {
     invisible(.Call(`_reticulate_py_clear_error`))
 }
 
-py_initialize <- function(python, libpython, pythonhome, virtualenv_activate, python3, interactive, numpy_load_error) {
-    invisible(.Call(`_reticulate_py_initialize`, python, libpython, pythonhome, virtualenv_activate, python3, interactive, numpy_load_error))
+py_initialize <- function(python, libpython, pythonhome, virtualenv_activate, python_major_version, python_minor_version, interactive, numpy_load_error) {
+    invisible(.Call(`_reticulate_py_initialize`, python, libpython, pythonhome, virtualenv_activate, python_major_version, python_minor_version, interactive, numpy_load_error))
 }
 
 py_finalize <- function() {

--- a/R/config.R
+++ b/R/config.R
@@ -896,7 +896,7 @@ python_config <- function(python,
     executable           = config$Executable, # sys.executable
     base_executable      = config$BaseExecutable, # sys._base_executable; exe for venv starter
     version_string       = version_string,
-    version              = version,
+    version              = as.package_version(version),
     architecture         = architecture,
     anaconda             = anaconda,
     conda                = config$IsConda,

--- a/R/package.R
+++ b/R/package.R
@@ -204,7 +204,8 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
                     config$libpython,
                     config$pythonhome,
                     config$virtualenv_activate,
-                    config$version >= "3.0",
+                    config$version$major,
+                    config$version$minor,
                     interactive(),
                     numpy_load_error)
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -200,18 +200,19 @@ BEGIN_RCPP
 END_RCPP
 }
 // py_initialize
-void py_initialize(const std::string& python, const std::string& libpython, const std::string& pythonhome, const std::string& virtualenv_activate, bool python3, bool interactive, const std::string& numpy_load_error);
-RcppExport SEXP _reticulate_py_initialize(SEXP pythonSEXP, SEXP libpythonSEXP, SEXP pythonhomeSEXP, SEXP virtualenv_activateSEXP, SEXP python3SEXP, SEXP interactiveSEXP, SEXP numpy_load_errorSEXP) {
+void py_initialize(const std::string& python, const std::string& libpython, const std::string& pythonhome, const std::string& virtualenv_activate, int python_major_version, int python_minor_version, bool interactive, const std::string& numpy_load_error);
+RcppExport SEXP _reticulate_py_initialize(SEXP pythonSEXP, SEXP libpythonSEXP, SEXP pythonhomeSEXP, SEXP virtualenv_activateSEXP, SEXP python_major_versionSEXP, SEXP python_minor_versionSEXP, SEXP interactiveSEXP, SEXP numpy_load_errorSEXP) {
 BEGIN_RCPP
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const std::string& >::type python(pythonSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type libpython(libpythonSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type pythonhome(pythonhomeSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type virtualenv_activate(virtualenv_activateSEXP);
-    Rcpp::traits::input_parameter< bool >::type python3(python3SEXP);
+    Rcpp::traits::input_parameter< int >::type python_major_version(python_major_versionSEXP);
+    Rcpp::traits::input_parameter< int >::type python_minor_version(python_minor_versionSEXP);
     Rcpp::traits::input_parameter< bool >::type interactive(interactiveSEXP);
     Rcpp::traits::input_parameter< const std::string& >::type numpy_load_error(numpy_load_errorSEXP);
-    py_initialize(python, libpython, pythonhome, virtualenv_activate, python3, interactive, numpy_load_error);
+    py_initialize(python, libpython, pythonhome, virtualenv_activate, python_major_version, python_minor_version, interactive, numpy_load_error);
     return R_NilValue;
 END_RCPP
 }
@@ -854,7 +855,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_reticulate_py_activate_virtualenv", (DL_FUNC) &_reticulate_py_activate_virtualenv, 1},
     {"_reticulate_main_process_python_info", (DL_FUNC) &_reticulate_main_process_python_info, 0},
     {"_reticulate_py_clear_error", (DL_FUNC) &_reticulate_py_clear_error, 0},
-    {"_reticulate_py_initialize", (DL_FUNC) &_reticulate_py_initialize, 7},
+    {"_reticulate_py_initialize", (DL_FUNC) &_reticulate_py_initialize, 8},
     {"_reticulate_py_finalize", (DL_FUNC) &_reticulate_py_finalize, 0},
     {"_reticulate_py_is_none", (DL_FUNC) &_reticulate_py_is_none, 1},
     {"_reticulate_py_compare_impl", (DL_FUNC) &_reticulate_py_compare_impl, 3},

--- a/src/libpython.cpp
+++ b/src/libpython.cpp
@@ -159,6 +159,7 @@ void initialize_type_objects(bool python3) {
   if (builtins == NULL) goto error;
   PyExc_KeyboardInterrupt = PyObject_GetAttrString(builtins, "KeyboardInterrupt"); // new ref
   PyExc_RuntimeError = PyObject_GetAttrString(builtins, "RuntimeError"); // new ref
+  PyExc_AttributeError = PyObject_GetAttrString(builtins, "AttributeError"); // new ref
 
   if (PyErr_Occurred()) { error:
      // Should never happen. If you see this please report a bug.
@@ -195,7 +196,7 @@ bool LibPython::loadSymbols(int python_major_ver, int python_minor_ver, std::str
   LOAD_PYTHON_SYMBOL(Py_InitializeEx)
   LOAD_PYTHON_SYMBOL(Py_Finalize)
   LOAD_PYTHON_SYMBOL(Py_IsInitialized)
-  LOAD_PYTHON_SYMBOL(Py_GetVersion)
+  LOAD_PYTHON_SYMBOL(Py_GetVersion)          // Deprecated in 3.13
   LOAD_PYTHON_SYMBOL(Py_AddPendingCall)
   LOAD_PYTHON_SYMBOL(Py_MakePendingCalls)
   LOAD_PYTHON_SYMBOL(PyErr_SetInterrupt)
@@ -316,7 +317,7 @@ bool LibPython::loadSymbols(int python_major_ver, int python_minor_ver, std::str
 
   if (python_major_ver >= 3) {
     LOAD_PYTHON_SYMBOL(PyException_SetTraceback)
-    LOAD_PYTHON_SYMBOL(Py_GetProgramFullPath)
+    LOAD_PYTHON_SYMBOL(Py_GetProgramFullPath)   // Deprecated in 3.13
 
     // Debug versions of Python will provide PyModule_Create2TraceRefs,
     // while release versions will provide PyModule_Create
@@ -346,7 +347,7 @@ bool LibPython::loadSymbols(int python_major_ver, int python_minor_ver, std::str
     } else {
       LOAD_PYTHON_SYMBOL(Py_InitModule4)
     }
-    LOAD_PYTHON_SYMBOL_AS(Py_GetProgramFullPath, Py_GetProgramFullPath_v2)
+    LOAD_PYTHON_SYMBOL_AS(Py_GetProgramFullPath, Py_GetProgramFullPath_v2)  // Deprecated in 3.13
     LOAD_PYTHON_SYMBOL(PyString_AsStringAndSize)
     LOAD_PYTHON_SYMBOL(PyString_FromStringAndSize)
     LOAD_PYTHON_SYMBOL(PyString_FromString)

--- a/src/libpython.cpp
+++ b/src/libpython.cpp
@@ -188,6 +188,18 @@ int _PyIter_Check(PyObject* o) {
   return PyObject_HasAttrString(o, "__next__");
 }
 
+int _PyObject_GetOptionalAttrString(PyObject* obj, const char* attr_name, PyObject** result) {
+  *result = PyObject_GetAttrString(obj, attr_name);
+  if (*result == NULL) {
+    if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
+      PyErr_Clear();
+      return 0;
+    }
+    return -1;
+  }
+  return 1;
+}
+
 
 bool LibPython::loadSymbols(int python_major_ver, int python_minor_ver, std::string* pError)
 {
@@ -210,6 +222,13 @@ bool LibPython::loadSymbols(int python_major_ver, int python_minor_ver, std::str
   LOAD_PYTHON_SYMBOL(PyObject_SetAttr)
   LOAD_PYTHON_SYMBOL(PyObject_GetAttrString)
   LOAD_PYTHON_SYMBOL(PyObject_HasAttrString)
+  if (python_major_ver >= 3 && python_minor_ver >= 13) {
+    LOAD_PYTHON_SYMBOL(PyObject_HasAttrStringWithError)
+    LOAD_PYTHON_SYMBOL(PyObject_GetOptionalAttrString)
+  } else {
+    LOAD_PYTHON_SYMBOL_AS(PyObject_HasAttrStringWithError, PyObject_HasAttrString)
+    PyObject_GetOptionalAttrString = &_PyObject_GetOptionalAttrString;
+  }
   LOAD_PYTHON_SYMBOL(PyObject_SetAttrString)
   LOAD_PYTHON_SYMBOL(PyObject_GetItem)
   LOAD_PYTHON_SYMBOL(PyObject_SetItem)

--- a/src/libpython.cpp
+++ b/src/libpython.cpp
@@ -174,12 +174,12 @@ if (!loadSymbol(pLib_, #name, (void**)&as, pError)) \
 if (!loadSymbol(pLib_, #name, (void**) &libpython::name, pError)) \
   return false;
 
-bool SharedLibrary::load(const std::string& libPath, bool python3, std::string* pError)
+bool SharedLibrary::load(const std::string& libPath, int major_ver, int minor_ver, std::string* pError)
 {
   if (!loadLibrary(libPath, &pLib_, pError))
     return false;
 
-  return loadSymbols(python3, pError);
+  return loadSymbols(major_ver, minor_ver, pError);
 }
 
 // Define "slow" fallback implementation for Py version <= 3.9
@@ -188,7 +188,7 @@ int _PyIter_Check(PyObject* o) {
 }
 
 
-bool LibPython::loadSymbols(bool python3, std::string* pError)
+bool LibPython::loadSymbols(int python_major_ver, int python_minor_ver, std::string* pError)
 {
   bool is64bit = sizeof(size_t) >= 8;
 
@@ -314,7 +314,7 @@ bool LibPython::loadSymbols(bool python3, std::string* pError)
   if (!loadSymbol(pLib_, names, (void**)&PyUnicode_AsEncodedString, pError) )
     return false;
 
-  if (python3) {
+  if (python_major_ver >= 3) {
     LOAD_PYTHON_SYMBOL(PyException_SetTraceback)
     LOAD_PYTHON_SYMBOL(Py_GetProgramFullPath)
 

--- a/src/libpython.h
+++ b/src/libpython.h
@@ -260,6 +260,11 @@ LIBPYTHON_EXTERN PyObject* (*PyObject_GetAttrString)(PyObject*, const char *);
 LIBPYTHON_EXTERN int (*PyObject_HasAttrString)(PyObject*, const char *);
 LIBPYTHON_EXTERN int (*PyObject_SetAttrString)(PyObject*, const char *, PyObject*);
 
+// added in Python 3.13
+LIBPYTHON_EXTERN int (*PyObject_HasAttrStringWithError)(PyObject*, const char *);
+LIBPYTHON_EXTERN int (*PyObject_GetOptionalAttrString)(PyObject* obj, const char* attr_name, PyObject** result);
+
+
 LIBPYTHON_EXTERN PyObject* (*PyObject_GetItem)(PyObject*, PyObject*);
 LIBPYTHON_EXTERN int (*PyObject_SetItem)(PyObject*, PyObject*, PyObject*);
 LIBPYTHON_EXTERN int (*PyObject_DelItem)(PyObject*, PyObject*);

--- a/src/libpython.h
+++ b/src/libpython.h
@@ -145,6 +145,7 @@ LIBPYTHON_EXTERN PyObject* Py_Tuple;
 LIBPYTHON_EXTERN PyObject* Py_Complex;
 LIBPYTHON_EXTERN PyObject* Py_ByteArray;
 LIBPYTHON_EXTERN PyObject* PyExc_KeyboardInterrupt;
+LIBPYTHON_EXTERN PyObject* PyExc_AttributeError;
 LIBPYTHON_EXTERN PyObject* PyExc_RuntimeError;
 LIBPYTHON_EXTERN PyObject* PyExc_ValueError;
 

--- a/src/libpython.h
+++ b/src/libpython.h
@@ -636,12 +636,12 @@ bool import_numpy_api(bool python3, std::string* pError);
 class SharedLibrary {
 
 public:
-  bool load(const std::string& libPath, bool python3, std::string* pError);
+  bool load(const std::string& libPath, int major_ver, int minor_ver, std::string* pError);
   bool unload(std::string* pError);
   virtual ~SharedLibrary() {}
 
 private:
-  virtual bool loadSymbols(bool python3, std::string* pError) = 0;
+  virtual bool loadSymbols(int major_ver, int minor_ver, std::string* pError) = 0;
 
 protected:
   SharedLibrary() : pLib_(NULL) {}
@@ -656,7 +656,7 @@ class LibPython : public SharedLibrary {
 private:
   LibPython() : SharedLibrary() {}
   friend SharedLibrary& libPython();
-  virtual bool loadSymbols(bool python3, std::string* pError);
+  virtual bool loadSymbols(int major_ver, int minor_ver, std::string* pError);
 };
 
 inline SharedLibrary& libPython() {

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -2851,7 +2851,7 @@ SEXP main_process_python_info_unix() {
   // read Python program path
   std::string python_path;
   if (Py_GetVersion()[0] >= '3') {
-    loadSymbol(pLib, "Py_GetProgramFullPath", (void**) &Py_GetProgramFullPath);
+    loadSymbol(pLib, "Py_GetProgramFullPath", (void**) &Py_GetProgramFullPath); // deprecated in 3.13
     const std::wstring wide_python_path(Py_GetProgramFullPath());
     python_path = to_string(wide_python_path);
   } else {

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -628,7 +628,6 @@ std::string get_module_name(PyObject* classPtr) {
     // try to to fetch type(class).__module__. But make sure we're not recursing more than once
     static bool recursing = false;
     if (!recursing && !PyType_CheckExact(classPtr)) {
-      // get_module_name is marked as noexcept, so recursing = false is guaranteed to be executed
       auto _recursion_guard = ScopedAssign(&recursing, true);
       return get_module_name((PyObject*) Py_TYPE(classPtr));
     }

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -594,7 +594,23 @@ std::string get_module_name(PyObject* classPtr) {
         std::string module(moduleStr);
         return module;
       }
-  }
+    }
+
+    if (PyBytes_Check(moduleObj)) {
+      // I'm pretty sure this only happened in Python 2, but we keep the check in case not.
+      Py_ssize_t size;
+      char* moduleStr;
+      if (PyBytes_AsStringAndSize(moduleObj, &moduleStr, &size) == 0) {
+        if (strcmp(moduleStr, "__builtin__") == 0) {
+          return PYTHON_BUILTIN;
+        }
+        std::string module(moduleStr, size);
+        return module;
+      }
+      if (PyErr_Occurred()) PyErr_Print();
+      REprintf("as_r_class: failed to convert __module__ bytes object to string\n");
+      return NULL;
+    }
 
     // if (PyErr_Occurred()) PyErr_Print();
     // REprintf("__module__ not a string\n");

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -2904,12 +2904,13 @@ void py_initialize(const std::string& python,
                    const std::string& libpython,
                    const std::string& pythonhome,
                    const std::string& virtualenv_activate,
-                   bool python3,
+                   int python_major_version,
+                   int python_minor_version,
                    bool interactive,
                    const std::string& numpy_load_error) {
 
   // set python3 and interactive flags
-  s_isPython3 = python3;
+  s_isPython3 = python_major_version == 3;
   s_isInteractive = interactive;
 
   if(!s_isPython3)
@@ -2917,7 +2918,7 @@ void py_initialize(const std::string& python,
 
   // load the library
   std::string err;
-  if (!libPython().load(libpython, is_python3(), &err))
+  if (!libPython().load(libpython, python_major_version, python_minor_version, &err))
     stop(err);
 
   if (is_python3()) {

--- a/tests/testthat/test-python-class.R
+++ b/tests/testthat/test-python-class.R
@@ -102,7 +102,7 @@ test_that("Can define and instantiate empty classes", {
   x <- Hi()
   x$name <- "Hi"
 
-  expect_s3_class(x, "python.builtin.Hi")
+  expect_s3_class(x, "Hi")
   expect_equal(x$name, "Hi")
 })
 
@@ -205,14 +205,14 @@ test_that("self is not converted when there's a py_to_r method for it", {
     }
   ))
 
-  assign("py_to_r.python.builtin.Base", value = function(x) {
+  assign("py_to_r.Base", value = function(x) {
     "base"
   }, envir = .GlobalEnv)
 
   x <- Hi(2)
   expect_equal(x, "base")
 
-  rm(py_to_r.python.builtin.Base, envir = .GlobalEnv)
+  rm(py_to_r.Base, envir = .GlobalEnv)
 })
 
 test_that("can call super from an inherited class", {

--- a/tests/testthat/test-python-class.R
+++ b/tests/testthat/test-python-class.R
@@ -2,7 +2,7 @@ context("PyClass")
 
 test_that("Can create a Python class and call methods", {
   skip_if_no_python()
-  
+
   Hi <- PyClass("Hi", list(
     name = NULL,
     `__init__` = function(self, name) {
@@ -13,18 +13,18 @@ test_that("Can create a Python class and call methods", {
       paste0("Hi ", self$name)
     }
   ))
-  
+
   a <- Hi("World")
   b <- Hi("R")
-  
+
   expect_equal(a$say_hi(), "Hi World")
   expect_equal(b$say_hi(), "Hi R")
-  
+
 })
 
 test_that("Can inherit from another class created in R", {
   skip_if_no_python()
-  
+
   Hi <- PyClass("Hi", list(
     name = NULL,
     `__init__` = function(self, name) {
@@ -35,26 +35,26 @@ test_that("Can inherit from another class created in R", {
       paste0("Hi ", self$name)
     }
   ))
-  
+
   Hello <- PyClass("Hello", inherit = Hi, list(
     say_hello = function(self) {
       paste0("Hello and ", super()$say_hi())
     }
   ))
-  
+
   a <- Hello("World")
   expect_equal(a$say_hello(), "Hello and Hi World")
 })
 
 test_that("Can inherit from a Python class", {
   skip_if_no_python()
-  
+
   py <- reticulate::py_run_string("
 class Person(object):
   def __init__ (self, name):
     self.name = name
 ")
-  
+
   Person2 <- PyClass("Person2", inherit = py$Person, list(
     `__init__` = function(self, name) {
       super()$`__init__`(name)
@@ -62,7 +62,7 @@ class Person(object):
       NULL
     }
   ))
-  
+
 
   a <- Person2("World")
   expect_equal(a$name, "World")
@@ -71,52 +71,52 @@ class Person(object):
 
 test_that("Can inherit from multiple Python classes", {
   skip_if_no_python()
-  
+
   py <- reticulate::py_run_string("
 class Clock(object):
   def __init__ (self, time):
     self.time = time
-    
+
 class Calendar(object):
   def __init__ (self, date):
     self.date = date
 ")
-  
+
   ClockCalendar <- PyClass("ClockCalendar", inherit = list(py$Clock, py$Calendar), list(
     `__init__` = function(self, time, date) {
       py$Clock$`__init__`(self, time)
       py$Calendar$`__init__`(self, date)
     }
   ))
-  
+
   a <- ClockCalendar("15:54", "2019-11-05")
-  
+
   expect_equal(a$date, "2019-11-05")
   expect_equal(a$time, "15:54")
 })
 
 test_that("Can define and instantiate empty classes", {
   skip_if_no_python()
-  
+
   Hi <- PyClass("Hi")
   x <- Hi()
   x$name <- "Hi"
-  
+
   expect_s3_class(x, "python.builtin.Hi")
   expect_equal(x$name, "Hi")
 })
 
 test_that("Methods can access enclosed env", {
   skip_if_no_python()
-  
+
   Hi <- PyClass("Hi", list(
     say_a = function(self) {
       a
     }
   ))
-  
+
   x <- Hi()
-  
+
   a <- 1
   expect_equal(x$say_a(), 1)
   a <- 2
@@ -124,15 +124,15 @@ test_that("Methods can access enclosed env", {
 })
 
 test_that("Can directly access variables from a class", {
-  
+
   skip_if_no_python()
-  
+
   bt <- import_builtins()
-  
+
   Hi <- PyClass("Hi", list(
     `__init__` = function(self, a) {
       self$a <- a
-      self$x <- bt$isinstance # Have a python that can't be 
+      self$x <- bt$isinstance # Have a python that can't be
                               # converted to an R type
       NULL
     },
@@ -146,7 +146,7 @@ test_that("Can directly access variables from a class", {
       self$a + n
     }
   ))
-  
+
   x <- Hi(a = 2)
   expect_equal(x$add_2(), 4)
   expect_equal(x$a, 2)
@@ -156,14 +156,14 @@ test_that("Can directly access variables from a class", {
 
 test_that("Properties are automatically converted in inherited classes", {
   skip_if_no_python()
-  
+
   bt <- import_builtins(convert = FALSE)
   p <- py_run_string("
 class Base(object):
   def __init__ (self, x):
     self.x = 1
 ", convert = FALSE)
-  
+
   Hi <- PyClass("Hi", inherit = p$Base, list(
     `__init__` = function(self, a, ...) {
       self$a <- a
@@ -181,7 +181,7 @@ class Base(object):
       self$a + n
     }
   ))
-  
+
   x <- Hi(a = 2, x = 1)
   expect_equal(x$add_2(), 4)
   expect_equal(x$a, 2)
@@ -191,10 +191,10 @@ class Base(object):
 
 test_that("self is not converted when there's a py_to_r method for it", {
   skip_if_no_python()
-  
+
   bt <- import_builtins(convert = FALSE)
   Base <- PyClass("Base")
-  
+
   Hi <- PyClass("Hi", inherit = Base, list(
     `__init__` = function(self, a) {
       self$a <- a
@@ -204,28 +204,28 @@ test_that("self is not converted when there's a py_to_r method for it", {
       self$a + 2
     }
   ))
-  
+
   assign("py_to_r.python.builtin.Base", value = function(x) {
     "base"
   }, envir = .GlobalEnv)
-  
+
   x <- Hi(2)
   expect_equal(x, "base")
-  
+
   rm(py_to_r.python.builtin.Base, envir = .GlobalEnv)
 })
 
 test_that("can call super from an inherited class", {
-  
+
   Base1 <- PyClass("Base1", list(`__init__` = function(self, a) {
     self$a <- a
   }))
-  
+
   Base2 <- PyClass("Base2", list(`__init__` = function(self, a, b) {
     self$b <- b
     super()$`__init__`(a)
   }), inherit = Base1)
-  
+
   Inhe <- PyClass("Inhe", inherit = Base2, list(
     `__init__` = function(self, a, b, c) {
       self$c <- c
@@ -233,14 +233,11 @@ test_that("can call super from an inherited class", {
       NULL
     }
   ))
-  
+
   x <- Inhe(10, 20, 30)
-  
-  
+
+
   expect_equal(x$a, 10)
   expect_equal(x$b, 20)
   expect_equal(x$c, 30)
 })
-
-
-

--- a/tests/testthat/test-python-objects.R
+++ b/tests/testthat/test-python-objects.R
@@ -87,6 +87,7 @@ class List(Sequence, list):
 test_that("wrapt.ProxyObject dicts can be converted", {
   skip_if_no_python()
   skip_if(!py_module_available("wrapt"))
+  skip_if(py_version() >= "3.13")
 
   # something similar to tensorflow _DictWrapper() class
   # https://github.com/tensorflow/tensorflow/blob/r2.12/tensorflow/python/trackable/data_structures.py#L784

--- a/tests/testthat/test-python-objects.R
+++ b/tests/testthat/test-python-objects.R
@@ -122,8 +122,13 @@ assert isinstance(Dict({}), dict)
   #     '__reduce__'?
   # - Note: dict.__module__ still returns 'builtins', the above Exceptoin is a
   #   metaclass/ObjectProxy issue
-  # - We do the best we can and build an R class vector as:
-  #     classes <- c("Dict", "ObjectProxy", "NewBase", "python.builtin.object")
+  # - So for metaclasses like this we do the best we can and try to resolve
+  #   __module__ from the type(type(cls)) and build an R class vector as:
+  #      classes <- c("wrapt.wrappers.Dict", "wrapt.wrappers.ObjectProxy", "wrapt.wrappers.NewBase",
+  #                   "python.builtin.object")
+  #   (we could instead fail earlier and instead build:
+  #      classes <- c("Dict", "ObjectProxy", "NewBase", "python.builtin.object")
+  #    it's not clear which is a better approach)
 
   expect_true(grepl("Dict$", classes[1]))
   expect_true(grepl("ObjectProxy$", classes[2]))


### PR DESCRIPTION
For Reticulate internals, [Python 3.13](https://docs.python.org/3/whatsnew/3.13.html) introduces two significant changes:

1. `PyObject_HasAttrString()` now emits a non-suppressible warning to stderr when it returns a false value:

```
Exception ignored in PyObject_HasAttrString();
consider using PyObject_HasAttrStringWithError(),
PyObject_GetOptionalAttrString(), or PyObject_GetAttrString()
```

To prevent this output from repeatedly appearing in users consoles, Reticulate internals have been refactored to use the new C entry points introduced in Python 3.13: `PyObject_HasAttrStringWithError` and `PyObject_GetOptionalAttrString`, with backports for older Python versions.

2. Quoting from [Python 3.13 release notes](https://docs.python.org/3/whatsnew/3.13.html)
> Support for chained `classmethod` descriptors has been removed. These descriptors can no longer wrap other descriptors, such as `property`, due to design flaws that led to several issues.

This change impacts how the S3 class attribute vector is determined when presenting a Python object at the R level. Specifically, Python classes using metaclasses where `__module__` or `__name__` is a `property` can no longer resolve correctly. This issue is encountered in objects subclassing `wrapt.ProxyObject`, and likely other classes using a similar pattern. As a result, internal updates to `get_r_class()` in Reticulate were required, and the S3 class of such objects has now changed.