### PR TITLE
R non-API updates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,7 +23,7 @@
   described in the "Using reticulate in an R package vignette" (#1754).
   https://rstudio.github.io/reticulate/articles/package.html
 
-- Internal changes to support R-devel (4.5) (#1747).
+- Internal changes to support R-devel (4.5) and R API updates (#1747, #1774).
 
 - Internal fixes to prevent reticulate-managed `uv` from writing outside
   reticulates cache directory (#1745).

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -1421,7 +1421,7 @@ SEXP py_to_r_cpp(PyObject* x, bool convert, bool simple = true);
 //' @keywords internal
 // [[Rcpp::export]]
 bool is_py_object(SEXP x) {
-  if(OBJECT(x)) {
+  if(Rf_isObject(x)) {
     switch (TYPEOF(x)) {
     case ENVSXP:
     case CLOSXP:
@@ -2211,7 +2211,7 @@ PyObject* r_to_py_cpp(RObject x, bool convert);
 // returns a new reference
 PyObject* r_to_py(RObject x, bool convert) {
   // if the object bit is not set, we can skip R dispatch
-  if (OBJECT(x) == 0)
+  if (Rf_isObject(x) == 0)
     return r_to_py_cpp(x, convert);
 
   if(is_py_object(x)) {
@@ -4410,7 +4410,7 @@ PyObjectRef r_convert_dataframe(RObject dataframe, bool convert) {
 
     int status = 0;
 
-    if (OBJECT(column) != 0) {
+    if (Rf_isObject(column) != 0) {
       // An object with a class attribute, we dispatch to the S3 method
       // and continue to the next column.
       // see comment in r_to_py() for why indirection in constructor is needed.
@@ -4772,7 +4772,7 @@ SEXP py_iterate(PyObjectRef x, Function f, bool simplify = true) {
           {
               SEXP item = list[i];
               if (TYPEOF(item) != outType ||
-                  OBJECT(item) ||
+                  Rf_isObject(item) ||
                   Rf_length(item) != 1)
               {
                   outType = VECSXP;

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -918,7 +918,7 @@ void py_validate_xptr(PyObjectRef x)
 }
 
 bool option_is_true(const std::string& name) {
-  SEXP valueSEXP = Rf_GetOption(Rf_install(name.c_str()), R_BaseEnv);
+  SEXP valueSEXP = Rf_GetOption1(Rf_install(name.c_str()));
   return Rf_isLogical(valueSEXP) && (as<bool>(valueSEXP) == true);
 }
 


### PR DESCRIPTION
Fixes for the current CRAN Note:

```
Version: 1.41.0.1
Check: compiled code
Result: NOTE
  File ‘reticulate/libs/reticulate.so’:
    Found non-API calls to R: ‘OBJECT’, ‘Rf_GetOption’
  
  Compiled code should not call non-API entry points in R.
  
  See ‘Writing portable packages’ in the ‘Writing R Extensions’ manual,
  and section ‘Moving into C API compliance’ for issues with the use of
  non-API entry points.
```