### PR TITLE
Implement `resolve_python_version()`

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -390,7 +390,3 @@ py_set_qt_qpa_platform_plugin_path <- function(config) {
   FALSE
 
 }
-
-reticulate_default_python <- function() {
-  "3.11"
-}

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -629,16 +629,13 @@ resolve_python_version <- function(constraints = NULL) {
   }
 
   if (!length(candidates)) {
+    constraints <- paste0(constraints, collapse = ",")
     msg <- paste0(
       'Requested Python version constraints could not be satisfied.\n',
-      'Hint: Call `py_require(<version>, action = "set")` to select a specific Python version.'
+      '  constraints: "', constraints, '"\n',
+      'Hint: Call `py_require(python_version = <string>, action = "set")` to replace constraints.'
     )
-    cl <- call("resolve_python_version", constraints = paste0(constraints, collapse = ","))
-    stop(simpleError(msg, cl))
-
-    # stop("Requested Python version constraints could not be satisfied.\n",
-    #      '  constraints: "', paste0(constraints, collapse = ","), '"\n',
-
+    stop(msg)
   }
 
   as.character(candidates[1L])

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -629,10 +629,17 @@ resolve_python_version <- function(constraints = NULL) {
   }
 
   if (!length(candidates)) {
-    stop("Requested Python version constraints could not be satisfied.\n",
-         '  constraints: "', paste0(constraints, collapse = ","), '"\n',
-         'Hint: Call `py_require(<version>, action = "set")` to select a specific Python version.')
-    }
+    msg <- paste0(
+      'Requested Python version constraints could not be satisfied.\n',
+      'Hint: Call `py_require(<version>, action = "set")` to select a specific Python version.'
+    )
+    cl <- call("resolve_python_version", constraints = paste0(constraints, collapse = ","))
+    stop(simpleError(msg, cl))
+
+    # stop("Requested Python version constraints could not be satisfied.\n",
+    #      '  constraints: "', paste0(constraints, collapse = ","), '"\n',
+
+  }
 
   as.character(candidates[1L])
 }

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -616,6 +616,13 @@ resolve_python_version <- function(constraints = NULL) {
   ord <- union(ord, seq_along(candidates))
   candidates <- candidates[ord]
 
+  # Maybe add non-latest patch levels to candidates if they're explicitly
+  # mentioned in constraints
+  additional_candidates <- sub("^[<>=!]{1,2}", "", constraints)
+  additional_candidates <- numeric_version(additional_candidates, strict = FALSE)
+  additional_candidates <- additional_candidates[!is.na(additional_candidates)]
+  candidates <- c(candidates, additional_candidates)
+
   for (check in as_version_constraint_checkers(constraints)) {
     satisfies_constraint <- check(candidates)
     candidates <- candidates[satisfies_constraint]

--- a/tests/testthat/_snaps/py_require.md
+++ b/tests/testthat/_snaps/py_require.md
@@ -14,7 +14,7 @@
         ╰─▶ Because you require numpy<2 and numpy>=2, we can conclude that your
             requirements are unsatisfiable.
       -- Current requirements -------------------------------------------------
-       Python:   3.11 (reticulate default)
+       Python:   3.11.11 (reticulate default)
        Packages: numpy, numpy<2, numpy>=2
       -------------------------------------------------------------------------
       Error in uv_get_or_create_env() : 
@@ -38,7 +38,7 @@
         ╰─▶ Because notexists was not found in the package registry and you require
             notexists, we can conclude that your requirements are unsatisfiable.
       -- Current requirements -------------------------------------------------
-       Python:   3.11 (reticulate default)
+       Python:   3.11.11 (reticulate default)
        Packages: numpy, pandas, notexists
       -------------------------------------------------------------------------
       Error in uv_get_or_create_env() : 
@@ -60,13 +60,10 @@
       > py_require(python_version = ">=3.10")
       > py_require(python_version = "<3.10")
       > uv_get_or_create_env()
-      error: No interpreter found for Python >=3.10, <3.10 in virtual environments or managed installations
-      -- Current requirements -------------------------------------------------
-       Python:   >=3.10, <3.10
-       Packages: numpy
-      -------------------------------------------------------------------------
-      Error in uv_get_or_create_env() : 
-        Call `py_require()` to remove or replace conflicting requirements.
+      Error in resolve_python_version(constraints = ">=3.10,<3.10") : 
+        Requested Python version constraints could not be satisfied.
+      Hint: Call `py_require(<version>, action = "set")` to select a specific Python version.
+      Calls: uv_get_or_create_env -> resolve_python_version
       Execution halted
       ------- session end -------
       success: false
@@ -86,7 +83,7 @@
       > py_require()
       ══════════════════════════ Python requirements ══════════════════════════
       ── Current requirements ─────────────────────────────────────────────────
-       Python:   [No Python version specified. Will default to '3.11']
+       Python:   [No Python version specified. Will default to '3.11.11']
        Packages: numpy, pandas, numpy==2
       ── R package requests ───────────────────────────────────────────────────
       R package  Python packages                           Python version      
@@ -112,7 +109,7 @@
       > py_require()
       ══════════════════════════ Python requirements ══════════════════════════
       ── Current requirements ─────────────────────────────────────────────────
-       Python:   [No Python version specified. Will default to '3.11']
+       Python:   [No Python version specified. Will default to '3.11.11']
        Packages: numpy, pandas
       ── R package requests ───────────────────────────────────────────────────
       R package  Python packages                           Python version      
@@ -140,7 +137,7 @@
       > py_require()
       ══════════════════════════ Python requirements ══════════════════════════
       ── Current requirements ─────────────────────────────────────────────────
-       Python:   [No Python version specified. Will default to '3.11']
+       Python:   [No Python version specified. Will default to '3.11.11']
        Packages: numpy, pandas
        Exclude:  Anything newer than 1990-01-01
       ── R package requests ───────────────────────────────────────────────────

--- a/tests/testthat/_snaps/py_require.md
+++ b/tests/testthat/_snaps/py_require.md
@@ -60,9 +60,10 @@
       > py_require(python_version = ">=3.10")
       > py_require(python_version = "<3.10")
       > uv_get_or_create_env()
-      Error in resolve_python_version(constraints = ">=3.10,<3.10") : 
+      Error in resolve_python_version(constraints = python_version) : 
         Requested Python version constraints could not be satisfied.
-      Hint: Call `py_require(<version>, action = "set")` to select a specific Python version.
+        constraints: ">=3.10,<3.10"
+      Hint: Call `py_require(python_version = <string>, action = "set")` to replace constraints.
       Calls: uv_get_or_create_env -> resolve_python_version
       Execution halted
       ------- session end -------


### PR DESCRIPTION
Currently, adding a Python constraint like `py_require(python_version = ">=3.8")` changes the selected Python from 3.11 to 3.13, which then results in errors when trying to install packages that are not compatible yet with the latest Python version (e.g., tensorflow, torch).

This PR implements a custom constraint resolver that prefers returning a bugfix Python release, rather than the bleeding edge. 

Some examples:
```r
> resolve_python_version()
[1] "3.11.11"
> resolve_python_version(">=3.9")
[1] "3.11.11"
> resolve_python_version(">=3.9")
[1] "3.11.11"
> resolve_python_version(">=3.11")
[1] "3.11.11"
> resolve_python_version(">=3.12")
[1] "3.12.8"
> resolve_python_version(">=3.13")
[1] "3.13.1"
> resolve_python_version("<=3.13")
[1] "3.11.11"
> resolve_python_version("<=3.11")
[1] "3.11.11"
> resolve_python_version("<3.11")
[1] "3.10.16"
> resolve_python_version("3.14.0a3")
[1] "3.14.0a3"
> resolve_python_version("<=3.12,>=3.9,!=3.11")
[1] "3.10.16"
> resolve_python_version("<=3.12,>=3.9")
[1] "3.11.11"
> resolve_python_version("<=3.12,>=3.9,3.10")
[1] "3.10.16"
> resolve_python_version("3.10,3.11")
Error in `resolve_python_version()`:
! Requested Python version constraints could not be satisfied.
  constraints: "3.10,3.11"
Hint: Call `py_require(<version>, action = "set")` to select a specific Python version.
Run `rlang::last_trace()` to see where the error occurred.
> resolve_python_version(">=3.9,3.12")
[1] "3.12.8"
> resolve_python_version(">=3.9,3.12.1")
[1] "3.12.1"
```