### PR TITLE
Accommodate changing definition of `Rf_error()`

### DIFF
--- a/src/tinythread.h
+++ b/src/tinythread.h
@@ -30,7 +30,7 @@ freely, subject to the following restrictions:
 #ifndef _TINYTHREAD_H_
 #define _TINYTHREAD_H_
 
-extern "C" void Rf_error(const char* fmt, ...);
+#include <R_ext/Error.h>  // for Rf_error()
 
 /// @file
 /// @mainpage TinyThread++ API Reference


### PR DESCRIPTION
Fix for issue reported via email:


> ```
> **********************************************************************
> From an attempt to add 'noreturn' in C++ as well as C:
> 
> In file included from pending_py_calls_notifier.cpp:14:
> In file included from /Users/ripley/R/R-devel/include/R.h:73:
> /Users/ripley/R/R-devel/include/R_ext/Error.h:65:3: error: 'noreturn' attribute
> does not appear on the first declaration
>   65 | [[noreturn]] void Rf_error(const char *, ...) R_PRINTF_FORMAT(1, 2);
>      |   ^
> ./tinythread.h:33:17: note: previous declaration is here
>   33 | extern "C" void Rf_error(const char* fmt, ...);
>      |                 ^
> 1 error generated.
> 
> Please use one or the other, preferably the R header.
> **********************************************************************
> ```