### PR TITLE
Fixes Positron restart

### DIFF
--- a/R/thread.R
+++ b/R/thread.R
@@ -62,6 +62,9 @@ py_run_file_on_thread <- function(file, ..., args = NULL) {
                     basename(dirname(file)) %in% c("positron", "posit"))
 
   if (launching_lsp) {
+    # this is equivalent to the result of .getIpykernelPath UI command.
+    .globals$positron_ipykernel_path <- file.path(dirname(file), "positron")
+
     main_dict <- py_eval("__import__('__main__').__dict__.copy()", FALSE)
     py_get_attr(main_dict, "pop")("__annotations__")
     # IPykernel will create a thread that redirects all output from fileno of

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -89,7 +89,9 @@ register_ark_methods <- function() {
   # which will be needed for the variable inspectors and for help handlers
   # this can'rt be executed during handling of RPC's, so it's important that it's cached.
   .ps.ui.executeCommand <- get(".ps.ui.executeCommand", globalenv())
-  .globals$positron_ipykernel_path <- .ps.ui.executeCommand("positron.reticulate.getIPykernelPath")
+  if (is.null(.globals$positron_ipykernel_path)) {
+    .globals$positron_ipykernel_path <- .ps.ui.executeCommand("positron.reticulate.getIPykernelPath")
+  }
 
   # register help handler
   tryCatch({


### PR DESCRIPTION
when reticulate restarts, reticulate initializes Python from within an
RPC method call (from ark) which in turn does not allow us to call into
`getIpykernelPath` (which happens when registering ark methods)

The solution here, is to store the ipykernel path when starting positron,
so we don't need to later call into the UI comm to get it.