### PR TITLE
Resolve `oldlibpath` even if nothing to set.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,8 @@
 
 - Internal fixes to prevent reticulate-managed `uv` from writing outside
   reticulates cache directory (#1745).
+  
+- Fixed an issue with pointing reticulate at a pyenv shim python (#1758)
 
 # reticulate 1.41.0
 

--- a/R/config.R
+++ b/R/config.R
@@ -774,8 +774,8 @@ prefix_python_lib_to_ld_library_path <- function(python) {
   python <- c(python, normalizePath(python, mustWork = FALSE))
   libpath <- file.path(dirname(dirname(python)), "lib")
   libpath <- libpath[file.exists(libpath)]
+  oldlibpath <- Sys.getenv("LD_LIBRARY_PATH", unset = NA)
   if (length(libpath)) {
-    oldlibpath <- Sys.getenv("LD_LIBRARY_PATH", unset = NA)
     newlibpath <- paste0(c(libpath, oldlibpath), collapse = ":")
     Sys.setenv(LD_LIBRARY_PATH = newlibpath)
   }


### PR DESCRIPTION
Fix #1758