### PR TITLE
Allow re-running scripts with `exclude_newer` set

### DIFF
--- a/R/py_require.R
+++ b/R/py_require.R
@@ -161,9 +161,16 @@ py_require <- function(packages = NULL,
     if (uv_initialized) {
       switch(action,
         add = {
+
           if(all(packages %in% pr$packages)) {
             packages <- NULL # no-op, skip activating new env
           } else {
+            bare_name <- function(x) sub("^([^[!=><]+).*", "\\1", x)
+            if (any(bare_name(packages) %in% bare_name(pr$packages))) {
+              # e.g., if user calls 'numpy<2' after already initialized with 'numpy>2'
+              signal_condition("After Python has initialized, only `action = 'add'` with new packages is supported.")
+              packages <- NULL
+            }
             pr$packages <- unique(c(packages, pr$packages))
           }
         },

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -120,7 +120,8 @@ py_require <- function(packages = NULL,
 
     if (uv_initialized) {
 
-      signal_condition("`exclude_newer` cannot be changed after Python has initialized.")
+      if (!identical(exclude_newer, pr$exclude_newer))
+        stop("`exclude_newer` cannot be changed after Python has initialized.")
 
     } else {
 

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -549,11 +549,18 @@ uv_get_or_create_env <- function(packages = py_reqs_get("packages"),
     message(paste0(c(shQuote(uv), maybe_shQuote(uv_args)), collapse = " "))
 
   env_python <- suppressWarnings(system2(uv, maybe_shQuote(uv_args), stdout = TRUE))
-  exit_status <- attr(env_python, "status", TRUE) %||% 0L
+  error_code <- attr(env_python, "status", TRUE)
 
-  if (exit_status != 0L) {
+  if (!is.null(error_code)) {
+    cat("uv error code: ", error_code, "\n", sep = "", file = stderr())
     msg <- do.call(py_reqs_format, call_args)
     writeLines(c(msg, strrep("-", 73L)), con = stderr())
+    if (error_code == 2) {
+      cat(
+        "Hint: If you are temporarily offline, try setting `Sys.setenv(UV_OFFLINE=1)`.\n",
+        file = stderr()
+      )
+    }
     stop("Call `py_require()` to remove or replace conflicting requirements.")
   }
 

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -532,11 +532,6 @@ uv_get_or_create_env <- function(packages = py_reqs_get("packages"),
       c(RUST_LOG = NA)
   ))
 
-  # "tool",
-  # "--no-config",
-  # "--isolated",
-  # "--upgrade",
-
   uv_args <- c(
     "run",
     "--no-project",
@@ -549,8 +544,9 @@ uv_get_or_create_env <- function(packages = py_reqs_get("packages"),
     "python", "-c", "import sys; print(sys.executable);"
   )
 
-  ## debug print system call:
-  # message(paste0(c(uv, maybe_shQuote(uv_args)), collapse = " "))
+  # debug print system call
+  if (Sys.getenv("_RETICULATE_DEBUG_UV_") == "1")
+    message(paste0(c(shQuote(uv), maybe_shQuote(uv_args)), collapse = " "))
 
   env_python <- suppressWarnings(system2(uv, maybe_shQuote(uv_args), stdout = TRUE))
   exit_status <- attr(env_python, "status", TRUE) %||% 0L

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -13,8 +13,8 @@
 #' `Sys.setenv(RETICULATE_USE_MANAGED_VENV = "yes")`.
 #'
 #' The ephemeral virtual environment is not created until the user interacts
-#' with Python for the first time in the R session. Typically, this occurs when
-#' `import()` is first called.
+#' with Python for the first time in the R session, typically when `import()` is
+#' first called.
 #'
 #' If `py_require()` is called with new requirements after reticulate has
 #' already initialized an ephemeral Python environment, a new ephemeral
@@ -25,17 +25,17 @@
 #' Calling `py_require()` without arguments returns a list of the currently
 #' declared requirements.
 #'
-#' `py_require()` can also be called by R packages (e.g., in `.onLoad()` or
-#' elsewhere) to declare Python dependencies. The print method for
-#' `py_require()` displays the Python dependencies declared by R packages in the
-#' current session.
+#' R packages can also call `py_require()` (e.g., in `.onLoad()` or elsewhere)
+#' to declare Python dependencies. The print method for `py_require()` displays
+#' the Python dependencies declared by R packages in the current session.
 #'
 #' @note Reticulate uses [`uv`](https://docs.astral.sh/uv/) to resolve Python
 #'   dependencies. Many `uv` options can be customized via environment
 #'   variables, as described
-#'   [here](https://docs.astral.sh/uv/configuration/environment/). For example,
-#'   you can set `Sys.setenv(UV_OFFLINE=1)` or `Sys.setenv(UV_INDEX =
-#'   "https://download.pytorch.org/whl/cpu")`.
+#'   [here](https://docs.astral.sh/uv/configuration/environment/). For example:
+#'   - If temporarily offline, set `Sys.setenv(UV_OFFLINE=1)`.
+#'   - To use a different index: `Sys.setenv(UV_INDEX = "https://download.pytorch.org/whl/cpu")`.
+#'   - To allow resolving a prerelease dependency: `Sys.setenv(UV_PRERELEASE="allow")`.
 #'
 #' @param packages A character vector of Python packages to be available during
 #'   the session. These can be simple package names like `"jax"` or names with
@@ -44,21 +44,22 @@
 #' @param python_version A character vector of Python version constraints \cr
 #'   (e.g., `"3.10"` or `">=3.9,<3.13,!=3.11"`).
 #'
-#' @param ... Dots are for future extensions, must be empty.
+#' @param ... Reserved for future extensions; must be empty.
 #'
-#' @param action Defines how `py_require()` handles the provided requirements.
-#'   Options are:
-#'   - `add`: Add the entries to the current set of requirements.
-#'   - `remove`: Remove exact matches from the requirements list. For example, if
-#'   `"numpy==2.2.2"` is in the list, passing `"numpy"` with `action = "remove"`
-#'   will not remove it. Requests to remove nonexistent entries are ignored.
-#'   - `set`: Clear all existing requirements and replaces them with the
+#' @param action Determines how `py_require()` processes the provided
+#'   requirements. Options are:
+#'   - `add`: Adds the entries to the current set of requirements.
+#'   - `remove`: Removes__exact_ matches from the requirements list. For example,
+#'   if `"numpy==2.2.2"` is in the list, passing `"numpy"` with `action =
+#'   "remove"` will not remove it. Requests to remove nonexistent entries are
+#'   ignored.
+#'   - `set`: Clears all existing requirements and replaces them with the
 #'   provided ones. Packages and the Python version can be set independently.
 #'
 #' @param exclude_newer Restricts package versions to those published before a
 #'   specified date. This offers a lightweight alternative to freezing package
-#'   versions, to guard against future published package versions breaking a
-#'   workflow. Once  `exclude_newer` is set, only the `set` action can override
+#'   versions, helping guard against Python package updates that break a
+#'   workflow. Once `exclude_newer` is set, only the `set` action can override
 #'   it.
 #'
 #' @export

--- a/man/py_require.Rd
+++ b/man/py_require.Rd
@@ -20,22 +20,22 @@ version constraints like \code{"jax[cpu]>=0.5"}.}
 \item{python_version}{A character vector of Python version constraints \cr
 (e.g., \code{"3.10"} or \code{">=3.9,<3.13,!=3.11"}).}
 
-\item{...}{Dots are for future extensions, must be empty.}
+\item{...}{Reserved for future extensions; must be empty.}
 
 \item{exclude_newer}{Restricts package versions to those published before a
 specified date. This offers a lightweight alternative to freezing package
-versions, to guard against future published package versions breaking a
-workflow. Once  \code{exclude_newer} is set, only the \code{set} action can override
+versions, helping guard against Python package updates that break a
+workflow. Once \code{exclude_newer} is set, only the \code{set} action can override
 it.}
 
-\item{action}{Defines how \code{py_require()} handles the provided requirements.
-Options are:
+\item{action}{Determines how \code{py_require()} processes the provided
+requirements. Options are:
 \itemize{
-\item \code{add}: Add the entries to the current set of requirements.
-\item \code{remove}: Remove exact matches from the requirements list. For example, if
-\code{"numpy==2.2.2"} is in the list, passing \code{"numpy"} with \code{action = "remove"}
-will not remove it. Requests to remove nonexistent entries are ignored.
-\item \code{set}: Clear all existing requirements and replaces them with the
+\item \code{add}: Adds the entries to the current set of requirements.
+\item \code{remove}: Removes__exact_ matches from the requirements list. For example,
+if \code{"numpy==2.2.2"} is in the list, passing \code{"numpy"} with \code{action =   "remove"} will not remove it. Requests to remove nonexistent entries are
+ignored.
+\item \code{set}: Clears all existing requirements and replaces them with the
 provided ones. Packages and the Python version can be set independently.
 }}
 }
@@ -53,8 +53,8 @@ You can also force reticulate to use an ephemeral environment by setting
 \code{Sys.setenv(RETICULATE_USE_MANAGED_VENV = "yes")}.
 
 The ephemeral virtual environment is not created until the user interacts
-with Python for the first time in the R session. Typically, this occurs when
-\code{import()} is first called.
+with Python for the first time in the R session, typically when \code{import()} is
+first called.
 
 If \code{py_require()} is called with new requirements after reticulate has
 already initialized an ephemeral Python environment, a new ephemeral
@@ -65,15 +65,18 @@ the Python version, or modifying \code{exclude_newer} is not possible.
 Calling \code{py_require()} without arguments returns a list of the currently
 declared requirements.
 
-\code{py_require()} can also be called by R packages (e.g., in \code{.onLoad()} or
-elsewhere) to declare Python dependencies. The print method for
-\code{py_require()} displays the Python dependencies declared by R packages in the
-current session.
+R packages can also call \code{py_require()} (e.g., in \code{.onLoad()} or elsewhere)
+to declare Python dependencies. The print method for \code{py_require()} displays
+the Python dependencies declared by R packages in the current session.
 }
 \note{
 Reticulate uses \href{https://docs.astral.sh/uv/}{\code{uv}} to resolve Python
 dependencies. Many \code{uv} options can be customized via environment
 variables, as described
-\href{https://docs.astral.sh/uv/configuration/environment/}{here}. For example,
-you can set \code{Sys.setenv(UV_OFFLINE=1)} or \code{Sys.setenv(UV_INDEX = "https://download.pytorch.org/whl/cpu")}.
+\href{https://docs.astral.sh/uv/configuration/environment/}{here}. For example:
+\itemize{
+\item If temporarily offline, set \code{Sys.setenv(UV_OFFLINE=1)}.
+\item To use a different index: \code{Sys.setenv(UV_INDEX = "https://download.pytorch.org/whl/cpu")}.
+\item To allow resolving a prerelease dependency: \code{Sys.setenv(UV_PRERELEASE="allow")}.
+}
 }

--- a/tests/testthat/_snaps/py_require.md
+++ b/tests/testthat/_snaps/py_require.md
@@ -13,6 +13,7 @@
         × No solution found when resolving `--with` dependencies:
         ╰─▶ Because you require numpy<2 and numpy>=2, we can conclude that your
             requirements are unsatisfiable.
+      uv error code: 1
       -- Current requirements -------------------------------------------------
        Python:   3.11.11 (reticulate default)
        Packages: numpy, numpy<2, numpy>=2
@@ -132,6 +133,7 @@
         × No solution found when resolving `--with` dependencies:
         ╰─▶ Because notexists was not found in the package registry and you require
             notexists, we can conclude that your requirements are unsatisfiable.
+      uv error code: 1
       -- Current requirements -------------------------------------------------
        Python:   3.11.11 (reticulate default)
        Packages: numpy, pandas, notexists


### PR DESCRIPTION
This PR
- Allows rerunning scripts with (unchanged) `py_require(exclude_newer =)` calls
- Discusses `UV_OFFLINE` and `UV_PRERELEASE` envvars in the docs and error hints
- Adds a guardrail to error if user attempts to change a package version after it has already been loaded.