### PR TITLE
`py_require()` checks and fails on 'equal' / 'not equal' Python version requests are used

### DIFF
--- a/R/py_require.R
+++ b/R/py_require.R
@@ -52,11 +52,16 @@ py_require <- function(packages = NULL,
   uv_initialized <- is_python_initialized() &&
     is_uv_reticulate_managed_env(py_exe())
 
-  if (uv_initialized && !is.null(python_version)) {
-    stop(
-      "Python version requirements cannot be ",
-      "changed after Python has been initialized"
-    )
+  if (!is.null(python_version)) {
+    if(uv_initialized) {
+      stop(
+        "Python version requirements cannot be ",
+        "changed after Python has been initialized"
+      )
+    }
+    if(substr(python_version, 1, 2) == "==") {
+      python_version <- substr(python_version, 3, nchar(python_version))
+    }
   }
 
   if (!is.null(exclude_newer)) {
@@ -441,8 +446,6 @@ uv_get_or_create_env <- function(packages = py_reqs_get("packages"),
   }
 
   if (length(python_version)) {
-    has_const <- substr(python_version, 1, 1) %in% c(">", "<", "=", "!")
-    python_version[!has_const] <- paste0("==", python_version[!has_const])
     python_arg <- c("--python", paste0(uv_maybe_processx(python_version), collapse = ","))
   } else {
     python_arg <- NULL

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -59,9 +59,12 @@ py_require <- function(packages = NULL,
         "changed after Python has been initialized"
       )
     }
-    if(substr(python_version, 1, 2) == "==") {
-      python_version <- substr(python_version, 3, nchar(python_version))
-    }
+    py_equal <- substr(python_version, 1, 2) == "=="
+    python_version[py_equal] <- substr(
+      x = python_version[py_equal],
+      start = 3,
+      stop =  nchar(python_version[py_equal])
+      )
   }
 
   if (!is.null(exclude_newer)) {

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -53,7 +53,7 @@ py_require <- function(packages = NULL,
     is_uv_reticulate_managed_env(py_exe())
 
   if (!is.null(python_version)) {
-    if(uv_initialized) {
+    if (uv_initialized) {
       stop(
         "Python version requirements cannot be ",
         "changed after Python has been initialized"
@@ -63,8 +63,8 @@ py_require <- function(packages = NULL,
     python_version[py_equal] <- substr(
       x = python_version[py_equal],
       start = 3,
-      stop =  nchar(python_version[py_equal])
-      )
+      stop = nchar(python_version[py_equal])
+    )
   }
 
   if (!is.null(exclude_newer)) {

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -76,9 +76,33 @@ py_require <- function(packages = NULL,
     return(py_reqs_get())
   }
 
+  py_versions <- py_reqs_action(action, python_version, py_reqs_get("python_version"))
+
+  ver_equal <- substr(py_versions, 1, 1) %in% c("=", 0:9)
+  ver_not_equal <- substr(py_versions, 1, 1) %in% c(">", "<", "!")
+
+  if (any(ver_equal) && any(ver_not_equal)) {
+    stop(
+      "Python version requirements cannot combine\n  'non-equal to' (",
+      paste0(py_versions[ver_not_equal], collapse = ", "),
+      ") and 'equal to' (",
+      paste0(py_versions[ver_equal], collapse = ", "),
+      ")\n  specifications"
+    )
+  }
+
+  if (sum(ver_equal) > 1) {
+    stop(
+      "Python version requirements cannot contain\n",
+      "  more than one 'equal to' specifications (",
+      paste0(py_versions[ver_equal], collapse = ", "),
+      ")"
+    )
+  }
+
   pr <- py_reqs_get()
   pr$packages <- py_reqs_action(action, packages, py_reqs_get("packages"))
-  pr$python_version <- py_reqs_action(action, python_version, py_reqs_get("python_version"))
+  pr$python_version <- py_versions
   pr$exclude_newer <- pr$exclude_newer %||% exclude_newer
   pr$history <- c(pr$history, list(list(
     requested_from = environmentName(topenv(parent.frame())),

--- a/tests/testthat/_snaps/py_require.md
+++ b/tests/testthat/_snaps/py_require.md
@@ -22,36 +22,6 @@
       success: false
       exit_code: 1
 
-# Error requesting newer package version against an older snapshot
-
-    Code
-      r_session(attach_namespace = TRUE, {
-        py_require("tensorflow==2.18.*")
-        py_require(exclude_newer = "2024-10-20")
-        uv_get_or_create_env()
-      })
-    Output
-      > py_require("tensorflow==2.18.*")
-      > py_require(exclude_newer = "2024-10-20")
-      > uv_get_or_create_env()
-        × No solution found when resolving `--with` dependencies:
-        ╰─▶ Because only tensorflow<2.18.dev0 is available and you require
-            tensorflow>=2.18.dev0, we can conclude that your requirements are
-            unsatisfiable.
-      
-            hint: `tensorflow` was requested with a pre-release marker (e.g.,
-            tensorflow>=2.18.dev0), but pre-releases weren't enabled (try:
-            `--prerelease=allow`)
-      -- Current requirements -------------------------------------------------
-       Packages: numpy, tensorflow==2.18.*
-       Exclude:  Anything newer than 2024-10-20
-      -------------------------------------------------------------------------
-      Error: Call `py_require()` to remove or replace conflicting requirements.
-      Execution halted
-      ------- session end -------
-      success: false
-      exit_code: 1
-
 # Error requesting a package that does not exists
 
     Code
@@ -184,7 +154,7 @@
         py_require("numpy==2")
         py_require("numpy==2", action = "remove")
         py_require(exclude_newer = "1990-01-01")
-        py_require(python_version = c("3.11", ">=3.10"))
+        py_require(python_version = c("<=3.11", ">=3.10"))
         py_require()
       })
     Output
@@ -192,11 +162,11 @@
       > py_require("numpy==2")
       > py_require("numpy==2", action = "remove")
       > py_require(exclude_newer = "1990-01-01")
-      > py_require(python_version = c("3.11", ">=3.10"))
+      > py_require(python_version = c("<=3.11", ">=3.10"))
       > py_require()
       ========================== Python requirements ========================== 
       -- Current requirements -------------------------------------------------
-       Python:   3.11, >=3.10
+       Python:   <=3.11, >=3.10
        Packages: numpy, pandas
        Exclude:  Anything newer than 1990-01-01
       -- R package requests --------------------------------------------------- 
@@ -214,7 +184,7 @@
         gr_package <- (function() {
           py_require(paste0("package", 1:20))
           py_require(paste0("package", 1:10), action = "remove")
-          py_require(python_version = c("3.11", ">=3.10"))
+          py_require(python_version = c("<=3.11", ">=3.10"))
         })
         environment(gr_package) <- asNamespace("graphics")
         gr_package()
@@ -224,21 +194,21 @@
       > gr_package <- (function() {
       +     py_require(paste0("package", 1:20))
       +     py_require(paste0("package", 1:10), action = "remove")
-      +     py_require(python_version = c("3.11", ">=3.10"))
+      +     py_require(python_version = c("<=3.11", ">=3.10"))
       + })
       > environment(gr_package) <- asNamespace("graphics")
       > gr_package()
       > py_require()
       ========================== Python requirements ========================== 
       -- Current requirements -------------------------------------------------
-       Python:   3.11, >=3.10
+       Python:   <=3.11, >=3.10
        Packages: numpy, package11, package12, package13, package14,
                  package15, package16, package17, package18, package19,
                  package20
       -- R package requests --------------------------------------------------- 
       R package  Python packages                           Python version      
       reticulate numpy                                                         
-      graphics   package11, package12, package13,          3.11, >=3.10        
+      graphics   package11, package12, package13,          <=3.11, >=3.10      
                  package14, package15, package16,                              
                  package17, package18, package19,                              
                  package20                                                     


### PR DESCRIPTION
- `uv run` does not accept Python version `==3.11`, and `==3.09`. In this change, `py_require()` removes any `==` from Python version requirements
- `uv run` does not accepts any combination of `==` requirements with non-equal requirements (`>=`, `<=`). In this change, `py_require()` checks and returns an informative error
- `uv run` does not accept more than one, different, equal-to Python version. In this change, `py_require()` will check and return an error this occurs 
- Adds tests for the changes mentioned above, and updates tests that were sending equal and non-equal Python requirements
- Unrelated, but just found out that newer pre-release versions of packages will modify the error output (https://pypi.org/project/tensorflow/#history), so switched the tests that requests a `tensorflow` 2.18 against an older snapshot from expect error test.
```
── Failure (test-py_require.R:12:3): Error requesting newer package version against an older snapshot ──
Snapshot of code has changed:
old[9:21] vs new[9:23]
    > py_require(exclude_newer = "2024-10-20")
    > uv_get_or_create_env()
      × No solution found when resolving `--with` dependencies:
-     ╰─▶ Because only tensorflow<2.18.dev0 is available and you require
-         tensorflow>=2.18.dev0, we can conclude that your requirements are
-         unsatisfiable.
+     ╰─▶ Because only the following versions of tensorflow are available:
+             tensorflow<2.18.dev0
+             tensorflow>2.19.dev0
+         and you require tensorflow>=2.18.dev0,<2.19.dev0, we can conclude that
+         your requirements are unsatisfiable.
```