### PR TITLE
Propagate exceptions to Python context managers in `with()`.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # reticulate (development version)
 
-- Reticulate now clears its cache automatically every 120 days. Configure the interval 
+- Reticulate now clears its cache automatically every 120 days. Configure the interval
   in `.Rprofile` with: `options(reticulate.max_cache_age = as.difftime(30, units = "days"))`.
 
 - `install_miniconda()` now installs miniforge instead of miniconda (#1800, #1820).
@@ -12,8 +12,11 @@
 - `py_require()` now gives a better message when a user erroneously declares
    a module from the Python standard library as a required package (@lazappi, #1788)
 
-- Positron's reticulate integration will now be automatically enabled when 
+- Positron's reticulate integration will now be automatically enabled when
   the reticulate package is loaded in Positron (#1822).
+
+- `with()` now forwards errors to Python context manager exit handlers
+  (e.g., so database transactions can roll back cleanly) (#1840, #1841)
 
 # reticulate 1.43.0
 

--- a/tests/testthat/test-python-with.R
+++ b/tests/testthat/test-python-with.R
@@ -1,0 +1,35 @@
+test_that("with() propagates errors/exceptions to Python context managers", {
+  skip_if_no_python()
+
+  py_run_string(paste(
+    "class _ReticulateCaptureCtx:",
+    "    def __init__(self):",
+    "        self.args = None",
+    "    def __enter__(self):",
+    "        return self",
+    "    def __exit__(self, exc_type, exc_value, exc_tb):",
+    "        self.args = (exc_type, exc_value, exc_tb)",
+    "        return False",
+    sep = "\n"
+  ))
+
+  # check R error
+  ctx <- py_eval("_ReticulateCaptureCtx()")
+  expect_error(with(ctx, stop('boom')), "boom")
+  args <- ctx$args
+  expect_s3_class(args[[1]], "python.builtin.type")
+  expect_s3_class(args[[2]], "error")
+
+  # check python exception
+  ctx <- py_eval("_ReticulateCaptureCtx()")
+  expect_error(
+    with(ctx, py_run_string("raise ValueError('kaboom')")),
+    "kaboom"
+  )
+  args <- ctx$args
+  expect_s3_class(args[[1]], "python.builtin.type")
+  expect_s3_class(args[[2]], "python.builtin.ValueError")
+  expect_s3_class(args[[3]], "python.builtin.traceback")
+
+  py_run_string("del _ReticulateCaptureCtx")
+})


### PR DESCRIPTION

  - Forward the actual exception triple in `with.python.builtin.object` to the Python `__exit__` handler. This is so transactional context managers can roll back correctly.
  - Add tests to ensure R errors and Python exceptions are passed along correctly.

Closes: #1840.
