### PR TITLE
Faster uv list

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,11 @@
 - Fixed error in `get_python_conda_info()` when conda not found through `conda-meta/history` 
   and `NULL` is passed to `normalizePath` (#1184)
 
+- `uv_python_list()` now tries managed python environments before system-installed
+  Python environments. This makes it much faster as system discovery can be slow. 
+  Users can still control their preference using the `UV_PYTHON_PREFERENCE` environment
+  variable. (#1810)
+
 # reticulate 1.42.0
 
 - Fixed an issue in RStudio on Windows where interrupts were

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -840,21 +840,19 @@ is_reticulate_managed_uv <- function(uv = uv_binary(bootstrap_install = FALSE)) 
 
 # return a dataframe of python options sorted by default reticulate preference
 uv_python_list <- function(uv = uv_binary(), python_preference = NULL) {
-
   if (isTRUE(attr(uv, "reticulate-managed", TRUE)))
     withr::local_envvar(c(
       UV_CACHE_DIR = reticulate_cache_dir("uv", "cache"),
       UV_PYTHON_INSTALL_DIR = reticulate_cache_dir("uv", "python")
     ))
   
-  # if (is.null(uv) || !file.exists(uv)) {
   if (Sys.getenv("_RETICULATE_DEBUG_UV_") == "1")
     system2 <- system2t
 
   withr::local_envvar(c(
     UV_PYTHON_PREFERENCE = python_preference %||% Sys.getenv("UV_PYTHON_PREFERENCE", "only-managed")
   ))
-  
+
   x <- system2(uv, c("python list",
       "--all-versions",
       "--color never",

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -839,36 +839,49 @@ is_reticulate_managed_uv <- function(uv = uv_binary(bootstrap_install = FALSE)) 
 
 
 # return a dataframe of python options sorted by default reticulate preference
-uv_python_list <- function(uv = uv_binary(), python_preference = NULL) {
+uv_python_list <- function(
+  uv = uv_binary(),
+  python_preference = Sys.getenv("UV_PYTHON_PREFERENCE", "only-managed")
+) {
   if (isTRUE(attr(uv, "reticulate-managed", TRUE)))
     withr::local_envvar(c(
       UV_CACHE_DIR = reticulate_cache_dir("uv", "cache"),
       UV_PYTHON_INSTALL_DIR = reticulate_cache_dir("uv", "python")
     ))
-  
+
+
   if (Sys.getenv("_RETICULATE_DEBUG_UV_") == "1")
     system2 <- system2t
 
-  
-  x <- withr::with_envvar(
-    c(
-      UV_PYTHON_PREFERENCE = python_preference %||% Sys.getenv("UV_PYTHON_PREFERENCE", "only-managed")
+  # valid values of python_preference are: only-managed, managed, system, only-system
+  # https://docs.astral.sh/uv/reference/settings/#python-preference
+  if (python_preference != "only-managed") {
+    # uv does not find many pythons that are found by `virtualenv_starter(all=T)`,
+    # including pythons installed by `install_python()`
+    # To help uv find them, we temporarily place them on the PATH.
+    withr::local_path(
+      dirname(virtualenv_starter(all = TRUE)$path),
+      action = "suffix"
+    )
+  }
+
+  x <- system2(uv, c(
+    "python list",
+    "--all-versions",
+    "--color never",
+    "--output-format json",
+    "--python-preference ", python_preference
     ),
-    {
-      system2(uv, c("python list",
-          "--all-versions",
-          "--color never",
-          "--output-format json"
-        ),
-        stdout = TRUE
-      )
-    }
+    stdout = TRUE
   )
- 
+
   x <- paste0(x, collapse = "")
   x <- jsonlite::parse_json(x, simplifyVector = TRUE)
-  if (!length(x) && is.null(python_preference) && !nzchar(Sys.getenv("UV_PYTHON_PREFERENCE", ""))) {
-    return(uv_python_list(uv, python_preference = "only-system"))
+
+  if (!length(x) &&
+        missing(python_preference) &&
+        is.na(Sys.getenv("UV_PYTHON_PREFERENCE", NA))) {
+    return(uv_python_list(uv, "only-system"))
   }
 
   x <- x[is.na(x$symlink) , ]             # ignore local filesystem symlinks


### PR DESCRIPTION
uv list can be slow on some systems. With this PR we use `only-managed` by default and only fallback to system python installations if no managed python is found which is required by some systems, see https://github.com/rstudio/reticulate/pull/1752/files

```
> system.time({uv_python_list()})
   user  system elapsed 
  0.016   0.022   0.089 
> system.time(uv_python_list(python_preference = "only-system"))
   user  system elapsed 
  0.994   1.340   5.977 
```