### PR TITLE
Fixes to print method for py_require()

### DIFF
--- a/R/py_require.R
+++ b/R/py_require.R
@@ -299,7 +299,17 @@ print.python_requirements <- function(x, ...) {
   }
   python_version <- x$python_version
   if (is.null(python_version)) {
-    python_version <- paste0("[No Python version specified. Will default to '", resolve_python_version() , "']")
+    if(is_epheremal_venv_initialized()) {
+      python_version <- paste0(
+        "[No Python version specified. Defaulted to '",
+        resolve_python_version() , "']"
+      )
+    } else {
+      python_version <- paste0(
+        "[No Python version specified. Will default to '",
+        resolve_python_version() , "']"
+      )
+    }
   }
 
   requested_from <- as.character(lapply(x$history, function(x) x$requested_from))
@@ -362,6 +372,11 @@ print.python_requirements <- function(x, ...) {
 # Python requirements - utils --------------------------------------------------
 
 py_reqs_pad <- function(x = "", len, use_cli, is_title = FALSE) {
+
+  if(nchar(x) > len) {
+    x <- paste0(substr(x, 1, len-3), "...")
+  }
+
   padding <- paste0(rep(" ", len - nchar(x)), collapse = "")
   ret <- paste0(x, padding)
   if (use_cli) {

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -471,7 +471,11 @@ py_reqs_format <- function(packages = NULL,
       paste0(" ", python, "   ", python_version)
     },
     if (!is.null(packages)) {
-      pkg_lines <- strwrap(paste0(packages, collapse = ", "), 60)
+      tbl_width <- 60
+      long_pkgs <- nchar(packages) > tbl_width
+      packages[long_pkgs] <- substr(packages[long_pkgs], 1, tbl_width - 3)
+      packages[long_pkgs] <- paste0(packages[long_pkgs], "...")
+      pkg_lines <- strwrap(paste0(packages, collapse = ", "), tbl_width)
       pkgs <- "Packages:"
       if (use_cli) {
         pkgs <- cli::col_blue(pkgs)


### PR DESCRIPTION
It truncates the package name if it's longer than the designated borders. It will shorten it enough to also prepend "..." to try to clarify that the name is shortened  

```r
> library(tensorflow)
> library(ragnar)
> reticulate::py_require()
══════════════════════════ Python requirements ══════════════════════════
── Current requirements ─────────────────────────────────────────────────
 Python:   >=3.9, <3.13
 Packages: numpy, tensorflow,
           markitdown@git+https://github.com/microsoft/markitdown.gi...
── R package requests ───────────────────────────────────────────────────
R package  Python packages                           Python version      
reticulate numpy                                                         
tensorflow tensorflow                                >=3.9, <3.13        
ragnar     markitdown@git+https://github.com/micro...               
```

The Python version message changes if Python is loaded:

```r
> reticulate::import("numpy")
Installed 56 packages in 151ms
Module(numpy)
> reticulate::py_require()
══════════════════════════ Python requirements ══════════════════════════
── Current requirements ─────────────────────────────────────────────────
 Python:   [No Python version specified. Defaulted to '3.11.11']
 Packages: numpy,
           markitdown@git+https://github.com/microsoft/markitdown.gi...
── R package requests ───────────────────────────────────────────────────
R package  Python packages                           Python version      
reticulate numpy                                                         
ragnar     markitdown@git+https://github.com/micro...   
```

Still says "Will default..` if no Python is initialized:

```r
> reticulate::py_require()
══════════════════════════ Python requirements ══════════════════════════
── Current requirements ─────────────────────────────────────────────────
 Python:   [No Python version specified. Will default to '3.11.11']
 Packages: numpy,
           markitdown@git+https://github.com/microsoft/markitdown.gi...
── R package requests ───────────────────────────────────────────────────
R package  Python packages                           Python version      
reticulate numpy                                                         
ragnar     markitdown@git+https://github.com/micro...    
```