### PR TITLE
Avoid Poetry warning for non-Poetry pyproject.toml projects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # reticulate (development version)
 
+- Fixed a spurious warning about Poetry being unavailable when a project had a
+  `pyproject.toml` without a `[tool.poetry]` section, such as uv or PEP 621
+  projects. (#1900)
+
 # reticulate 1.46.0
 
 - Internal updates to avoid `R_NamespaceRegistry` and `R_UnboundValue` in

--- a/R/poetry.R
+++ b/R/poetry.R
@@ -21,7 +21,7 @@ poetry_config <- function(required_module) {
 
   # check that it has a 'tool.poetry' section
   info <- tryCatch(toml[[c("tool", "poetry")]], error = identity)
-  if (inherits(info, "error"))
+  if (is.null(info) || inherits(info, "error"))
     return(NULL)
 
   # validate that 'poetry' is available

--- a/tests/testthat/test-python-virtual-environments.R
+++ b/tests/testthat/test-python-virtual-environments.R
@@ -46,16 +46,14 @@ test_that("reticulate does not warn about Poetry for non-Poetry pyproject.toml",
   skip_on_cran()
   skip_on_os("windows")
 
-  python3 <- Sys.which("python3")
-  if (!nzchar(python3))
-    skip("test requires Python 3 binary with venv module")
-
   project <- tempfile("python-project-")
   dir.create(project)
   on.exit(unlink(project, recursive = TRUE), add = TRUE)
 
   venv <- file.path(project, ".venv")
-  virtualenv_create(envname = venv, python = python3, packages = FALSE)
+  status <- system2(py_exe(), c("-m", "venv", venv))
+  if (!identical(status, 0L))
+    skip("test requires Python with venv module")
 
   writeLines(c(
     "[project]",

--- a/tests/testthat/test-python-virtual-environments.R
+++ b/tests/testthat/test-python-virtual-environments.R
@@ -40,3 +40,45 @@ test_that("reticulate can bind to virtual environments created with venv", {
   expect_true(grepl(venv, site))
 
 })
+
+test_that("reticulate does not warn about Poetry for non-Poetry pyproject.toml", {
+  skip_if_no_python()
+  skip_on_cran()
+  skip_on_os("windows")
+
+  python3 <- Sys.which("python3")
+  if (!nzchar(python3))
+    skip("test requires Python 3 binary with venv module")
+
+  project <- tempfile("python-project-")
+  dir.create(project)
+  on.exit(unlink(project, recursive = TRUE), add = TRUE)
+
+  venv <- file.path(project, ".venv")
+  virtualenv_create(envname = venv, python = python3, packages = FALSE)
+
+  writeLines(c(
+    "[project]",
+    'name = "reticulate-test"',
+    'version = "0.0.0"'
+  ), file.path(project, "pyproject.toml"))
+
+  expr <- bquote({
+    library(reticulate)
+    Sys.setenv(RETICULATE_CHECK_REQUIRED_PACKAGES = "false")
+    options(reticulate.poetry.exe = .(file.path(project, "missing-poetry")))
+
+    setwd(.(project))
+    config <- py_config()
+
+    stopifnot(
+      grepl("[/\\\\][.]venv[/\\\\]", config$python),
+      identical(config$forced, "'./.venv' existing in the current working directory")
+    )
+  })
+
+  result <- do.call(r_session, list(force_managed_python = FALSE, exprs = expr))
+
+  expect_null(attr(result, "status"))
+  expect_false(any(grepl("Poetry", result, fixed = TRUE)))
+})


### PR DESCRIPTION
## Summary

Fixes Python discovery for projects with a `pyproject.toml` that do not use Poetry, such as uv or PEP 621 projects.

Previously, `poetry_config()` treated a missing `[tool.poetry]` table as a Poetry project because `RcppTOML` returned `NULL`, not an error. That could produce a spurious warning even when reticulate selected a local `./.venv`:

```r
Warning message:
In poetry_config(required_module) :
  This project appears to use Poetry for Python dependency management.
However, the 'poetry' command line tool is not available.
reticulate will be unable to activate this project.
Please ensure that 'poetry' is available on the PATH.
```

This change makes `poetry_config()` return `NULL` when `[tool.poetry]` is absent, letting normal discovery continue.

Public-facing change:
- Removes the spurious Poetry warning for non-Poetry `pyproject.toml` projects.

