### PR TITLE
Prefix Python venv starter lib to `LD_LIBRARY_PATH`

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -164,6 +164,9 @@ initialize_python <- function(required_module = NULL, use_environment = NULL) {
 
   # munge PATH for python (needed so libraries can be found in some cases)
   oldpath <- python_munge_path(config$python)
+  # also munge LD_LIBRARY_PATH on Linux
+  # (needed for Python 3.12 preinstalled on GHA runners, perhaps other installations too)
+  prefix_python_lib_to_ld_library_path(config$python)
 
   # on macOS, we need to do some gymnastics to ensure that Anaconda
   # libraries can be properly discovered (and this will only work in RStudio)

--- a/R/pip.R
+++ b/R/pip.R
@@ -5,6 +5,8 @@ pip_version <- function(python) {
   if (!file.exists(python))
     return(numeric_version("0.0"))
 
+  local_prefix_python_lib_to_ld_library_path(python)
+
   # otherwise, ask pip what version it is
   command <- "import sys; import pip; sys.stdout.write(pip.__version__)"
   version <- system2(python, c("-c", shQuote(command)), stdout = TRUE, stderr = TRUE)
@@ -54,9 +56,10 @@ pip_install <- function(python,
       conda <- NULL
   }
 
-  result <- if (is.null(conda) || identical(conda, FALSE))
+  result <- if (is.null(conda) || identical(conda, FALSE)) {
+    local_prefix_python_lib_to_ld_library_path(python)
     system2t(python, args)
-  else
+  } else
     conda_run2(python, args, conda = conda, envname = envname)
 
 
@@ -71,6 +74,7 @@ pip_install <- function(python,
 
 pip_uninstall <- function(python, packages) {
 
+  local_prefix_python_lib_to_ld_library_path(python)
   # run it
   args <- c("-m", "pip", "uninstall", "--yes", packages)
   result <- system2t(python, args)
@@ -85,6 +89,8 @@ pip_uninstall <- function(python, packages) {
 }
 
 pip_freeze <- function(python) {
+
+  local_prefix_python_lib_to_ld_library_path(python)
 
   # run pip freeze to list dependencies
   args <- c("-m", "pip", "freeze")

--- a/R/utils.R
+++ b/R/utils.R
@@ -231,12 +231,10 @@ yoink <- function(package, symbol) {
   do.call(":::", list(package, symbol))
 }
 
-defer <- function(expr, envir = parent.frame()) {
-  call <- substitute(
-    evalq(expr, envir = envir),
-    list(expr = substitute(expr), envir = parent.frame())
-  )
-  do.call(base::on.exit, list(substitute(call), add = TRUE), envir = envir)
+defer <- function(expr, envir = parent.frame(), priority = c("first", "last")) {
+  thunk <- as.call(list(function() expr))
+  after <- priority == "last"
+  do.call(base::on.exit, list(thunk, TRUE, after), envir = envir)
 }
 
 #' @importFrom utils head

--- a/R/virtualenv.R
+++ b/R/virtualenv.R
@@ -131,6 +131,7 @@ virtualenv_create <- function(
     python <- virtualenv_starter(version)
 
 
+  local_prefix_python_lib_to_ld_library_path(python)
   check_can_be_virtualenv_starter(python, version)
 
   module <- module %||% virtualenv_module(python)

--- a/reticulate.Rproj
+++ b/reticulate.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 67dda317-993d-4309-bfde-903441588c12
 
 RestoreWorkspace: No
 SaveWorkspace: No


### PR DESCRIPTION
Fixes #1712
Possibly fixes #1713 also.