### PR TITLE
Bootstrap unmanaged uv installation

### DIFF
--- a/R/py_require.R
+++ b/R/py_require.R
@@ -74,6 +74,17 @@
 #'   [here](https://docs.astral.sh/uv/pip/packages/#installing-a-package) and
 #'   [here](https://pip.pypa.io/en/stable/cli/pip_install/#examples).
 #'
+#'
+#'   ## Clearing the Cache
+#'
+#'   `reticulate` caches ephemeral environments in the directory returned by
+#'   `tools::R_user_dir("reticulate", "cache")`. To clear the cache, delete the
+#'   directory:
+#'
+#'   ```r
+#'   unlink(tools::R_user_dir("reticulate", "cache"), recursive = TRUE)
+#'   ```
+#'
 #' @param packages A character vector of Python packages to be available during
 #'   the session. These can be simple package names like `"jax"` or names with
 #'   version constraints like `"jax[cpu]>=0.5"`. Pip style syntax for installing

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -522,10 +522,17 @@ uv_binary <- function(bootstrap_install = TRUE) {
   }
 
   uv <- reticulate_cache_dir("uv", "bin", if (is_windows()) "uv.exe" else "uv")
-  if (file.exists(uv)) {
-    if (!is_usable_uv(uv)) # exists, but version too old
-      system2(uv, "self update")
+  if (is_usable_uv(uv))
     return(uv)
+
+  if (file.exists(uv)) {
+    # exists, but version too old
+    unlink(dirname(uv), recursive = TRUE)
+    ## We don't do `system2(uv, "self update")` because self update is only
+    ## supported on a "managed" uv installations, and uv only supports one
+    ## managed installation per system. uv installs and maintains a config file
+    ## for the auto updater in XDG_CONFIG_DIRS/uv/uv-receipt.json and errors if
+    ## multiple uv installations attempt to modify that config file.
   }
 
   if (bootstrap_install) {
@@ -542,12 +549,10 @@ uv_binary <- function(bootstrap_install = TRUE) {
 
     if (is_windows()) {
       system2("powershell", c(
-        "-ExecutionPolicy",
-        "ByPass",
+        "-ExecutionPolicy", "ByPass",
         "-c",
         paste0(
-          "$env:UV_INSTALL_DIR='", dirname(uv), "';",
-          "$env:INSTALLER_NO_MODIFY_PATH= 1;",
+          "$env:UV_UNMANAGED_INSTALL='", dirname(uv), "';", # shQuote()?
           # 'Out-Null' makes installation silent
           "irm ", install_uv, " | iex *> Out-Null"
         )
@@ -557,8 +562,7 @@ uv_binary <- function(bootstrap_install = TRUE) {
       dir.create(dirname(uv), showWarnings = FALSE, recursive = TRUE)
       system2(install_uv, c("--quiet"),
         env = c(
-          "INSTALLER_NO_MODIFY_PATH=1",
-          paste0("UV_INSTALL_DIR=", maybe_shQuote(dirname(uv)))
+          paste0("UV_UNMANAGED_INSTALL=", maybe_shQuote(dirname(uv)))
         )
       )
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -654,8 +654,8 @@ rm_all_reticulate_state <- function(external = FALSE) {
       system2(uv, c("cache", "clean"))
       rm_rf(system2(uv, c("python", "dir"),
                     env = "NO_COLOR=1", stdout = TRUE))
-      # rm_rf(system2(uv, c("tool", "dir"),
-      #               env = "NO_COLOR=1", stdout = TRUE))
+      rm_rf(system2(uv, c("tool", "dir"),
+                    env = "NO_COLOR=1", stdout = TRUE))
     }
 
     if (nzchar(Sys.which("pip3")))
@@ -676,6 +676,7 @@ rm_all_reticulate_state <- function(external = FALSE) {
   try(tools::R_user_dir("reticulate", "cache"))
   try(tools::R_user_dir("reticulate", "data"))
   try(tools::R_user_dir("reticulate", "config"))
+  invisible()
 }
 
 

--- a/man/py_require.Rd
+++ b/man/py_require.Rd
@@ -126,4 +126,14 @@ See more examples
 \href{https://docs.astral.sh/uv/pip/packages/#installing-a-package}{here} and
 \href{https://pip.pypa.io/en/stable/cli/pip_install/#examples}{here}.
 }
+
+\subsection{Clearing the Cache}{
+
+\code{reticulate} caches ephemeral environments in the directory returned by
+\code{tools::R_user_dir("reticulate", "cache")}. To clear the cache, delete the
+directory:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{unlink(tools::R_user_dir("reticulate", "cache"), recursive = TRUE)
+}\if{html}{\out{</div>}}
+}
 }

--- a/vignettes/package.Rmd
+++ b/vignettes/package.Rmd
@@ -61,15 +61,15 @@ use_backend <- function(backend, gpu = TRUE) {
   py_require("tensorflow", action = "remove") # Remove default backend
 
   switch(paste0(backend, "_", get_os()),
-    Linux_jax = if (gpu) py_require("jax[cuda12]") else py_require("jax[cpu]"),
-    macOS_jax = py_require(c("jax", if (gpu) "jax-metal")),
-    Windows_jax = py_require("jax"),
-    Linux_tensorflow = { ... },
-    macOS_tensorflow = { ... },
-    Windows_tensorflow = { ... },
-    Linux_torch = { ... },
-    macOS_torch = { ... },
-    Windows_torch = { ... }
+    jax_Linux = if (gpu) py_require("jax[cuda12]") else py_require("jax[cpu]"),
+    jax_macOS = py_require(c("jax", if (gpu) "jax-metal")),
+    jax_Windows = py_require("jax"),
+    tensorflow_Linux = { ... },
+    tensorflow_macOS = { ... },
+    tensorflow_Windows = { ... },
+    torch_Linux = { ... },
+    torch_macOS = { ... },
+    torch_Windows = { ... }
   )
 }
 ```


### PR DESCRIPTION
I noticed that `uv self update` will fail if there are multiple self-updating-capable uv installations on a system.

Typically, if a `uv` is already installed, reticulate will use that. reticulate only bootstraps a uv installation into its cache dir if `uv` is not found.

However, before this PR, if user installs uv manually after reticulate has bootstraped an installation, then `self update` will later error with:

```
warning: Self-update is only available for uv binaries installed via the standalone installation scripts.

If you installed uv with pip, brew, or another package manager, update uv with `pip install --upgrade`, `brew upgrade`, or similar.
```

This is because the self-updater checks the `.config/uv/uv-receipt.json`, which is written to by install scripts unless self-updating is disabled. 

This PR switches to bootstrapping the installation with `UV_UNMANAGED_INSTALL` set.