### PR TITLE
Accept `quit()` and `exit()` in `repl_python()`

### DIFF
--- a/R/repl.R
+++ b/R/repl.R
@@ -247,7 +247,7 @@ repl_python <- function(
     if (buffer$empty()) {
 
       # handle user requests to quit
-      if (trimmed %in% c("quit", "exit")) {
+      if (trimmed %in% c("quit", "exit", "quit()", "exit()")) {
         quit_requested <<- TRUE
         return()
       }

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -938,9 +938,6 @@ SEXP get_r_trace(bool maybe_use_cached = false) {
 
 SEXP py_fetch_error(bool maybe_reuse_cached_r_trace) {
 
-  // TODO: we need to add a guardrail to catch cases when
-  // this is being invoked from not the main thread
-
   if(!is_main_thread()) {
     GILScope _gil;
     PyErr_Print();


### PR DESCRIPTION
For consistency with the native Python repl.