### PR TITLE
Fix normalizePath null call with missing conda

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,9 @@
 - Fixed error in `install_python()` under R 4.5 when the requested Python
   version has a `":latest"` suffix, as it does by default. (#1792, #1797)
 
+- Fixed error in `get_python_conda_info()` when conda not found through `conda-meta/history` 
+  and `NULL` is passed to `normalizePath` (#1184)
+
 # reticulate 1.42.0
 
 - Fixed an issue in RStudio on Windows where interrupts were

--- a/R/conda.R
+++ b/R/conda.R
@@ -1133,9 +1133,13 @@ get_python_conda_info <- function(python) {
     }
   }
 
-  conda <- normalizePath(conda, winslash = "/", mustWork = FALSE)
-  if(!file.exists(conda))
+  if (is.null(conda)) {
     conda <- NA
+  } else {
+    conda <- normalizePath(conda, winslash = "/", mustWork = FALSE)
+    if(!file.exists(conda))
+      conda <- NA
+  }
 
   list(
     conda = conda,


### PR DESCRIPTION
I was trying to use reticulate with a pixi env which only populates `conda-meta/history` with

```
// not relevant for pixi but for `conda run -p`
```

I have `options(reticulate.conda_binary = conda)` set to a copy of `micromamba.exe` to handle the conda related operations but when `use_python` tries to get the conda root/binary info it passes `NULL` to `normalizePath` if it can't find conda automatically, which causes the following error `Error in path.expand(path) : invalid 'path' argument` which is mentioned in https://github.com/rstudio/reticulate/issues/1184

```
 1: source("src/r/conda.R")
 2: withVisible(eval(ei, envir))
 3: eval(ei, envir)
 4: eval(ei, envir)
 5: conda.R#9: use_python(pixi_env, required = TRUE)
 6: python_config(python)
 7: python_munge_path(python)
 8: get_python_conda_info(python)
 9: normalizePath(conda, winslash = "/", mustWork = FALSE)
10: path.expand(path)
```

Related issue:
https://github.com/rstudio/reticulate/issues/1650

