### PR TITLE
`py_install()`: fix warning message `py_require()` suggestion

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -97,7 +97,7 @@ py_install <- function(packages,
       "To add more packages to your current session, call `py_require()` instead\n",
       "of `py_install()`. Running:\n  ",
       paste0(
-        "`py_require(", paste0(sprintf("\"%s\"", packages), collapse = ", "), ")`"
+        "`py_require(c(", paste0(sprintf("\"%s\"", packages), collapse = ", "), "))`"
       )
     )
     py_require(packages)


### PR DESCRIPTION
This PR fixes a typo in the `py_install()` warning message suggested code: the set of packages is now all in one character vector passed as the first argument to `py_require()`.