### PR TITLE
More updates for Python 3.13

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@
 - Added support for Python 3.13. Note that Python 3.13 removed support
   for `classmethod` descriptors, which may affect the S3 class of
   some Python objects that use metaclass properties to resolve a class’s
-  `__module__` or `__name__` attribute. (#1686)
+  `__module__` or `__name__` attribute. (#1686, #1698)
 
 - `py_is_null_xptr()` and `[[` now load delayed modules (#1688).
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -295,8 +295,8 @@ py_eval_impl <- function(code, convert = TRUE) {
     .Call(`_reticulate_py_eval_impl`, code, convert)
 }
 
-py_convert_pandas_series <- function(series) {
-    .Call(`_reticulate_py_convert_pandas_series`, series)
+py_convert_pandas_series <- function(series_) {
+    .Call(`_reticulate_py_convert_pandas_series`, series_)
 }
 
 py_convert_pandas_df <- function(df) {

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -650,13 +650,13 @@ BEGIN_RCPP
 END_RCPP
 }
 // py_convert_pandas_series
-SEXP py_convert_pandas_series(PyObjectRef series);
-RcppExport SEXP _reticulate_py_convert_pandas_series(SEXP seriesSEXP) {
+SEXP py_convert_pandas_series(PyObjectRef series_);
+RcppExport SEXP _reticulate_py_convert_pandas_series(SEXP series_SEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
-    Rcpp::traits::input_parameter< PyObjectRef >::type series(seriesSEXP);
-    rcpp_result_gen = Rcpp::wrap(py_convert_pandas_series(series));
+    Rcpp::traits::input_parameter< PyObjectRef >::type series_(series_SEXP);
+    rcpp_result_gen = Rcpp::wrap(py_convert_pandas_series(series_));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/libpython.cpp
+++ b/src/libpython.cpp
@@ -61,7 +61,7 @@ bool loadLibrary(const std::string& libPath, void** ppLib, std::string* pError)
   *ppLib = (void*)::LoadLibraryEx(libPath.c_str(), NULL, 0);
 #else
   if (libPath == "NA") {
-    *ppLib = ::dlopen(NULL, RTLD_NOW|RTLD_GLOBAL);
+    *ppLib = ::dlopen(NULL, RTLD_NOW|RTLD_GLOBAL); // on linux, should we also do: | RTLD_DEEPBIND ??
   } else {
     *ppLib = ::dlopen(libPath.c_str(), RTLD_NOW|RTLD_GLOBAL);
   }


### PR DESCRIPTION
This PR removes all remaining usages of `PyObject_HasAttrString()` from the codebase, to prevent warnings like this from being presented to users:

```
>>> from itertools import islice
Exception ignored in PyObject_HasAttrString(); consider using PyObject_HasAttrStringWithError(), PyObject_GetOptionalAttrString() or PyObject_GetAttrString():
Traceback (most recent call last):
  File "/Users/tomasz/github/rstudio/reticulate/inst/python/rpytools/call.py", line 6, in python_function
    return call_r_function(f, *args, **kwargs)
RuntimeError: <text>:1:2: unexpected input
1: __
     ^
```