### PR TITLE
Move TensorFlow snapshot before prereleases

### DIFF
--- a/tests/testthat/test-py_require.R
+++ b/tests/testthat/test-py_require.R
@@ -127,7 +127,7 @@ test_that("Error requesting newer package version against an older snapshot", {
   session <- r_session(attach_namespace = TRUE, {
     uv_get_or_create_env(
       packages = "tensorflow==2.18.*",
-      exclude_newer = "2024-10-20"
+      exclude_newer = "2024-09-29"
     )
   })
   expect_match(


### PR DESCRIPTION
## Summary

[uv 0.12 changed prerelease resolution](https://github.com/astral-sh/uv/pull/19993) to fall back to prereleases when no stable release satisfies a request. TensorFlow 2.18.0rc2 was published before the test's October 20 cutoff, so the supposedly invalid request began resolving successfully.

Move the cutoff to September 29, before the first TensorFlow 2.18 prerelease. This preserves the test's original error contract and fixed-snapshot design.

This is an internal test-only change. There are no public-facing changes.

## Testing

- `devtools::test(filter = "py_require", stop_on_failure = TRUE)` with uv 0.12.0
