### PR TITLE
Fix internal `uv_binary()` resolution

### DIFF
--- a/R/py_require.R
+++ b/R/py_require.R
@@ -678,7 +678,9 @@ uv_binary <- function(bootstrap_install = TRUE) {
     }
   }
 
-  if (file.exists(uv)) uv else NULL # print visible
+  # if we bootstrap-installed successfully, return the path to the uv binary
+  # if not, reset `uv` for the on.exit() hook and return NULL visibly
+  if (file.exists(uv)) uv else (uv <- NULL)
 }
 
 uv_get_or_create_env <- function(packages = py_reqs_get("packages"),


### PR DESCRIPTION
Previously, if we called `uv_binary(bootstrap_install = FALSE)`, then all subsequent `uv_binary()` calls would return a path to a `uv` binary that didn't exist.

This bug surfaced in #1850. 