### PR TITLE
Updates to `py_require()`  

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -25,10 +25,17 @@ py_config <- function() {
 #'   not yet been initialized by `reticulate`.
 #'
 #' @export
-py_version <- function() {
+py_version <- function(patch = FALSE) {
 
   if (!py_available(initialize = FALSE))
     return(NULL)
+
+  if (patch) {
+    sys <- import("sys")
+    minor_major_patch <- sys$version_info[NA:3]
+    version <- paste0(unlist(minor_major_patch), collapse = ".")
+    return(numeric_version(version))
+  }
 
   config <- py_config()
   numeric_version(config$version)

--- a/R/config.R
+++ b/R/config.R
@@ -21,6 +21,8 @@ py_config <- function() {
 #'
 #' Get the version of Python currently being used by `reticulate`.
 #'
+#' @param patch boolean, whether to include the patch level in the returned version.
+#'
 #' @return The version of Python currently used, or `NULL` if Python has
 #'   not yet been initialized by `reticulate`.
 #'

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -44,6 +44,8 @@
 #' @param python_version A character vector of Python version constraints \cr
 #'   (e.g., `"3.10"` or `">=3.9,<3.13,!=3.11"`).
 #'
+#' @param ... Dots are for future extensions, must be empty.
+#'
 #' @param action Defines how `py_require()` handles the provided requirements.
 #'   Options are:
 #'   - `add`: Add the entries to the current set of requirements.
@@ -62,8 +64,12 @@
 #' @export
 py_require <- function(packages = NULL,
                        python_version = NULL,
+                       ...,
                        exclude_newer = NULL,
                        action = c("add", "remove", "set")) {
+
+  if (length(list(...)))
+    stop("... must be empty")
 
   pr <- py_reqs_get()
 

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -16,18 +16,18 @@
 #' with Python for the first time in the R session. Typically, this occurs when
 #' `import()` is first called.
 #'
-#' If `py_require()` is called with new requirements after Reticulate has
+#' If `py_require()` is called with new requirements after reticulate has
 #' already initialized an ephemeral Python environment, a new ephemeral
 #' environment is activated on top of the existing one. Once Python is
-#' initialized, only adding packages is supported--removing packages, changing
+#' initialized, only adding packages is supported---removing packages, changing
 #' the Python version, or modifying `exclude_newer` is not possible.
 #'
 #' Calling `py_require()` without arguments returns a list of the currently
 #' declared requirements.
 #'
-#' `py_require()` can also be used in R packages (e.g., in `.onLoad()` or
+#' `py_require()` can also be called by R packages (e.g., in `.onLoad()` or
 #' elsewhere) to declare Python dependencies. The print method for
-#' `py_require()` shows the Python dependencies declared by R packages in the
+#' `py_require()` displays the Python dependencies declared by R packages in the
 #' current session.
 #'
 #' @note Reticulate uses [`uv`](https://docs.astral.sh/uv/) to resolve Python

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -500,7 +500,6 @@ uv_get_or_create_env <- function(packages = py_reqs_get("packages"),
                                  python_version = py_reqs_get("python_version"),
                                  exclude_newer = py_reqs_get("exclude_newer")) {
 
-  # print(rlang::trace_back())
   uv <- uv_binary() %||% return() # error?
 
   # capture args; maybe used in error message later
@@ -662,15 +661,6 @@ uv_python_list <- function() {
     ),
     stdout = TRUE
   )
-  # x <- tryCatch(
-    # system2(
-      # uv_binary(),
-      # c("python list --no-config --python-preference only-managed",
-        # "--only-downloads --color never"),
-      # stdout = TRUE
-    # ),
-    # warning = function(w) character()
-  # )
 
   x <- jsonlite::parse_json(x)
   x <- unlist(lapply(x, `[[`, "version"))

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -157,11 +157,22 @@ py_require <- function(packages = NULL,
 
   if (!is.null(packages)) {
     if (uv_initialized) {
-      if (action == "add") {
-        pr$packages <- py_reqs_action(action, packages, py_reqs_get("packages"))
-      } else {
-        signal_condition("After Python has initialized, only `action = 'add'` is supported.")
-      }
+      switch(action,
+        add = {
+          if(all(packages %in% pr$packages)) {
+            packages <- NULL # no-op, skip activating new env
+          } else {
+            pr$packages <- unique(c(packages, pr$packages))
+          }
+        },
+        remove = {
+          if (any(packages %in% pr$packages))
+            signal_condition("After Python has initialized, only `action = 'add'` is supported.")
+        },
+        set = {
+          if (!base::setequal(packages, pr$packages))
+            signal_condition("After Python has initialized, only `action = 'add'` is supported.")
+        })
     } else {
       pr$packages <- py_reqs_action(action, packages, py_reqs_get("packages"))
     }

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -91,14 +91,14 @@ py_require <- function(packages = NULL,
       current_py_version <- py_version(patch = TRUE)
       for (check in as_version_constraint_checkers(python_version)) {
         if (!isTRUE(check(current_py_version))) {
-          signal_condition(
+          signal_condition(paste0(collapse = "",
             "Python version requirements cannot be ",
             "changed after Python has been initialized.\n",
-            "- Python version request: '", python_version, "'",
+            "* Python version request: '", python_version, "'",
             if (called_from_package) paste0(" (from package:", parent.pkg(), ")"),
             "\n",
-            "- Python version initialized: '", as.character(current_py_version), "'"
-          )
+            "* Python version initialized: '", as.character(current_py_version), "'"
+          ))
           break
         }
       }

--- a/R/utils.R
+++ b/R/utils.R
@@ -708,3 +708,10 @@ expand_env_vars <- function(x) {
 }
 
 `%""%` <- function(x, y) if(identical(x, "")) y else x
+
+parent.pkg <- function(env = parent.frame(2)) {
+  if (isNamespace(env <- topenv(env)))
+    as.character(getNamespaceName(env)) # unname
+  else
+    NULL # print visible
+}

--- a/R/virtualenv.R
+++ b/R/virtualenv.R
@@ -692,12 +692,14 @@ as_version_constraint_checkers <- function(version) {
   ver <- numeric_version(ver)
 
   .mapply(function(op, ver) {
-    op <- get(op, mode = "function")
+    op <- as.symbol(op)
     force(ver)
 
     # return a "checker" function that takes a vector of versions and returns
     # a logical vector of if the version satisfies the constraint.
-    function(x) {
+    rlang::zap_srcref(eval(bquote(function(x) {
+      op <- .(op)
+      ver <- .(ver)
       x <- numeric_version(x)
       # if the constraint version is missing minor or patch level, set
       # to 0, so we can match on all, equivalent to pip style syntax like '3.8.*'
@@ -707,7 +709,7 @@ as_version_constraint_checkers <- function(version) {
           x[, lvl] <- 0L
         }
       op(x, ver)
-    }
+    })))
   }, list(op, ver), NULL)
 }
 

--- a/man/py_require.Rd
+++ b/man/py_require.Rd
@@ -2,67 +2,78 @@
 % Please edit documentation in R/py_require.R
 \name{py_require}
 \alias{py_require}
-\title{Declare Python requirements}
+\title{Declare Python Requirements}
 \usage{
 py_require(
   packages = NULL,
   python_version = NULL,
+  ...,
   exclude_newer = NULL,
   action = c("add", "remove", "set")
 )
 }
 \arguments{
-\item{packages}{A character vector of Python packages to make available
-during the working session. These can be bare python package names like
-\code{"jax"}, or package names with version constraints like \code{"jax[cpu]>=0.5"}}
+\item{packages}{A character vector of Python packages to be available during
+the session. These can be simple package names like \code{"jax"} or names with
+version constraints like \code{"jax[cpu]>=0.5"}.}
 
-\item{python_version}{A character vector of Python version constraints.
-(e.g.: \code{"3.10"} or \code{">=3.9,<3.13,!=3.11"}).}
+\item{python_version}{A character vector of Python version constraints \cr
+(e.g., \code{"3.10"} or \code{">=3.9,<3.13,!=3.11"}).}
 
-\item{exclude_newer}{Only use package versions that were published prior to a
-given date. This provides a light-weight alternative to "freezing" Python
-package versions, to guard against future package versions breaking a
-workflow. After the first time \code{exclude_newer}, only the 'set' \code{action} can
-override the date afterwards.}
+\item{...}{Dots are for future extensions, must be empty.}
 
-\item{action}{What \code{py_require()} should do with the provided \code{packages} and
-\code{python_version}. There are three options:
+\item{exclude_newer}{Restricts package versions to those published before a
+specified date. This offers a lightweight alternative to freezing package
+versions, to guard against future published package versions breaking a
+workflow. Once  \code{exclude_newer} is set, only the \code{set} action can override
+it.}
+
+\item{action}{Defines how \code{py_require()} handles the provided requirements.
+Options are:
 \itemize{
-\item \code{add}: Adds the entries to the current set of requirements.
-\item \code{remove}: Removes the entries from the list of requirements. Strings must
-be an exact match to an existing requirement. For example, if
-\code{"numpy==2.2.2"} is currently on the list, passing \code{"numpy"} with a
-'remove' action will not affect the list. Requests to remove entries that
-are not present are silently ignored.
-\item \code{set}: Deletes any requirement already defined, and replaces them with what
-is provided in the command call. Packages and Python version can be
-independently set.
+\item \code{add}: Add the entries to the current set of requirements.
+\item \code{remove}: Remove exact matches from the requirements list. For example, if
+\code{"numpy==2.2.2"} is in the list, passing \code{"numpy"} with \code{action = "remove"}
+will not remove it. Requests to remove nonexistent entries are ignored.
+\item \code{set}: Clear all existing requirements and replaces them with the
+provided ones. Packages and the Python version can be set independently.
 }}
 }
 \description{
 \code{py_require()} allows you to declare Python requirements for the R session,
 including Python packages, any version constraints on those packages, and any
 version constraints on Python itself. Reticulate can then automatically
-create and use an ephemeral Python environment that satisfies all the Python
+create and use an ephemeral Python environment that satisfies all these
 requirements.
 }
 \details{
-The virtual environment will not be created until the users attempts to
-interacts with Python for the first time during the R session. Typically,
-that would be the first time \code{import()} is called.
+Reticulate will only use an ephemeral environment if no other Python
+installation is found earlier in the \href{https://rstudio.github.io/reticulate/articles/versions.html#order-of-discovery}{Order of Discovery}.
+You can also force reticulate to use an ephemeral environment by setting
+\code{Sys.setenv(RETICULATE_USE_MANAGED_VENV = "yes")}.
 
-If \code{py_require()} is called with new requirements after reticulate has
-already initialized an ephemeral Python environment, then a new ephemeral
-environment is activated, layered atop of the existing one. Note that after
-initializing Python, only adding python packages is supported. Removing
-python packages, changing the Python version, or changing \code{excluding_newer}
-cannot change after reticulate has initialized Python.
+The ephemeral virtual environment is not created until the user interacts
+with Python for the first time in the R session. Typically, this occurs when
+\code{import()} is first called.
 
-If \code{py_require()} is called without arguments, then a list is returned with
-the currently declared requirements.
+If \code{py_require()} is called with new requirements after Reticulate has
+already initialized an ephemeral Python environment, a new ephemeral
+environment is activated on top of the existing one. Once Python is
+initialized, only adding packages is supported--removing packages, changing
+the Python version, or modifying \code{exclude_newer} is not possible.
 
-\code{py_require()} can also be called from R packages (e.g., in \code{.onLoad()} or
-elsewhere) to declare Python requirements. You can view which Python
-dependencies have been been declared by R packages in the current R session
-by printing with \code{py_require()} by printing \code{py_require()}.
+Calling \code{py_require()} without arguments returns a list of the currently
+declared requirements.
+
+\code{py_require()} can also be used in R packages (e.g., in \code{.onLoad()} or
+elsewhere) to declare Python dependencies. The print method for
+\code{py_require()} shows the Python dependencies declared by R packages in the
+current session.
+}
+\note{
+Reticulate uses \href{https://docs.astral.sh/uv/}{\code{uv}} to resolve Python
+dependencies. Many \code{uv} options can be customized via environment
+variables, as described
+\href{https://docs.astral.sh/uv/configuration/environment/}{here}. For example,
+you can set \code{Sys.setenv(UV_OFFLINE=1)} or \code{Sys.setenv(UV_INDEX = "https://download.pytorch.org/whl/cpu")}.
 }

--- a/man/py_require.Rd
+++ b/man/py_require.Rd
@@ -56,18 +56,18 @@ The ephemeral virtual environment is not created until the user interacts
 with Python for the first time in the R session. Typically, this occurs when
 \code{import()} is first called.
 
-If \code{py_require()} is called with new requirements after Reticulate has
+If \code{py_require()} is called with new requirements after reticulate has
 already initialized an ephemeral Python environment, a new ephemeral
 environment is activated on top of the existing one. Once Python is
-initialized, only adding packages is supported--removing packages, changing
+initialized, only adding packages is supported---removing packages, changing
 the Python version, or modifying \code{exclude_newer} is not possible.
 
 Calling \code{py_require()} without arguments returns a list of the currently
 declared requirements.
 
-\code{py_require()} can also be used in R packages (e.g., in \code{.onLoad()} or
+\code{py_require()} can also be called by R packages (e.g., in \code{.onLoad()} or
 elsewhere) to declare Python dependencies. The print method for
-\code{py_require()} shows the Python dependencies declared by R packages in the
+\code{py_require()} displays the Python dependencies declared by R packages in the
 current session.
 }
 \note{

--- a/man/py_require.Rd
+++ b/man/py_require.Rd
@@ -12,47 +12,57 @@ py_require(
 )
 }
 \arguments{
-\item{packages}{A vector of Python packages to make available during the
-working session.}
+\item{packages}{A character vector of Python packages to make available
+during the working session. These can be bare python package names like
+\code{"jax"}, or package names with version constraints like \code{"jax[cpu]>=0.5"}}
 
-\item{python_version}{A vector of one, or multiple, Python versions to
-consider. \code{uv} will not be able to process conflicting Python versions
-(e.g.: '>=3.11', '3.10').}
+\item{python_version}{A character vector of Python version constraints.
+(e.g.: \code{"3.10"} or \code{">=3.9,<3.13,!=3.11"}).}
 
-\item{exclude_newer}{Leverages a feature from \code{uv} that allows you to limit
-the candidate package versions to those that were uploaded prior to a given
-date. During the working session, the date can be "added" only one time.
-After the first time the argument is used, only the 'set' \code{action} can
+\item{exclude_newer}{Only use package versions that were published prior to a
+given date. This provides a light-weight alternative to "freezing" Python
+package versions, to guard against future package versions breaking a
+workflow. After the first time \code{exclude_newer}, only the 'set' \code{action} can
 override the date afterwards.}
 
-\item{action}{What \code{py_require()} should do with the packages and Python
-version provided during the given command call. There are three options:
+\item{action}{What \code{py_require()} should do with the provided \code{packages} and
+\code{python_version}. There are three options:
 \itemize{
-\item add - Adds the requirement to the list
-\item remove - Removes the requirement form the list. It has to be an exact match
-to an existing requirement. For example, if 'numpy==2.2.2' is currently on
-the list, passing 'numpy' with a 'remove' action will affect the list.
-\item set - Deletes any requirement already defined, and replaces them with what
+\item \code{add}: Adds the entries to the current set of requirements.
+\item \code{remove}: Removes the entries from the list of requirements. Strings must
+be an exact match to an existing requirement. For example, if
+\code{"numpy==2.2.2"} is currently on the list, passing \code{"numpy"} with a
+'remove' action will not affect the list. Requests to remove entries that
+are not present are silently ignored.
+\item \code{set}: Deletes any requirement already defined, and replaces them with what
 is provided in the command call. Packages and Python version can be
 independently set.
 }}
 }
 \description{
-It allows you to specify the Python packages, and their versions, to use
-during your working session. It also allows to specify Python version
-requirements. It uses \href{https://docs.astral.sh/uv/}{uv} to automatically
-resolves multiple version requirements of the same package (e.g.:
-'numpy>=2.2.0', numpy==2.2.2'), as well as resolve multiple Python version
-requirements (e.g.: '>=3.10', '3.11').  \code{uv} will automatically download and
-install the resulting Python version and packages, so there is no need to
-take any steps prior to starting the Python session.
+\code{py_require()} allows you to declare Python requirements for the R session,
+including Python packages, any version constraints on those packages, and any
+version constraints on Python itself. Reticulate can then automatically
+create and use an ephemeral Python environment that satisfies all the Python
+requirements.
 }
 \details{
-The virtual environment will not be initialized until the users attempts to
-interacts with Python for the first time during the session. Typically,
+The virtual environment will not be created until the users attempts to
+interacts with Python for the first time during the R session. Typically,
 that would be the first time \code{import()} is called.
 
-If \code{uv} is not installed, \code{reticulate} will attempt to download and install
-a version of it in an isolated folder. This will allow you to get the
-advantages of \code{uv}, without modifying your computer's environment.
+If \code{py_require()} is called with new requirements after reticulate has
+already initialized an ephemeral Python environment, then a new ephemeral
+environment is activated, layered atop of the existing one. Note that after
+initializing Python, only adding python packages is supported. Removing
+python packages, changing the Python version, or changing \code{excluding_newer}
+cannot change after reticulate has initialized Python.
+
+If \code{py_require()} is called without arguments, then a list is returned with
+the currently declared requirements.
+
+\code{py_require()} can also be called from R packages (e.g., in \code{.onLoad()} or
+elsewhere) to declare Python requirements. You can view which Python
+dependencies have been been declared by R packages in the current R session
+by printing with \code{py_require()} by printing \code{py_require()}.
 }

--- a/man/py_version.Rd
+++ b/man/py_version.Rd
@@ -6,6 +6,9 @@
 \usage{
 py_version(patch = FALSE)
 }
+\arguments{
+\item{patch}{boolean, whether to include the patch level in the returned version.}
+}
 \value{
 The version of Python currently used, or \code{NULL} if Python has
 not yet been initialized by \code{reticulate}.

--- a/man/py_version.Rd
+++ b/man/py_version.Rd
@@ -4,7 +4,7 @@
 \alias{py_version}
 \title{Python version}
 \usage{
-py_version()
+py_version(patch = FALSE)
 }
 \value{
 The version of Python currently used, or \code{NULL} if Python has

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -2879,7 +2879,7 @@ extern "C" PyObject* initializeRPYCall(void) {
 // [[Rcpp::export]]
 void py_activate_virtualenv(const std::string& script) {
   GILScope _gil;
-  
+
   // import runpy
   PyObjectPtr runpy_module(PyImport_ImportModule("runpy"));
   if (runpy_module.is_null())

--- a/tests/testthat/_snaps/py_require.md
+++ b/tests/testthat/_snaps/py_require.md
@@ -30,6 +30,8 @@
       r_session({
         pkg_py_require <- (function(ver) reticulate::py_require(python_version = ver))
         environment(pkg_py_require) <- asNamespace("stats")
+        Sys.setenv(RETICULATE_USE_MANAGED_VENV = "yes")
+        Sys.unsetenv("RETICULATE_PYTHON")
         library(reticulate)
         py_require(python_version = ">=3.9")
         py_require(python_version = ">=3.8,<3.14")
@@ -46,6 +48,8 @@
     Output
       > pkg_py_require <- (function(ver) reticulate::py_require(python_version = ver))
       > environment(pkg_py_require) <- asNamespace("stats")
+      > Sys.setenv(RETICULATE_USE_MANAGED_VENV = "yes")
+      > Sys.unsetenv("RETICULATE_PYTHON")
       > library(reticulate)
       > py_require(python_version = ">=3.9")
       > py_require(python_version = ">=3.8,<3.14")

--- a/tests/testthat/_snaps/py_require.md
+++ b/tests/testthat/_snaps/py_require.md
@@ -24,6 +24,56 @@
       success: false
       exit_code: 1
 
+# Setting py_require(python_version) after initializing Python 
+
+    Code
+      r_session({
+        pkg_py_require <- (function(ver) reticulate::py_require(python_version = ver))
+        environment(pkg_py_require) <- asNamespace("stats")
+        library(reticulate)
+        py_require(python_version = ">=3.9")
+        py_require(python_version = ">=3.8,<3.14")
+        py_require(python_version = "3.11")
+        pkg_py_require(">=3.10")
+        import("numpy")
+        py_require(python_version = ">=3.9.1")
+        py_require(python_version = ">=3.8.1,<3.14")
+        py_require(python_version = "3.11")
+        pkg_py_require(">=3.10")
+        pkg_py_require(">=3.12")
+        py_require(python_version = ">=3.12")
+      })
+    Output
+      > pkg_py_require <- (function(ver) reticulate::py_require(python_version = ver))
+      > environment(pkg_py_require) <- asNamespace("stats")
+      > library(reticulate)
+      > py_require(python_version = ">=3.9")
+      > py_require(python_version = ">=3.8,<3.14")
+      > py_require(python_version = "3.11")
+      > pkg_py_require(">=3.10")
+      > import("numpy")
+      Module(numpy)
+      > py_require(python_version = ">=3.9.1")
+      > py_require(python_version = ">=3.8.1,<3.14")
+      > py_require(python_version = "3.11")
+      > pkg_py_require(">=3.10")
+      > pkg_py_require(">=3.12")
+      Warning message:
+      In reticulate::py_require(python_version = ver) :
+        Python version requirements cannot be changed after Python has been initialized.
+      * Python version request: '>=3.12' (from package:stats)
+      * Python version initialized: '3.11.11'
+      > py_require(python_version = ">=3.12")
+      Error in py_require(python_version = ">=3.12") : 
+        Python version requirements cannot be changed after Python has been initialized.
+      * Python version request: '>=3.12'
+      * Python version initialized: '3.11.11'
+      Calls: py_require -> signal_condition
+      Execution halted
+      ------- session end -------
+      success: false
+      exit_code: 1
+
 # Error requesting a package that does not exists
 
     Code
@@ -219,54 +269,4 @@
       ------- session end -------
       success: true
       exit_code: 0
-
-# Setting py_require(python_version) after initializing Python 
-
-    Code
-      r_session({
-        pkg_py_require <- (function(ver) reticulate::py_require(python_version = ver))
-        environment(pkg_py_require) <- asNamespace("stats")
-        library(reticulate)
-        py_require(python_version = ">=3.9")
-        py_require(python_version = ">=3.8,<3.14")
-        py_require(python_version = "3.11")
-        pkg_py_require(">=3.10")
-        import("numpy")
-        py_require(python_version = ">=3.9.1")
-        py_require(python_version = ">=3.8.1,<3.14")
-        py_require(python_version = "3.11")
-        pkg_py_require(">=3.10")
-        pkg_py_require(">=3.12")
-        py_require(python_version = ">=3.12")
-      })
-    Output
-      > pkg_py_require <- (function(ver) reticulate::py_require(python_version = ver))
-      > environment(pkg_py_require) <- asNamespace("stats")
-      > library(reticulate)
-      > py_require(python_version = ">=3.9")
-      > py_require(python_version = ">=3.8,<3.14")
-      > py_require(python_version = "3.11")
-      > pkg_py_require(">=3.10")
-      > import("numpy")
-      Module(numpy)
-      > py_require(python_version = ">=3.9.1")
-      > py_require(python_version = ">=3.8.1,<3.14")
-      > py_require(python_version = "3.11")
-      > pkg_py_require(">=3.10")
-      > pkg_py_require(">=3.12")
-      Warning message:
-      In reticulate::py_require(python_version = ver) :
-        Python version requirements cannot be changed after Python has been initialized.
-      * Python version request: '>=3.12' (from package:stats)
-      * Python version initialized: '3.11.11'
-      > py_require(python_version = ">=3.12")
-      Error in py_require(python_version = ">=3.12") : 
-        Python version requirements cannot be changed after Python has been initialized.
-      * Python version request: '>=3.12'
-      * Python version initialized: '3.11.11'
-      Calls: py_require -> signal_condition
-      Execution halted
-      ------- session end -------
-      success: false
-      exit_code: 1
 

--- a/tests/testthat/_snaps/py_require.md
+++ b/tests/testthat/_snaps/py_require.md
@@ -220,3 +220,53 @@
       success: true
       exit_code: 0
 
+# Setting py_require(python_version) after initializing Python 
+
+    Code
+      r_session({
+        pkg_py_require <- (function(ver) reticulate::py_require(python_version = ver))
+        environment(pkg_py_require) <- asNamespace("stats")
+        library(reticulate)
+        py_require(python_version = ">=3.9")
+        py_require(python_version = ">=3.8,<3.14")
+        py_require(python_version = "3.11")
+        pkg_py_require(">=3.10")
+        import("numpy")
+        py_require(python_version = ">=3.9.1")
+        py_require(python_version = ">=3.8.1,<3.14")
+        py_require(python_version = "3.11")
+        pkg_py_require(">=3.10")
+        pkg_py_require(">=3.12")
+        py_require(python_version = ">=3.12")
+      })
+    Output
+      > pkg_py_require <- (function(ver) reticulate::py_require(python_version = ver))
+      > environment(pkg_py_require) <- asNamespace("stats")
+      > library(reticulate)
+      > py_require(python_version = ">=3.9")
+      > py_require(python_version = ">=3.8,<3.14")
+      > py_require(python_version = "3.11")
+      > pkg_py_require(">=3.10")
+      > import("numpy")
+      Module(numpy)
+      > py_require(python_version = ">=3.9.1")
+      > py_require(python_version = ">=3.8.1,<3.14")
+      > py_require(python_version = "3.11")
+      > pkg_py_require(">=3.10")
+      > pkg_py_require(">=3.12")
+      Warning message:
+      In reticulate::py_require(python_version = ver) :
+        Python version requirements cannot be changed after Python has been initialized.
+      - Python version request: '>=3.12' (from package:stats)
+      - Python version initialized: '3.11.11'
+      > py_require(python_version = ">=3.12")
+      Error in py_require(python_version = ">=3.12") : 
+        Python version requirements cannot be changed after Python has been initialized.
+      - Python version request: '>=3.12'
+      - Python version initialized: '3.11.11'
+      Calls: py_require -> signal
+      Execution halted
+      ------- session end -------
+      success: false
+      exit_code: 1
+

--- a/tests/testthat/_snaps/py_require.md
+++ b/tests/testthat/_snaps/py_require.md
@@ -257,13 +257,13 @@
       Warning message:
       In reticulate::py_require(python_version = ver) :
         Python version requirements cannot be changed after Python has been initialized.
-      - Python version request: '>=3.12' (from package:stats)
-      - Python version initialized: '3.11.11'
+      * Python version request: '>=3.12' (from package:stats)
+      * Python version initialized: '3.11.11'
       > py_require(python_version = ">=3.12")
       Error in py_require(python_version = ">=3.12") : 
         Python version requirements cannot be changed after Python has been initialized.
-      - Python version request: '>=3.12'
-      - Python version initialized: '3.11.11'
+      * Python version request: '>=3.12'
+      * Python version initialized: '3.11.11'
       Calls: py_require -> signal_condition
       Execution halted
       ------- session end -------

--- a/tests/testthat/_snaps/py_require.md
+++ b/tests/testthat/_snaps/py_require.md
@@ -28,55 +28,96 @@
 
     Code
       r_session({
-        pkg_py_require <- (function(ver) reticulate::py_require(python_version = ver))
-        environment(pkg_py_require) <- asNamespace("stats")
-        Sys.setenv(RETICULATE_USE_MANAGED_VENV = "yes")
         Sys.unsetenv("RETICULATE_PYTHON")
+        Sys.setenv(RETICULATE_USE_MANAGED_VENV = "yes")
+        pkg_py_require <- (function(...) reticulate::py_require(...))
+        environment(pkg_py_require) <- asNamespace("stats")
         library(reticulate)
-        py_require(python_version = ">=3.9")
+        py_require(python_version = ">=3.9", "pandas")
         py_require(python_version = ">=3.8,<3.14")
         py_require(python_version = "3.11")
-        pkg_py_require(">=3.10")
+        pkg_py_require(packages = c("pandas", "numpy"), python_version = ">=3.10")
+        prefix <- import("sys")$prefix
         import("numpy")
+        import("pandas")
+        stopifnot(py_version() == "3.11")
         py_require(python_version = ">=3.9.1")
         py_require(python_version = ">=3.8.1,<3.14")
         py_require(python_version = "3.11")
-        pkg_py_require(">=3.10")
-        pkg_py_require(">=3.12")
-        py_require(python_version = ">=3.12")
+        pkg_py_require(python_version = ">=3.10")
+        py_require("numpy")
+        py_require("pandas")
+        py_require(c("numpy", "pandas"), action = "set")
+        py_require(c("notexist"), action = "remove")
+        try(import("requests"))
+        py_require("requests")
+        import("requests")
+        prefix2 <- import("sys")$prefix
+        stopifnot(prefix != prefix2)
+        pkg_py_require(python_version = ">=3.12")
+        pkg_py_require("pandas", action = "remove")
+        try(py_require(exclude_newer = "2020-01-01"))
+        try(py_require(python_version = ">=3.12"))
+        try(py_require("pandas", action = "remove"))
       })
     Output
-      > pkg_py_require <- (function(ver) reticulate::py_require(python_version = ver))
-      > environment(pkg_py_require) <- asNamespace("stats")
-      > Sys.setenv(RETICULATE_USE_MANAGED_VENV = "yes")
       > Sys.unsetenv("RETICULATE_PYTHON")
+      > Sys.setenv(RETICULATE_USE_MANAGED_VENV = "yes")
+      > pkg_py_require <- (function(...) reticulate::py_require(...))
+      > environment(pkg_py_require) <- asNamespace("stats")
       > library(reticulate)
-      > py_require(python_version = ">=3.9")
+      > py_require(python_version = ">=3.9", "pandas")
       > py_require(python_version = ">=3.8,<3.14")
       > py_require(python_version = "3.11")
-      > pkg_py_require(">=3.10")
+      > pkg_py_require(packages = c("pandas", "numpy"), python_version = ">=3.10")
+      > prefix <- import("sys")$prefix
       > import("numpy")
       Module(numpy)
+      > import("pandas")
+      Module(pandas)
+      > stopifnot(py_version() == "3.11")
       > py_require(python_version = ">=3.9.1")
       > py_require(python_version = ">=3.8.1,<3.14")
       > py_require(python_version = "3.11")
-      > pkg_py_require(">=3.10")
-      > pkg_py_require(">=3.12")
+      > pkg_py_require(python_version = ">=3.10")
+      > py_require("numpy")
+      > py_require("pandas")
+      > py_require(c("numpy", "pandas"), action = "set")
+      > py_require(c("notexist"), action = "remove")
+      > try(import("requests"))
+      Error in py_module_import(module, convert = convert) : 
+        ModuleNotFoundError: No module named 'requests'
+      Run `reticulate::py_last_error()` for details.
+      > py_require("requests")
+      > import("requests")
+      Module(requests)
+      > prefix2 <- import("sys")$prefix
+      > stopifnot(prefix != prefix2)
+      > pkg_py_require(python_version = ">=3.12")
       Warning message:
-      In reticulate::py_require(python_version = ver) :
+      In reticulate::py_require(...) :
         Python version requirements cannot be changed after Python has been initialized.
       * Python version request: '>=3.12' (from package:stats)
       * Python version initialized: '3.11.11'
-      > py_require(python_version = ">=3.12")
+      > pkg_py_require("pandas", action = "remove")
+      Warning message:
+      In reticulate::py_require(...) :
+        After Python has initialized, only `action = 'add'` is supported.
+      > try(py_require(exclude_newer = "2020-01-01"))
+      Error in py_require(exclude_newer = "2020-01-01") : 
+        `exclude_newer` cannot be changed after Python has initialized.
+      > try(py_require(python_version = ">=3.12"))
       Error in py_require(python_version = ">=3.12") : 
         Python version requirements cannot be changed after Python has been initialized.
       * Python version request: '>=3.12'
       * Python version initialized: '3.11.11'
-      Calls: py_require -> signal_condition
-      Execution halted
+      > try(py_require("pandas", action = "remove"))
+      Error in py_require("pandas", action = "remove") : 
+        After Python has initialized, only `action = 'add'` is supported.
+      > 
       ------- session end -------
-      success: false
-      exit_code: 1
+      success: true
+      exit_code: 0
 
 # Error requesting a package that does not exists
 

--- a/tests/testthat/_snaps/py_require.md
+++ b/tests/testthat/_snaps/py_require.md
@@ -264,7 +264,7 @@
         Python version requirements cannot be changed after Python has been initialized.
       - Python version request: '>=3.12'
       - Python version initialized: '3.11.11'
-      Calls: py_require -> signal
+      Calls: py_require -> signal_condition
       Execution halted
       ------- session end -------
       success: false

--- a/tests/testthat/helper-py-require.R
+++ b/tests/testthat/helper-py-require.R
@@ -19,7 +19,7 @@ r_session <- function(exprs, echo = TRUE, color = FALSE,
     if (echo)
       "options(echo = TRUE)",
     lapply(exprs, deparse)
-    ))
+  ))
 
   writeLines(exprs, file <- tempfile(fileext = ".R"))
   on.exit(unlink(file), add = TRUE)

--- a/tests/testthat/test-py_require.R
+++ b/tests/testthat/test-py_require.R
@@ -35,6 +35,9 @@ test_that("Setting py_require(python_version) after initializing Python ", {
 
     # initialize python
     import("numpy")
+    py_version(patch = TRUE)
+    py_exe()
+    normalizePath(py_exe())
 
     # already satisfied requests are no-ops
     py_require(python_version = ">=3.9.1")
@@ -42,6 +45,9 @@ test_that("Setting py_require(python_version) after initializing Python ", {
     py_require(python_version = "3.11")
     pkg_py_require(">=3.10")
 
+    py_version(patch = TRUE)
+    py_exe()
+    normalizePath(py_exe())
 
     # unsatisfied requests from a package generate a warning
     # (it might make sense to narrow this to target just .onLoad() calls)

--- a/tests/testthat/test-py_require.R
+++ b/tests/testthat/test-py_require.R
@@ -171,26 +171,3 @@ test_that("Multiple py_require() calls from package are shows in one row", {
   }))
 })
 
-
-
-test_that("'Equal to' and 'Non-equal to' Python requirements fail",{
-  if (py_available()) {
-    skip("Can't test py_require(python_version) declarations after python initialized")
-    # TODO: fix test to actually test this
-  }
-
-  test_py_require_reset()
-  py_require(python_version = "==3.11")
-  x <- py_require()
-  expect_equal(x$python_version, "3.11")
-  expect_error(
-    py_require(python_version = ">=3.10"),
-    regexp = "Python version requirements cannot combine"
-    )
-  expect_error(
-    py_require(python_version = "3.10"),
-    regexp = "Python version requirements cannot contain"
-  )
-})
-
-

--- a/tests/testthat/test-py_require.R
+++ b/tests/testthat/test-py_require.R
@@ -24,6 +24,7 @@ test_that("Setting py_require(python_version) after initializing Python ", {
     pkg_py_require <- function(ver)
       reticulate::py_require(python_version = ver)
     environment(pkg_py_require) <- asNamespace("stats")
+    Sys.setenv(RETICULATE_USE_MANAGED_VENV = "yes")
 
     library(reticulate)
 
@@ -35,19 +36,12 @@ test_that("Setting py_require(python_version) after initializing Python ", {
 
     # initialize python
     import("numpy")
-    py_version(patch = TRUE)
-    py_exe()
-    normalizePath(py_exe())
 
     # already satisfied requests are no-ops
     py_require(python_version = ">=3.9.1")
     py_require(python_version = ">=3.8.1,<3.14")
     py_require(python_version = "3.11")
     pkg_py_require(">=3.10")
-
-    py_version(patch = TRUE)
-    py_exe()
-    normalizePath(py_exe())
 
     # unsatisfied requests from a package generate a warning
     # (it might make sense to narrow this to target just .onLoad() calls)

--- a/tests/testthat/test-py_require.R
+++ b/tests/testthat/test-py_require.R
@@ -15,6 +15,46 @@ test_that("Error requesting conflicting package versions", {
   }))
 })
 
+
+test_that("Setting py_require(python_version) after initializing Python ", {
+  test_py_require_reset()
+  local_edition(3)
+
+  expect_snapshot(r_session({
+    pkg_py_require <- function(ver)
+      reticulate::py_require(python_version = ver)
+    environment(pkg_py_require) <- asNamespace("stats")
+
+    library(reticulate)
+
+    # multiple requests are fine
+    py_require(python_version = ">=3.9")
+    py_require(python_version = ">=3.8,<3.14")
+    py_require(python_version = "3.11")
+    pkg_py_require(">=3.10")
+
+    # initialize python
+    import("numpy")
+
+    # already satisfied requests are no-ops
+    py_require(python_version = ">=3.9.1")
+    py_require(python_version = ">=3.8.1,<3.14")
+    py_require(python_version = "3.11")
+    pkg_py_require(">=3.10")
+
+
+    # unsatisfied requests from a package generate a warning
+    # (it might make sense to narrow this to target just .onLoad() calls)
+    pkg_py_require(">=3.12")
+
+    # unsatisfied requests from not a package error
+    py_require(python_version = ">=3.12")
+
+  }))
+
+})
+
+
 test_that("Error requesting newer package version against an older snapshot", {
   session <- r_session(attach_namespace = TRUE, {
     uv_get_or_create_env(
@@ -107,44 +147,6 @@ test_that("Multiple py_require() calls from package are shows in one row", {
   }))
 })
 
-
-test_that("Setting py_require(python_version) after initializing Python ", {
-  test_py_require_reset()
-  local_edition(3)
-
-  expect_snapshot(r_session({
-    pkg_py_require <- function(ver)
-      reticulate::py_require(python_version = ver)
-    environment(pkg_py_require) <- asNamespace("stats")
-
-    library(reticulate)
-
-    # multiple requests are fine
-    py_require(python_version = ">=3.9")
-    py_require(python_version = ">=3.8,<3.14")
-    py_require(python_version = "3.11")
-    pkg_py_require(">=3.10")
-
-    # initialize python
-    import("numpy")
-
-    # already satisfied requests are no-ops
-    py_require(python_version = ">=3.9.1")
-    py_require(python_version = ">=3.8.1,<3.14")
-    py_require(python_version = "3.11")
-    pkg_py_require(">=3.10")
-
-
-    # unsatisfied requests from a package generate a warning
-    # (it might make sense to narrow this to target just .onLoad() calls)
-    pkg_py_require(">=3.12")
-
-    # unsatisfied requests from not a package error
-    py_require(python_version = ">=3.12")
-
-  }))
-
-})
 
 
 test_that("'Equal to' and 'Non-equal to' Python requirements fail",{

--- a/tests/testthat/test-py_require.R
+++ b/tests/testthat/test-py_require.R
@@ -19,12 +19,16 @@ test_that("Error requesting conflicting package versions", {
 test_that("Setting py_require(python_version) after initializing Python ", {
   test_py_require_reset()
   local_edition(3)
+  # dry run to avoid installation messages in snapshot
+  try(uv_get_or_create_env("numpy", "3.11"))
 
   expect_snapshot(r_session({
     pkg_py_require <- function(ver)
       reticulate::py_require(python_version = ver)
     environment(pkg_py_require) <- asNamespace("stats")
-    Sys.setenv(RETICULATE_USE_MANAGED_VENV = "yes")
+    Sys.setenv("RETICULATE_USE_MANAGED_VENV" = "yes")
+    Sys.unsetenv("RETICULATE_PYTHON")
+    # Sys.setenv("RETICULATE_PYTHON"="managed")
 
     library(reticulate)
 


### PR DESCRIPTION
Changes in behavior:

- Don't signal error if called with an already satisfied requirement after Python has been initialized.
- Don't signal error if called with an unsatisfied requirement from a package after Python has been initialized.
-  Don't signal error if called with an unsatisfiable request before Python has been initialized. (Error is deferred until resolving the env, to give an opportunity in user code to proactively fix the requirements.)
-  In `uv_get_or_create_env()`, if python has been initialized, ensure we resolve the initialized python version.
- If an ephemeral uv env is initialized, only `action = "add"` for packages is supported.
- Add `...` to `py_require()` signature, require that `exclude_newer` and `action` are provided as named args. 
- Do not warn or show an error if `py_require()` is called after Python has initialized, but the call produces no actual changes to the requirements (e.g., removing packages that aren't in requirements, or adding packages that are, or setting with an identical set of packages). This allows a script with a `py_require()` call to be rerun in the same R session.
- Revise and expand `?py_require()` 