### PR TITLE
Misc Windows fixes

### DIFF
--- a/R/py_require.R
+++ b/R/py_require.R
@@ -752,6 +752,15 @@ uv_python_list <- function(uv = uv_binary()) {
   x
 }
 
+uvx_binary <- function(...) {
+  uv <- uv_binary(...)
+  if(is.null(uv)) {
+    return()
+  }
+  uvx <- file.path(dirname(uv), if (is_windows()) "uvx.exe" else "uvx")
+  if (file.exists(uvx)) uvx else NULL # print visible
+}
+
 resolve_python_version <- function(constraints = NULL, uv = uv_binary()) {
   constraints <- as.character(constraints %||% "")
   constraints <- trimws(unlist(strsplit(constraints, ",", fixed = TRUE)))

--- a/R/utils.R
+++ b/R/utils.R
@@ -647,15 +647,15 @@ maybe_shQuote <- function(x) {
 rm_all_reticulate_state <- function(external = FALSE) {
 
   rm_rf <- function(...)
-    unlink(path.expand(c(...)), recursive = TRUE, force = TRUE)
+    try(unlink(path.expand(c(...)), recursive = TRUE, force = TRUE))
 
   if (external) {
     if (!is.null(uv <- uv_binary(FALSE))) {
       system2(uv, c("cache", "clean"))
-      rm_rf(system2(uv, c("python", "dir"),
-                    env = "NO_COLOR=1", stdout = TRUE))
-      rm_rf(system2(uv, c("tool", "dir"),
-                    env = "NO_COLOR=1", stdout = TRUE))
+      withr::with_envvar(c("NO_COLOR"="1"), {
+        rm_rf(system2(uv, c("python", "dir"), stdout = TRUE))
+        rm_rf(system2(uv, c("tool", "dir"), stdout = TRUE))
+      })
     }
 
     if (nzchar(Sys.which("pip3")))
@@ -670,12 +670,12 @@ rm_all_reticulate_state <- function(external = FALSE) {
   rm_rf(virtualenv_path("r-reticulate"))
   for (venv in virtualenv_list()) {
     if (startsWith(venv, "r-"))
-      virtualenv_remove(venv, confirm = FALSE)
+      rm_rf(virtualenv_path(venv))
   }
   rm_rf(reticulate_cache_dir())
-  try(tools::R_user_dir("reticulate", "cache"))
-  try(tools::R_user_dir("reticulate", "data"))
-  try(tools::R_user_dir("reticulate", "config"))
+  rm_rf(tools::R_user_dir("reticulate", "cache"))
+  rm_rf(tools::R_user_dir("reticulate", "data"))
+  rm_rf(tools::R_user_dir("reticulate", "config"))
   invisible()
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -687,7 +687,7 @@ reticulate_cache_dir <- function(...) {
     path.expand(rappdirs::user_cache_dir("r-reticulate", NULL))
   }
 
-  file.path(root, ...)
+  normalizePath(file.path(root, ...), mustWork = FALSE)
 }
 
 


### PR DESCRIPTION
I tested out `py_require()` on Windows and noticed a few issues:

1. `uv` writes progress updates to stdout on Windows. This interfered with our ability to resolve the path to the ephemeral python, since we expected stdout to contain just the filepath.

   To fix, I refactored `uv_get_or_create()` to pass through both stderr and stdout from uv, and write the python executable path to a temporary file instead of stdout.

2. The codepath that installed uv produced a file named 'Out-Null' in the current working directory. 

   To fix, I refactored the `system2()` call to use `stdout=FALSE`


4. The codepath that installed uv didn't seem to handle paths or mixed \/ in the file correctly. 

   Rather than think to hard about how quoting needs to happen for cmd.exe calling powershell, I refactored the installer to pass filepaths via an envvar, and also, use `shortPathName()`.

