### PR TITLE
Py require default python

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -390,3 +390,7 @@ py_set_qt_qpa_platform_plugin_path <- function(config) {
   FALSE
 
 }
+
+reticulate_default_python <- function() {
+  "3.11"
+}

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -436,7 +436,7 @@ uv_get_or_create_env <- function(packages = py_reqs_get("packages"),
   call_args <- list(
     packages = packages,
     python_version = python_version %||%
-      paste(reticulate_default_python(), "(`reticulate` default)"),
+      paste(reticulate_default_python(), "(reticulate default)"),
     exclude_newer = exclude_newer
   )
 

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -147,7 +147,7 @@ print.python_requirements <- function(x, ...) {
   }
   python_version <- x$python_version
   if (is.null(python_version)) {
-    python_version <- "[No Python version specified]"
+    python_version <- paste0("[No Python version specified. Will default to '", reticulate_default_python() , "']")
   }
 
   requested_from <- as.character(lapply(x$history, function(x) x$requested_from))
@@ -435,7 +435,8 @@ uv_get_or_create_env <- function(packages = py_reqs_get("packages"),
   # capture args; maybe used in error message later
   call_args <- list(
     packages = packages,
-    python_version = python_version,
+    python_version = python_version %||%
+      paste(reticulate_default_python(), "(`reticulate` default)"),
     exclude_newer = exclude_newer
   )
 
@@ -444,8 +445,11 @@ uv_get_or_create_env <- function(packages = py_reqs_get("packages"),
 
   if (length(python_version)) {
     constraints <- unlist(strsplit(python_version, ",", fixed = TRUE))
-    python_version <- c("--python", paste0(constraints, collapse = ","))
+    constraints <- paste0(constraints, collapse = ",")
+  } else {
+    constraints <- reticulate_default_python()
   }
+  python_version <- c("--python", constraints)
 
   if (!is.null(exclude_newer)) {
     # todo, accept a POSIXct/lt, format correctly

--- a/tests/testthat/_snaps/py_require.md
+++ b/tests/testthat/_snaps/py_require.md
@@ -14,7 +14,7 @@
         ╰─▶ Because you require numpy<2 and numpy>=2, we can conclude that your
             requirements are unsatisfiable.
       -- Current requirements -------------------------------------------------
-       Python:   3.11 (`reticulate` default)
+       Python:   3.11 (reticulate default)
        Packages: numpy, numpy<2, numpy>=2
       -------------------------------------------------------------------------
       Error in uv_get_or_create_env() : 
@@ -38,7 +38,7 @@
         ╰─▶ Because notexists was not found in the package registry and you require
             notexists, we can conclude that your requirements are unsatisfiable.
       -- Current requirements -------------------------------------------------
-       Python:   3.11 (`reticulate` default)
+       Python:   3.11 (reticulate default)
        Packages: numpy, pandas, notexists
       -------------------------------------------------------------------------
       Error in uv_get_or_create_env() : 

--- a/tests/testthat/_snaps/py_require.md
+++ b/tests/testthat/_snaps/py_require.md
@@ -14,6 +14,7 @@
         ╰─▶ Because you require numpy<2 and numpy>=2, we can conclude that your
             requirements are unsatisfiable.
       -- Current requirements -------------------------------------------------
+       Python:   3.11 (`reticulate` default)
        Packages: numpy, numpy<2, numpy>=2
       -------------------------------------------------------------------------
       Error in uv_get_or_create_env() : 
@@ -37,6 +38,7 @@
         ╰─▶ Because notexists was not found in the package registry and you require
             notexists, we can conclude that your requirements are unsatisfiable.
       -- Current requirements -------------------------------------------------
+       Python:   3.11 (`reticulate` default)
        Packages: numpy, pandas, notexists
       -------------------------------------------------------------------------
       Error in uv_get_or_create_env() : 
@@ -84,7 +86,7 @@
       > py_require()
       ══════════════════════════ Python requirements ══════════════════════════
       ── Current requirements ─────────────────────────────────────────────────
-       Python:   [No Python version specified]
+       Python:   [No Python version specified. Will default to '3.11']
        Packages: numpy, pandas, numpy==2
       ── R package requests ───────────────────────────────────────────────────
       R package  Python packages                           Python version      
@@ -110,7 +112,7 @@
       > py_require()
       ══════════════════════════ Python requirements ══════════════════════════
       ── Current requirements ─────────────────────────────────────────────────
-       Python:   [No Python version specified]
+       Python:   [No Python version specified. Will default to '3.11']
        Packages: numpy, pandas
       ── R package requests ───────────────────────────────────────────────────
       R package  Python packages                           Python version      
@@ -138,7 +140,7 @@
       > py_require()
       ══════════════════════════ Python requirements ══════════════════════════
       ── Current requirements ─────────────────────────────────────────────────
-       Python:   [No Python version specified]
+       Python:   [No Python version specified. Will default to '3.11']
        Packages: numpy, pandas
        Exclude:  Anything newer than 1990-01-01
       ── R package requests ───────────────────────────────────────────────────


### PR DESCRIPTION
- Adds `reticulate_default_python()`
- `uv_get_or_create()` uses new function to get the default if no Python version is specified
- Updates `print.` and error `py_require()` output to clarify that it will use, or used, the default version
- Updates test snapshot