### PR TITLE
Redefine R_NO_REMAP only if not defined

### DIFF
--- a/src/pending_py_calls_notifier.cpp
+++ b/src/pending_py_calls_notifier.cpp
@@ -10,7 +10,9 @@
 // nicely like <windows.h>, <unistd.h>, etc.
 #include "tinythread.h"
 
+#ifndef R_NO_REMAP
 #define R_NO_REMAP
+#endif
 #include <R.h>  // R-devel (4.5) errors if you include Rinternals.h but not R.h in c++ modules.
 #include <Rinternals.h>
 


### PR DESCRIPTION
Noticed this as I was updating my local R-devel stack:

```sh
ccache g++-14 -I"/usr/local/lib/R-devel/lib/R/include" -DNDEBUG  -I'/usr/local/lib/R-devel/lib/R/library/Rcpp/include' -I/usr/local/include    -fpic  -O3 -Wall -pipe -pedantic -Wno-parentheses -Wno-nonnull -Wno-ignored-attributes  -flto  -DR_NO_REMAP -c signals.cpp -o signals.o
pending_py_calls_notifier.cpp:13:9: warning: "R_NO_REMAP" redefined
   13 | #define R_NO_REMAP
      |         ^~~~~~~~~~
<command-line>: note: this is the location of the previous definition
```

The two added lines should take care of it.  While only needed for R-devel now, this is (per R NEWS recently) becoming the C++ default.