### PR TITLE
Fix Pipenv discovery when here cannot find a project root

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,9 @@
 - Fixed managed `uv` bootstrapping on Windows when R inherits a PowerShell 7
   `PSModulePath`, such as from GitHub Actions `pwsh` steps.
 
+- Fixed Pipenv interpreter discovery when `here` cannot resolve a project root.
+  (#1909)
+
 - Fixed a spurious warning about Poetry being unavailable when a project had a
   `pyproject.toml` without a `[tool.poetry]` section, such as uv or PEP 621
   projects. (#1900)

--- a/R/pipenv.R
+++ b/R/pipenv.R
@@ -5,7 +5,7 @@ pipenv_config <- function(required_module) {
   if (!file.exists(pipfile))
     return(NULL)
 
-  python <- pipenv_python()
+  python <- pipenv_python(dirname(pipfile))
   python_config(python, required_module, forced = "Pipfile")
 
 }
@@ -25,14 +25,18 @@ pipenv_pipfile_path <- function() {
 
 }
 
-pipenv_python <- function() {
+pipenv_python <- function(root = NULL) {
 
   # validate that pipenv is available on the PATH
   if (!nzchar(Sys.which("pipenv")))
     stop("'pipenv' is not available")
 
   # move to root directory
-  root <- here::here()
+  if (is.null(root))
+    root <- tryCatch(here::here(), error = function(e) NULL)
+  if (is.null(root))
+    return(NULL)
+
   owd <- setwd(root)
   on.exit(setwd(owd), add = TRUE)
 

--- a/tests/testthat/test-python-pipenv.R
+++ b/tests/testthat/test-python-pipenv.R
@@ -21,11 +21,13 @@ testthat::test_that("pipenv discovery uses the located Pipfile directory", {
       file.create(pipfile)
 
       envpath <- file.path(project, ".venv")
-      reticulate::virtualenv_create(
-        envpath,
-        python = python,
-        packages = FALSE
+      status <- system2(
+        python,
+        c("-m", "venv", "--without-pip", shQuote(envpath)),
+        stdout = FALSE,
+        stderr = FALSE
       )
+      stopifnot(status == 0L)
 
       bindir <- file.path(project, "bin")
       dir.create(bindir)

--- a/tests/testthat/test-python-pipenv.R
+++ b/tests/testthat/test-python-pipenv.R
@@ -1,5 +1,81 @@
 context("pipenv")
 
+testthat::test_that("pipenv discovery uses the located Pipfile directory", {
+
+  skip_on_cran()
+
+  python <- Sys.which("python")
+  if (!nzchar(python))
+    python <- Sys.which("python3")
+  if (!nzchar(python))
+    skip("python is not installed")
+
+  result <- callr::r(
+    function(python) {
+
+      project <- tempfile("pipenv-")
+      dir.create(project)
+      on.exit(unlink(project, recursive = TRUE), add = TRUE)
+
+      pipfile <- file.path(project, "Pipfile")
+      file.create(pipfile)
+
+      envpath <- file.path(project, ".venv")
+      reticulate::virtualenv_create(
+        envpath,
+        python = python,
+        packages = FALSE
+      )
+
+      bindir <- file.path(project, "bin")
+      dir.create(bindir)
+
+      if (.Platform$OS.type == "windows") {
+        pipenv <- file.path(bindir, "pipenv.bat")
+        writeLines(c("@echo off", paste("echo", envpath)), pipenv)
+      } else {
+        pipenv <- file.path(bindir, "pipenv")
+        command <- sprintf("printf '%%s\\n' %s", shQuote(envpath))
+        writeLines(c("#!/bin/sh", command), pipenv)
+        Sys.chmod(pipenv, "0755")
+      }
+
+      withr::local_path(bindir)
+      Sys.unsetenv(c(
+        "PYTHON_SESSION_INITIALIZED",
+        "RETICULATE_PYTHON",
+        "RETICULATE_PYTHON_ENV",
+        "RETICULATE_PYTHON_FALLBACK",
+        "VIRTUAL_ENV"
+      ))
+      Sys.setenv(RETICULATE_USE_MANAGED_VENV = "false")
+
+      config <- testthat::with_mocked_bindings(
+        reticulate::py_discover_config(),
+        here = function(...) {
+          path <- list(...)
+          if (identical(path, list("Pipfile")))
+            return(pipfile)
+          stop("No root directory found", call. = FALSE)
+        },
+        .package = "here"
+      )
+
+      list(
+        actual = config$python,
+        expected = reticulate::virtualenv_python(envpath),
+        forced = config$forced
+      )
+
+    },
+    args = list(python)
+  )
+
+  expect_equal(result$actual, result$expected)
+  expect_equal(result$forced, "Pipfile")
+
+})
+
 test_that("reticulate uses the pipenv-configured version of Python", {
 
   skip_on_cran()


### PR DESCRIPTION
## Summary

Fixes #1909.

Pipenv discovery could repeat project-root resolution after locating a Pipfile. If `here::here()` failed on that second lookup, reticulate discarded the Pipenv result and continued discovery.

Reticulate now passes the located Pipfile directory to `pipenv_python()`. A no-argument call also returns `NULL` when `here` cannot resolve a root.

## Changes

Public-facing:

- Pipenv discovery can use a located Pipfile even when `here` cannot independently resolve the project root.
- A missing `here` root no longer surfaces from a no-argument Pipenv probe.

Internal:

- Add a regression test through `py_discover_config()` with a temporary Pipenv environment.
- Document the fix in NEWS.
