### PR TITLE
Use startup messages for py_require checks during package load

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -370,10 +370,10 @@ check_virtualenv_required_packages <- function(config) {
   # - numba==0.60.0
   # + numba==0.61.0
   if (any(grepl("downloading", pip_output, ignore.case = TRUE))) {
-    warning(paste(
+    warning_or_startup_message(paste(
       pip_output[grepl("downloading", pip_output, ignore.case = TRUE)],
       collapse = "\n"
-    ))
+    ), call. = FALSE)
   }
 
   # uv pip doesn't have an option to produce structured output,
@@ -399,7 +399,7 @@ check_virtualenv_required_packages <- function(config) {
       vapply(packages, function(pkg) any(startsWith(pkg, would_install_pkgs)), TRUE,
              USE.NAMES = FALSE)
     ]
-    warning(
+    warning_or_startup_message(
       "Some Python package requirements declared via `py_require()` are not",
       " installed in the selected Python environment: (", config$python, ")\n",
       "  ", paste0(would_install_pkgs, collapse=" "),
@@ -433,14 +433,7 @@ check_forbidden_initialization <- function() {
 
     call <- calls[[i]]
     frame <- frames[[i]]
-    if (!identical(call[[1]], as.name("runHook")))
-      next
-
-    bad <-
-      identical(call[[2]], ".onLoad") ||
-      identical(call[[2]], ".onAttach")
-
-    if (!bad)
+    if (!is_package_loading(list(call)))
       next
 
     pkgname <- tryCatch(

--- a/R/use_python.R
+++ b/R/use_python.R
@@ -278,20 +278,10 @@ use_miniconda <- function(condaenv = NULL, required = NULL) {
 
 use_python_required <- function() {
 
-  # for now, assume that calls from within a package's .onLoad() are
+  # for now, assume that calls from within package load hooks are
   # advisory, but we may consider relaxing this in the future
-  calls <- sys.calls()
-  for (call in calls) {
-
-    match <-
-      length(call) >= 2 &&
-      identical(call[[1L]], as.name("runHook")) &&
-      identical(call[[2L]], ".onLoad")
-
-    if (match)
-      return(FALSE)
-
-  }
+  if (is_package_loading())
+    return(FALSE)
 
   # default to TRUE
   TRUE

--- a/R/utils.R
+++ b/R/utils.R
@@ -742,6 +742,36 @@ parent.pkg <- function(env = parent.frame(2)) {
     NULL # print visible
 }
 
+is_package_loading <- function(calls = sys.calls()) {
+  for (call in calls) {
+    if (length(call) < 2L)
+      next
+
+    hook <- call[[2L]]
+    if (is.symbol(hook))
+      hook <- as.character(hook)
+
+    match <-
+      identical(call[[1L]], as.name("runHook")) &&
+      is.character(hook) &&
+      hook %in% c(".onLoad", ".onAttach")
+
+    if (match)
+      return(TRUE)
+  }
+
+  FALSE
+}
+
+warning_or_startup_message <- function(..., call. = TRUE) {
+  msg <- .makeMessage(...)
+  if (is_package_loading()) {
+    packageStartupMessage(msg)
+  } else {
+    warning(msg, call. = call.)
+  }
+}
+
 warn_and_return <- function(..., call. = TRUE) {
   cond <- if (inherits(..1, "condition")) {
     ..1

--- a/tests/testthat/test-py_require.R
+++ b/tests/testthat/test-py_require.R
@@ -244,3 +244,39 @@ test_that("py_require() warns missing packages in a virtual env", {
     }
   )
 })
+
+test_that("package load hooks get startup messages, not warnings", {
+  expect_true(is_package_loading(list(quote(runHook(".onLoad", foo)))))
+  expect_true(is_package_loading(list(quote(runHook(.onAttach, foo)))))
+  expect_false(is_package_loading(list(quote(runHook(".onUnload", foo)))))
+
+  msg <- paste(
+    "Some Python package requirements declared via `py_require()` are not",
+    "installed in the selected Python environment: (/path/to/python)\n",
+    "  numpy"
+  )
+
+  expect_warning(
+    warning_or_startup_message(msg, call. = FALSE),
+    "Some Python package requirements declared via `py_require()` are not",
+    fixed = TRUE
+  )
+
+  runHook <- function(name, expr) expr()
+  expect_message(
+    expect_warning(
+      runHook(".onLoad", function() warning_or_startup_message(msg, call. = FALSE)),
+      NA
+    ),
+    "Some Python package requirements declared via `py_require()` are not",
+    fixed = TRUE
+  )
+  expect_message(
+    expect_warning(
+      runHook(".onAttach", function() warning_or_startup_message(msg, call. = FALSE)),
+      NA
+    ),
+    "Some Python package requirements declared via `py_require()` are not",
+    fixed = TRUE
+  )
+})


### PR DESCRIPTION
## Summary

CRAN reverse dependency checks started reporting new warnings/notes after reticulate began warning when the selected Python environment does not satisfy `py_require()` requirements.

The warning is useful and should remain for normal user workflows, but during package load/install phases on CRAN machines it produces check noise that downstream packages cannot control.

This change keeps the same message content, but changes the signaling behavior during package load hooks:

- if running from a package load hook (`.onLoad` / `.onAttach`), emit `packageStartupMessage()`
- otherwise, keep emitting `warning()`

## Why this exists

The CRAN machines appear to hit Python initialization paths during install/load checks for reverse dependencies. In that context, warning emission causes new revdep WARNING/NOTE results even though downstream packages do not control CRAN's environment state.

Using startup messages in load hooks preserves visibility of the unmet `py_require()` requirements while avoiding CRAN check warnings from namespace/load-time execution.

## Reverse dependency failures observed

CRAN reported this warning text repeatedly:

`Some Python package requirements declared via py_require() are not installed in the selected Python environment: (...)`

### "whether package can be installed" -> WARNING

- agcounts
- caracas
- fastai
- leiden
- pangoling
- PytrendsLongitudinalR
- RGF
- rinet
- sjSDM
- tm.plugin.mail

### "whether the namespace can be loaded with stated dependencies" -> NOTE

- agcounts
- caracas
- fastai
- PytrendsLongitudinalR
- RGF
- rinet
- sjSDM
- tm.plugin.mail

The namespace NOTE entries also included the unmet package detail (e.g. `numpy`) and CRAN's generic namespace-load guidance.

## Implementation

- add helper to detect package load hooks from call stack (`runHook` with `.onLoad`/`.onAttach`)
- add helper that switches between `warning()` and `packageStartupMessage()` based on that detection
- route `check_virtualenv_required_packages()` messaging through this helper
- reuse the same load-hook detection helper for `use_python_required()`
- add tests verifying warning behavior in normal contexts and startup-message behavior in load hooks

## Validation

- `R -q -e "devtools::test(filter = 'py_require', reporter = 'summary')"`


## Raw CRAN reverse dependency check output

<details>
<summary>reverseDependencies/summary.txt</summary>

```text
Package check result: OK

Changes to worse in reverse depends:

Package: agcounts
Check: whether package can be installed
New result: WARNING
  Found the following significant warnings:
    Warning: Some Python package requirements declared via `py_require()` are not installed in the selected Python environment: (/home/hornik/tmp/scratch/check-CRAN-incoming-hornik/.virtualenvs/r-reticulate/bin/python)
  See ‘/home/hornik/tmp/CRAN_recheck/agcounts.Rcheck/00install.out’ for details.
  Used C++ compiler: ‘g++-15 (Debian 15.2.0-12) 15.2.0’

Package: agcounts
Check: whether the namespace can be loaded with stated dependencies
New result: NOTE
  Warning: Some Python package requirements declared via `py_require()` are not installed in the selected Python environment: (/home/hornik/tmp/scratch/check-CRAN-incoming-hornik/.virtualenvs/r-reticulate/bin/python)
    numpy
  
  A namespace must be able to be loaded with just the base namespace
  loaded: otherwise if the namespace gets loaded by a saved object, the
  session will be unable to start.
  
  Probably some imports need to be declared in the NAMESPACE file.

Package: caracas
Check: whether package can be installed
New result: WARNING
  Found the following significant warnings:
    Warning: Some Python package requirements declared via `py_require()` are not installed in the selected Python environment: (/home/hornik/tmp/scratch/check-CRAN-incoming-hornik/.virtualenvs/r-reticulate/bin/python)

Package: caracas
Check: whether the namespace can be loaded with stated dependencies
New result: NOTE
  Warning: Some Python package requirements declared via `py_require()` are not installed in the selected Python environment: (/home/hornik/tmp/scratch/check-CRAN-incoming-hornik/.virtualenvs/r-reticulate/bin/python)
    numpy
  
  A namespace must be able to be loaded with just the base namespace
  loaded: otherwise if the namespace gets loaded by a saved object, the
  session will be unable to start.
  
  Probably some imports need to be declared in the NAMESPACE file.

Package: fastai
Check: whether package can be installed
New result: WARNING
  Found the following significant warnings:
    Warning: Some Python package requirements declared via `py_require()` are not installed in the selected Python environment: (/home/hornik/tmp/scratch/check-CRAN-incoming-hornik/.virtualenvs/r-reticulate/bin/python)

Package: fastai
Check: whether the namespace can be loaded with stated dependencies
New result: NOTE
  Warning: Some Python package requirements declared via `py_require()` are not installed in the selected Python environment: (/home/hornik/tmp/scratch/check-CRAN-incoming-hornik/.virtualenvs/r-reticulate/bin/python)
    numpy
  
  A namespace must be able to be loaded with just the base namespace
  loaded: otherwise if the namespace gets loaded by a saved object, the
  session will be unable to start.
  
  Probably some imports need to be declared in the NAMESPACE file.

Package: leiden
Check: whether package can be installed
New result: WARNING
  Found the following significant warnings:
    Warning: Some Python package requirements declared via `py_require()` are not installed in the selected Python environment: (/home/hornik/tmp/scratch/check-CRAN-incoming-hornik/.virtualenvs/r-reticulate/bin/python)

Package: pangoling
Check: whether package can be installed
New result: WARNING
  Found the following significant warnings:
    Warning: Some Python package requirements declared via `py_require()` are not installed in the selected Python environment: (/home/hornik/tmp/scratch/check-CRAN-incoming-hornik/.virtualenvs/r-reticulate/bin/python)

Package: PytrendsLongitudinalR
Check: whether package can be installed
New result: WARNING
  Found the following significant warnings:
    Warning: Some Python package requirements declared via `py_require()` are not installed in the selected Python environment: (/home/hornik/tmp/scratch/check-CRAN-incoming-hornik/.virtualenvs/r-reticulate/bin/python)

Package: PytrendsLongitudinalR
Check: whether the namespace can be loaded with stated dependencies
New result: NOTE
  Warning: Some Python package requirements declared via `py_require()` are not installed in the selected Python environment: (/home/hornik/tmp/scratch/check-CRAN-incoming-hornik/.virtualenvs/r-reticulate/bin/python)
    numpy
  
  A namespace must be able to be loaded with just the base namespace
  loaded: otherwise if the namespace gets loaded by a saved object, the
  session will be unable to start.
  
  Probably some imports need to be declared in the NAMESPACE file.

Package: RGF
Check: whether package can be installed
New result: WARNING
  Found the following significant warnings:
    Warning: Some Python package requirements declared via `py_require()` are not installed in the selected Python environment: (/home/hornik/tmp/scratch/check-CRAN-incoming-hornik/.virtualenvs/r-reticulate/bin/python)

Package: RGF
Check: whether the namespace can be loaded with stated dependencies
New result: NOTE
  Warning: Some Python package requirements declared via `py_require()` are not installed in the selected Python environment: (/home/hornik/tmp/scratch/check-CRAN-incoming-hornik/.virtualenvs/r-reticulate/bin/python)
    numpy
  
  A namespace must be able to be loaded with just the base namespace
  loaded: otherwise if the namespace gets loaded by a saved object, the
  session will be unable to start.
  
  Probably some imports need to be declared in the NAMESPACE file.

Package: rinet
Check: whether package can be installed
New result: WARNING
  Found the following significant warnings:
    Warning: Some Python package requirements declared via `py_require()` are not installed in the selected Python environment: (/home/hornik/tmp/scratch/check-CRAN-incoming-hornik/.virtualenvs/r-reticulate/bin/python)

Package: rinet
Check: whether the namespace can be loaded with stated dependencies
New result: NOTE
  Warning: Some Python package requirements declared via `py_require()` are not installed in the selected Python environment: (/home/hornik/tmp/scratch/check-CRAN-incoming-hornik/.virtualenvs/r-reticulate/bin/python)
    numpy
  
  A namespace must be able to be loaded with just the base namespace
  loaded: otherwise if the namespace gets loaded by a saved object, the
  session will be unable to start.
  
  Probably some imports need to be declared in the NAMESPACE file.

Package: sjSDM
Check: whether package can be installed
New result: WARNING
  Found the following significant warnings:
    Warning: Some Python package requirements declared via `py_require()` are not installed in the selected Python environment: (/home/hornik/tmp/scratch/check-CRAN-incoming-hornik/.virtualenvs/r-reticulate/bin/python)

Package: sjSDM
Check: whether the namespace can be loaded with stated dependencies
New result: NOTE
  Warning: Some Python package requirements declared via `py_require()` are not installed in the selected Python environment: (/home/hornik/tmp/scratch/check-CRAN-incoming-hornik/.virtualenvs/r-reticulate/bin/python)
    numpy
  
  A namespace must be able to be loaded with just the base namespace
  loaded: otherwise if the namespace gets loaded by a saved object, the
  session will be unable to start.
  
  Probably some imports need to be declared in the NAMESPACE file.

Package: tm.plugin.mail
Check: whether package can be installed
New result: WARNING
  Found the following significant warnings:
    Warning: Some Python package requirements declared via `py_require()` are not installed in the selected Python environment: (/home/hornik/tmp/scratch/check-CRAN-incoming-hornik/.virtualenvs/r-reticulate/bin/python)

Package: tm.plugin.mail
Check: whether the namespace can be loaded with stated dependencies
New result: NOTE
  Warning: Some Python package requirements declared via `py_require()` are not installed in the selected Python environment: (/home/hornik/tmp/scratch/check-CRAN-incoming-hornik/.virtualenvs/r-reticulate/bin/python)
    numpy
  
  A namespace must be able to be loaded with just the base namespace
  loaded: otherwise if the namespace gets loaded by a saved object, the
  session will be unable to start.
  
  Probably some imports need to be declared in the NAMESPACE file.
```

</details>
