### PR TITLE
Simplify `uv_get_or_create_env()`; remove processx dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,7 +55,6 @@ Suggests:
     cli,
     rmarkdown,
     pillar,
-    processx,
     testthat
 LinkingTo: Rcpp
 RoxygenNote: 7.3.2

--- a/R/utils.R
+++ b/R/utils.R
@@ -644,9 +644,24 @@ maybe_shQuote <- function(x) {
 }
 
 
-rm_all_reticulate_state <- function() {
+rm_all_reticulate_state <- function(external = FALSE) {
+
   rm_rf <- function(...)
     unlink(path.expand(c(...)), recursive = TRUE, force = TRUE)
+
+  if (external) {
+    if (!is.null(uv <- uv_binary(FALSE))) {
+      system2(uv, c("cache", "clean"))
+      rm_rf(system2(uv, c("python", "dir"),
+                    env = "NO_COLOR=1", stdout = TRUE))
+      # rm_rf(system2(uv, c("tool", "dir"),
+      #               env = "NO_COLOR=1", stdout = TRUE))
+    }
+
+    if (nzchar(Sys.which("pip3")))
+      system2("pip3", c("cache", "purge"))
+  }
+
   rm_rf(user_data_dir("r-reticulate", NULL))
   rm_rf(user_data_dir("r-miniconda", NULL))
   rm_rf(user_data_dir("r-miniconda-arm64", NULL))

--- a/R/utils.R
+++ b/R/utils.R
@@ -668,6 +668,10 @@ rm_all_reticulate_state <- function(external = FALSE) {
   rm_rf(rappdirs::user_cache_dir("r-reticulate", NULL))
   rm_rf(miniconda_path_default())
   rm_rf(virtualenv_path("r-reticulate"))
+  for (venv in virtualenv_list()) {
+    if (startsWith(venv, "r-"))
+      virtualenv_remove(venv, confirm = FALSE)
+  }
 }
 
 

--- a/tests/testthat/test-py_require.R
+++ b/tests/testthat/test-py_require.R
@@ -1,5 +1,13 @@
+
+
+
 test_that("Error requesting conflicting package versions", {
   local_edition(3)
+
+  # dry run before snapshot tests, so download progress updates aren't
+  # in the snapshot
+  try(uv_get_or_create_env())
+
   expect_snapshot(r_session(attach_namespace = TRUE, {
     py_require("numpy<2")
     py_require("numpy>=2")


### PR DESCRIPTION
`uv` recently started to default print informative messages about download operations on non-pty stdout, removing the need for a custom spinner in reticulate.

With this update, I now see: 
![image](https://github.com/user-attachments/assets/c93e6ec5-9734-4245-b093-10c131deb3d9)

