### PR TITLE
Replace `Rf_error` usage with `Rcpp::stop`

### DIFF
--- a/src/r_api.h
+++ b/src/r_api.h
@@ -32,7 +32,7 @@ inline SEXP reticulate_get_var(SEXP sym, SEXP env) {
     value = Rcpp::internal::Rcpp_eval_impl(value, env);
 #endif
   if (value == NULL)
-    Rf_error("object '%s' not found", CHAR(PRINTNAME(sym)));
+    Rcpp::stop("object '%s' not found", CHAR(PRINTNAME(sym)));
   return value;
 }
 


### PR DESCRIPTION
Followup to https://github.com/rstudio/reticulate/issues/1887#issuecomment-4244898291