### PR TITLE
Focus Python Console with`repl_python(input)` in Positron.

### DIFF
--- a/R/repl.R
+++ b/R/repl.R
@@ -91,11 +91,10 @@ repl_python <- function(
 
 
   ensure_python_initialized()
-  if (is.null(input) &&
-      is_positron() &&
+  if (is_positron() &&
       exists(".ps.reticulate_open", inherits = TRUE)) {
 
-    eval(call(".ps.reticulate_open"))
+    eval(call(".ps.reticulate_open", input))
 
     # TODO: seems we need to rerun py_inject_r(), possibly other init hooks.
     # TODO: kernal initializion drops pre-existing objects in __main__


### PR DESCRIPTION
Add support for passing input via `repl_python(input)` to the Positron REPL.

This is the mechanism used by the Quarto extension in Positron.

Companion PR: https://github.com/posit-dev/ark/pull/713