### PR TITLE
Fix Positron stdout redirection after Ipykernel closes

### DIFF
--- a/R/thread.R
+++ b/R/thread.R
@@ -63,6 +63,11 @@ py_run_file_on_thread <- function(file, ..., args = NULL) {
   if (launching_lsp) {
     main_dict <- py_eval("__import__('__main__').__dict__.copy()", FALSE)
     py_get_attr(main_dict, "pop")("__annotations__")
+    # IPykernel will create a thread that redirects all output from fileno of
+    # the current sys.stdout and sys.stderr to its IO channels.
+    # This is not correctly cleaned up when IPykernel closes.
+    # To fix that, we set the IO streams to /dev/null before launching the kernel.
+    import("rpytools.run")$set_blank_io_streams()
   }
 
   import("rpytools.run")$run_file_on_thread(file, args, ...)

--- a/inst/python/rpytools/run.py
+++ b/inst/python/rpytools/run.py
@@ -50,6 +50,13 @@ def _launch_lsp_server_on_thread(path, args):
     return run_file_on_thread(path, args)
 
 
+def set_blank_io_streams():
+    import sys
+    import os
+    sys.stdout = open(os.devnull, "w")
+    sys.stderr = open(os.devnull, "w")
+
+
 def run_file_on_thread(path, argv=None, init_globals=None, run_name="__main__"):
     # for now, leave sys.argv and sys.path permanently modified.
     # Later, revisit if it's desirable/safe to restore after the initial


### PR DESCRIPTION
IPykernel will create a thread that redirects all output from fileno of the current sys.stdout and sys.stderr to its IO channels. This is not correctly cleaned up when IPykernel closes. See https://github.com/ipython/ipykernel/blob/2ca799276f4458d50085bb1ef8e2ddeb08a283a6/ipykernel/iostream.py#L439-L444
To fix that, we set the IO streams to /dev/null before launching the kernel.

Adresses https://github.com/posit-dev/positron/issues/5057
