### PR TITLE
Make sure `py_run_on_thread` knows its initializing PositronIPyKernel

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -111,6 +111,7 @@ import_positron_ipykernel_inspectors <- function() {
     return (NULL)
 
   # in 2025.03 release, inspectors module moved to here
+  # NOTE: Update `py_run_file_on_thread` when changing here
   tryCatch({
     .ps.ui.executeCommand <- get(".ps.ui.executeCommand", globalenv())
     ipykernel_path <- .ps.ui.executeCommand("positron.reticulate.getIPykernelPath")


### PR DESCRIPTION
This fixes the disappearing `r` object in the reticulate python console in Positron.
The problem is that with some folder renaming in Positron we were silently running the script without the workarounds to make `r` correcly appear in the console.
We should definitely update positron to call a dedicated entrypoint so we never silently fail when other file structure refactoring happens.

Opened https://github.com/posit-dev/positron/issues/6788 to track this issue.
 