### PR TITLE
Fixes display values in positron

### DIFF
--- a/R/ark-variables-methods.R
+++ b/R/ark-variables-methods.R
@@ -5,7 +5,8 @@
 
 
 ark_positron_variable_display_value.python.builtin.object <- function(x, ..., width = getOption("width")) {
-  .globals$get_positron_variable_inspector(x)$get_display_value(width)[[1L]]
+  val <- .globals$get_positron_variable_inspector(x)$get_display_value()[[1L]]
+  substr(val, 1L, width)
 }
 
 

--- a/inst/python/rpytools/ark_variables.py
+++ b/inst/python/rpytools/ark_variables.py
@@ -9,7 +9,14 @@ def get_keys_and_children(inspector):
     keys_iterator = iter(inspector.get_children())
     for key in islice(keys_iterator, MAX_DISPLAY):
         keys.append(str(key))
-        values.append(inspector.get_child(key))
+        try:
+            val = inspector.get_child(key)
+        except Exception:
+            # TODO: ideally this should be a sentiel value indicating it's
+            # not a python string, but the actual display value we want. For now,
+            # at least indicate some error.
+            val = "<error>"
+        values.append(val)
 
     if len(keys) == MAX_DISPLAY:
         # check if there are more children


### PR DESCRIPTION
In https://github.com/posit-dev/positron/pull/8545 the `get_display_value()` API changed and no longer allows a `width` argument.

The approach here should also work on previous positron versions, as width shouldn't be required and we still truncate on this side.