### PR TITLE
Add Positron Variables Pane Methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,9 @@
 - Improved behavior when the conda binary used to create an environment
   could not be resolved (contributed by @tl-hbk, #1654, #1659)
 
+- Added Positron support for the Variables Pane and `repl_python()`
+  (#1692, #1641, #1648, #1658, #1681, #1687).
+
 # reticulate 1.39.0
 
 - Python background threads can now run in parallel with the R session (#1641).

--- a/R/ark-variables-methods.R
+++ b/R/ark-variables-methods.R
@@ -17,7 +17,7 @@ ark_positron_variable_display_type.python.builtin.object <- function(x, ..., inc
   i <- .globals$get_positron_variable_inspector(x)
   out <-  i$get_display_type()
 
-  if(startsWith(class(x)[1], "python.builtin."))
+  if (startsWith(class(x)[1], "python.builtin.")) # display convert value?
     out <- paste("python", out)
 
   out
@@ -44,17 +44,15 @@ ark_positron_variable_get_children.python.builtin.object <- function(x, ...) {
 
   get_keys_and_children <- .globals$ark_variable_get_keys_and_children
   if (is.null(get_keys_and_children)) {
-    get_keys_and_children <- .globals$ark_variable_get_keys_and_children <- py_eval(
-      "lambda i: zip(*((str(key), i.get_child(key)) for key in i.get_children()))",
-      convert = FALSE
-    )
+    get_keys_and_children <- .globals$ark_variable_get_keys_and_children <-
+      import("rpytools.ark_variables", convert = FALSE)$get_keys_and_children
   }
 
   keys_and_children <- iterate(get_keys_and_children(i), simplify = FALSE)
-  out <- iterate(keys_and_children[[2L]], simplify = FALSE)
-  names(out) <- as.character(py_to_r(keys_and_children[[1L]]))
+  children <- iterate(keys_and_children[[2L]], simplify = FALSE)
+  names(children) <- as.character(py_to_r(keys_and_children[[1L]]))
 
-  out
+  children
 }
 
 #' @param index An integer > 1, representing the index position of the child in the
@@ -70,16 +68,25 @@ ark_positron_variable_get_child_at.python.builtin.object <- function(x, ..., nam
   i <- .globals$get_positron_variable_inspector(x)
   get_child <- .globals$ark_variable_get_child
   if (is.null(get_child)) {
-    get_child <- .globals$ark_variable_get_child <- py_run_string(
-      local = TRUE, convert = FALSE, "
-def new_get_child():
-  from itertools import islice
-  def get_child(inspector, index):
-    key = next(islice(inspector.get_children(), index-1, None))
-    return inspector.get_child(key)
-  return get_child
-")$new_get_child()
+    get_child <- .globals$ark_variable_get_child <-
+      import("rpytools.ark_variables", convert = FALSE)$get_child
+    }
+
+    get_child(i, index)
   }
 
-  get_child(i, index)
+
+ark_positron_variable_display_type.rpytools.ark_variables.ChildrenOverflow <- function(x, ..., include_length = TRUE) {
+  ""
+}
+ark_positron_variable_kind.rpytools.ark_variables.ChildrenOverflow <- function(x, ...) {
+  "empty" # other? collection? map? lazy?
+}
+
+ark_positron_variable_display_value.rpytools.ark_variables.ChildrenOverflow <- function(x, ..., width = getOption("width")) {
+  paste(py_to_r(x$n_remaining), "more values")
+}
+
+ark_positron_variable_has_children.rpytools.ark_variables.ChildrenOverflow <- function(x, ...) {
+  FALSE
 }

--- a/R/ark-variables-methods.R
+++ b/R/ark-variables-methods.R
@@ -1,0 +1,85 @@
+
+# Methods for Populating the Positron/Ark Variables Pane
+# These methods primarily delegate to the implementation in the
+# Positron python_ipykernel.inspectors python module.
+
+#' @param x Object to get the display value for
+#' @param width Maximum expected width. This is just a suggestion, the UI
+#'   can stil truncate the string to different widths.
+ark_positron_variable_display_value.python.builtin.object <- function(x, ..., width = getOption("width")) {
+  .globals$get_positron_variable_inspector(x)$get_display_value(width)[[1L]]
+}
+
+
+#' @param x Object to get the display type for
+#' @param include_length Boolean indicating whether to include object length.
+ark_positron_variable_display_type.python.builtin.object <- function(x, ..., include_length = TRUE) {
+  i <- .globals$get_positron_variable_inspector(x)
+  out <-  i$get_display_type()
+
+  if(startsWith(class(x)[1], "python.builtin."))
+    out <- paste("python", out)
+
+  out
+}
+
+
+#' @param x Object to get the variable kind for
+ark_positron_variable_kind.python.builtin.object <- function(x, ...) {
+  i <- .globals$get_positron_variable_inspector(x)
+  i$get_kind()
+}
+
+
+#' @param x Check if `x` has children
+ark_positron_variable_has_children.python.builtin.object <- function(x, ...) {
+  i <- .globals$get_positron_variable_inspector(x)
+  i$has_children()
+}
+
+ark_positron_variable_get_children.python.builtin.object <- function(x, ...) {
+  # Return an R list of children. The order of children should be
+  # stable between repeated calls on the same object. For example:
+  i <- .globals$get_positron_variable_inspector(x)
+
+  get_keys_and_children <- .globals$ark_variable_get_keys_and_children
+  if (is.null(get_keys_and_children)) {
+    get_keys_and_children <- .globals$ark_variable_get_keys_and_children <- py_eval(
+      "lambda i: zip(*((str(key), i.get_child(key)) for key in i.get_children()))",
+      convert = FALSE
+    )
+  }
+
+  keys_and_children <- iterate(get_keys_and_children(i), simplify = FALSE)
+  out <- iterate(keys_and_children[[2L]], simplify = FALSE)
+  names(out) <- as.character(py_to_r(keys_and_children[[1L]]))
+
+  out
+}
+
+#' @param index An integer > 1, representing the index position of the child in the
+#'   list returned by `ark_variable_get_children()`.
+#' @param name The name of the child, corresponding to `names(ark_variable_get_children(x))[index]`.
+#'   This may be a string or `NULL`. If using the name, it is the method author's responsibility to ensure
+#'   the name is a valid, unique accessor. Additionally, if the original name from `ark_variable_get_children()`
+#'   was too long, `ark` may discard the name and supply `name = NULL` instead.
+ark_positron_variable_get_child_at.python.builtin.object <- function(x, ..., name, index) {
+  # cat("name: ", name, "index: ", index, "\n", file = "~/debug.log", append = TRUE)
+  # This could be implemented as:
+  #   ark_variable_get_children(x)[[index]]
+  i <- .globals$get_positron_variable_inspector(x)
+  get_child <- .globals$ark_variable_get_child
+  if (is.null(get_child)) {
+    get_child <- .globals$ark_variable_get_child <- py_run_string(
+      local = TRUE, convert = FALSE, "
+def new_get_child():
+  from itertools import islice
+  def get_child(inspector, index):
+    key = next(islice(inspector.get_children(), index-1, None))
+    return inspector.get_child(key)
+  return get_child
+")$new_get_child()
+  }
+
+  get_child(i, index)
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -65,8 +65,12 @@
 
     setHook("reticulate.onPyInit", function() {
 
+      disable <- nzchar(Sys.getenv("_RETICULATE_POSITRON_DISABLE_VARIABLE_INSPECTORS_"))
+      if (disable)
+        return()
+
       # options("ark.testing" = TRUE)
-      inspectors <- import_positron_ipykernel_inspectors()
+      inspectors <- tryCatch(import_positron_ipykernel_inspectors(), error = function(e) NULL)
       if(is.null(inspectors)) {
         # warning("positron_ipykernel.inspectors could not be found, variables pane support for Python objects will be limited")
         return()

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -84,10 +84,13 @@
         "ark_positron_variable_get_child_at",
         "ark_positron_variable_get_children"
       )) {
-        method_sym <- as.name(paste0(method_name, ".python.builtin.object"))
-        .ark.register_method(
-          method_name, "python.builtin.object",
-          call(":::", quote(reticulate), method_sym))
+        for (class_name in c("python.builtin.object",
+                             "rpytools.ark_variables.ChildrenOverflow")) {
+          method <- get0(paste0(method_name, ".", class_name))
+          if (!is.null(method)) {
+            .ark.register_method(method_name, class_name, method)
+          }
+        }
       }
     })
   }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -110,17 +110,20 @@ import_positron_ipykernel_inspectors <- function() {
   if(!is_positron())
     return (NULL)
 
-  .ps.positron_ipykernel_path <- get0(".ps.positron_ipykernel_path", globalenv())
-  if (!is.null(.ps.positron_ipykernel_path)) {
-    path <- .ps.positron_ipykernel_path()
-    if (grepl("positron_ipykernel[/\\]?$", path))
-      path <- dirname(path)
-    inspectors <- import_from_path("positron_ipykernel.inspectors", path = path)
+  tryCatch({
+    # https://github.com/posit-dev/positron/pull/5368
+    .ps.ui.executeCommand <- get(".ps.ui.executeCommand", globalenv())
+    ipykernel_path <- .ps.ui.executeCommand("positron.reticulate.getIPykernelPath")
+    inspectors <- import_from_path("positron_ipykernel.inspectors",
+                                   path = dirname(ipykernel_path))
     return(inspectors)
-  }
+  },
+  error = function(e) NULL)
+
 
   # hacky "usually work" fallbacks for finding the positron-python extension,
   # until ark+positron are updated and can reliably provide the canonical path
+  # (i.e., until https://github.com/posit-dev/positron/pull/5368 is in the release build)
 
   # Try inspecting `_` env var. Only works in some contexts.
   x <- Sys.getenv("_")

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -106,6 +106,17 @@ import_positron_ipykernel_inspectors <- function() {
   if(!is_positron())
     return (NULL)
 
+  .ps.positron_ipykernel_path <- get0(".ps.positron_ipykernel_path", globalenv())
+  if (!is.null(.ps.positron_ipykernel_path)) {
+    path <- .ps.positron_ipykernel_path()
+    if (grepl("positron_ipykernel[/\\]?$", path))
+      path <- dirname(path)
+    inspectors <- import_from_path("positron_ipykernel.inspectors", path = path)
+    return(inspectors)
+  }
+
+  # hacky fallback by inspecting `_` env var, until ark is updated.
+  # Only works in some contexts.
   x <- Sys.getenv("_")
   # x ==
   # on mac: "/Applications/Positron.app/Contents/Resources/app/extensions/positron-r/resources/ark/ark"

--- a/inst/python/rpytools/ark_variables.py
+++ b/inst/python/rpytools/ark_variables.py
@@ -1,0 +1,33 @@
+from itertools import islice
+
+MAX_DISPLAY = 100
+
+def get_keys_and_children(inspector):
+    keys, values = [], []
+    keys_iterator = iter(inspector.get_children())
+    # positron frontend only displays the first 100 items, then the length of the rest.
+    try:
+        for _ in range(MAX_DISPLAY):
+            key = next(keys_iterator)
+            keys.append(str(key))
+            values.append(inspector.get_child(key))
+    except StopIteration:
+        return keys, values
+
+    n_remaining = 0
+    for n_remaining, _ in enumerate(keys_iterator, 1):
+        pass
+    if n_remaining > 0:
+        keys.append("[[...]]")
+        values.append(ChildrenOverflow(n_remaining))
+
+    return keys, values
+
+
+def get_child(inspector, index):
+    key = next(islice(inspector.get_children(), index - 1, None))
+    return inspector.get_child(key)
+
+class ChildrenOverflow:
+    def __init__(self, n_remaining):
+        self.n_remaining = n_remaining


### PR DESCRIPTION
This PR adds support for reticulate objects in the Positron Variables Pane. 

With an example session:

```r
# needed because positron leaks an internal VIRTUAL_ENV env var into the R process
Sys.unsetenv("VIRTUAL_ENV")

library(reticulate)
library(keras3)

anint <- py_eval("1", FALSE)
adict <- py_eval("{'a':1, 'b':2}", FALSE)
adict['foo'] <- adict # recursive

alist <- py_eval("['a', 1]", FALSE)
atuple <- py_eval("('a', 1)", FALSE)

input <- keras_input(c(24, 24))

output <- input |>
  layer_dense(32, "relu") |>
  layer_dense(10, "softmax")

model <- keras_model(input, output)
```
We now see:


https://github.com/user-attachments/assets/30e1d667-63ed-4435-a568-dc4bfff1b04e



Previously, all python objects presented as:
<img width="820" alt="image" src="https://github.com/user-attachments/assets/f2ac1508-ee72-42a9-8814-8a94b6a7319d">


This uses the ark interface added in https://github.com/posit-dev/ark/pull/560 and https://github.com/posit-dev/ark/pull/561