### PR TITLE
Support uv version >=0.8

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # reticulate (development version)
 
+- Restored compatability with `uv` versions >= 0.8.0 (#1818).
+
 # reticulate 1.43.0
 
 - Fixed usage of micromamba and mamba, next-generation conda environment management tools.
@@ -14,14 +16,14 @@
 - Fixed error in `install_python()` under R 4.5 when the requested Python
   version has a `":latest"` suffix, as it does by default. (#1792, #1797)
 
-- Fixed error in `get_python_conda_info()` when conda not found through `conda-meta/history` 
+- Fixed error in `get_python_conda_info()` when conda not found through `conda-meta/history`
   and `NULL` is passed to `normalizePath` (#1184)
 
 - Hotfix to pin `uv` version resolved by reticulate to `<0.8.0`. (#1812)
 
-- Python discovery by `uv` is much faster now. The internal utility `uv_python_list()` 
-  searches only for managed python environments by default. Users can request discovery of 
-  system pythons by setting `UV_PYTHON_PREFERENCE`. Also, `uv_python_list()` will now discover 
+- Python discovery by `uv` is much faster now. The internal utility `uv_python_list()`
+  searches only for managed python environments by default. Users can request discovery of
+  system pythons by setting `UV_PYTHON_PREFERENCE`. Also, `uv_python_list()` will now discover
   pyenv pythons and python binaries installed by `install_python()` if a system python is requested. (#1810)
 
 # reticulate 1.42.0

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -561,7 +561,6 @@ py_reqs_get <- function(x = NULL) {
 
 uv_binary <- function(bootstrap_install = TRUE) {
   min_uv_version <- numeric_version("0.6.3")
-  max_uv_version <- numeric_version("0.8.0")
   is_usable_uv <- function(uv) {
     if (is.null(uv) || is.na(uv) || uv == "" || !file.exists(uv)) {
       return(FALSE)
@@ -571,7 +570,7 @@ uv_binary <- function(bootstrap_install = TRUE) {
       return(FALSE)
     }
     ver <- numeric_version(sub("uv ([0-9.]+).*", "\\1", ver), strict = FALSE)
-    !is.na(ver) && ver >= min_uv_version && ver < max_uv_version
+    !is.na(ver) && ver >= min_uv_version
   }
 
   repeat {
@@ -585,7 +584,7 @@ uv_binary <- function(bootstrap_install = TRUE) {
       if (uv == "managed") break else return(uv)
     }
 
-    # on Windows, the invocation cost of `uv`` is non-negligable.
+    # on Windows, the invocation cost of `uv`` is non-negligible.
     # observed to be 0.2s for just `uv --version`
     # This is a an approach to avoid paying that cost on each invocation
     # This is mostly motivated by uv_run_tool(),
@@ -707,9 +706,8 @@ uv_get_or_create_env <- function(packages = py_reqs_get("packages"),
   on.exit(unlink(uv_output_file), add = TRUE)
 
   uv_args <- c(
-    "run",
-    "--no-project",
-    # "--python-preference", "managed",
+    "tool", "run",
+    "--isolated",
     python_version,
     exclude_newer,
     packages,
@@ -740,10 +738,10 @@ uv_get_or_create_env <- function(packages = py_reqs_get("packages"),
     stop("Call `py_require()` to remove or replace conflicting requirements.")
   }
 
-  ephemeral_python <- readLines(uv_output_file, warn = FALSE)
+  cached_python <- readLines(uv_output_file, warn = FALSE)
   if (debug)
-    message("resolved ephemeral python: ", ephemeral_python)
-  ephemeral_python
+    message("resolved ephemeral python: ", cached_python)
+  cached_python
 }
 
 #' uv run tool

--- a/tests/testthat/_snaps/py_require.md
+++ b/tests/testthat/_snaps/py_require.md
@@ -13,7 +13,7 @@
       > py_require("numpy<2")
       > py_require("numpy>=2")
       > import("numpy")
-        × No solution found when resolving `--with` dependencies:
+        × No solution found when resolving tool dependencies:
         ╰─▶ Because you require numpy<2 and numpy>=2, we can conclude that your
             requirements are unsatisfiable.
       uv error code: 1
@@ -137,7 +137,7 @@
     Output
       > py_require(c("pandas", "numpy", "notexists"))
       > uv_get_or_create_env()
-        × No solution found when resolving `--with` dependencies:
+        × No solution found when resolving tool dependencies:
         ╰─▶ Because notexists was not found in the package registry and you require
             notexists, we can conclude that your requirements are unsatisfiable.
       uv error code: 1

--- a/tests/testthat/_snaps/py_require.md
+++ b/tests/testthat/_snaps/py_require.md
@@ -337,7 +337,7 @@
       > library(reticulate)
       > py_require("os")
       > os <- import("os")
-        × No solution found when resolving `--with` dependencies:
+        × No solution found when resolving tool dependencies:
         ╰─▶ Because os was not found in the package registry and you require os, we
             can conclude that your requirements are unsatisfiable.
       uv error code: 1


### PR DESCRIPTION
This PR switches `py_require()` to use `uv tool run` instead of `uv run`. This is so that internally uv resolves a `CachedEnvironment` instead of an `EphemeralEnvironment`.

Beginning with `uv` 0.8.0, `uv run --no-project` creates a truly ephemeral environment that is deleted at the end of the `uv` invocation. `uv tool run --isolated` invokes essentially the same code path within `uv`, except it returns the `CachedEnvironment` directly rather than layering a new `EphemeralEnvironment` atop it.

If upstream ever changes so that `uv tool run` also tears down the environment after the uv call finishes, we will probably have to materialize the environment within R's `tempdir()`. Note that would substantially complicate our current approach of displaying uv stderr output to the user. It would also be substantially slower, since the internal code path that `uv` takes to create the ephemeral venv is different, and much faster than, `uv venv`.