### PR TITLE
Add RETICULATE_MAX_CACHE_AGE_DAYS environment variable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # reticulate (development version)
 
+- `RETICULATE_MAX_CACHE_AGE` can now configure the maximum age, in days, of
+  reticulate's managed `uv` cache before it is cleared (#1905).
+
 - Fixed managed `uv` bootstrapping on Windows when R inherits a PowerShell 7
   `PSModulePath`, such as from GitHub Actions `pwsh` steps.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # reticulate (development version)
 
-- `RETICULATE_MAX_CACHE_AGE` can now configure the maximum age, in days, of
-  reticulate's managed `uv` cache before it is cleared (#1905).
+- `RETICULATE_MAX_CACHE_AGE_DAYS` can now configure the maximum age, in days,
+  of reticulate's managed `uv` cache before it is cleared (#1905).
 
 - Fixed managed `uv` bootstrapping on Windows when R inherits a PowerShell 7
   `PSModulePath`, such as from GitHub Actions `pwsh` steps.

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -117,15 +117,16 @@
 #' ```
 #'
 #' Reticulate also clears its managed cache automatically on an interval,
-#' defaulting to every 120 days. Set `RETICULATE_MAX_CACHE_AGE` to a number of
-#' days in `.Renviron`:
+#' defaulting to every 120 days. Set `RETICULATE_MAX_CACHE_AGE_DAYS` to a
+#' possibly fractional number of days in `.Renviron`:
 #'
 #' ```
-#' RETICULATE_MAX_CACHE_AGE=30
+#' RETICULATE_MAX_CACHE_AGE_DAYS=30
 #' ```
 #'
-#' The `reticulate.max_cache_age` R option takes precedence. Configure it in
-#' `.Rprofile` with:
+#' The environment variable takes precedence over the
+#' `reticulate.max_cache_age` R option. Configure the option in `.Rprofile`
+#' with:
 #'
 #' ```r
 #' options(reticulate.max_cache_age = as.difftime(30, units = "days"))
@@ -1158,11 +1159,15 @@ maybe_clear_reticulate_uv_cache <- function() {
   if (!file.exists(uv))
     return()
 
-  max_age <- getOption("reticulate.max_cache_age")
-  if (is.null(max_age)) {
-    max_age <- Sys.getenv("RETICULATE_MAX_CACHE_AGE", unset = "120")
+  max_age <- Sys.getenv("RETICULATE_MAX_CACHE_AGE_DAYS", unset = NA)
+  if (!is.na(max_age)) {
     max_age <- suppressWarnings(as.numeric(max_age))
     max_age <- as.difftime(max_age, units = "days")
+  } else {
+    max_age <- getOption(
+      "reticulate.max_cache_age",
+      as.difftime(120, units = "days")
+    )
   }
   if (is.na(max_age))
     return()

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -117,7 +117,15 @@
 #' ```
 #'
 #' Reticulate also clears its managed cache automatically on an interval,
-#' defaulting to every 120 days. Configure this interval in `.Rprofile` with:
+#' defaulting to every 120 days. Set `RETICULATE_MAX_CACHE_AGE` to a number of
+#' days in `.Renviron`:
+#'
+#' ```
+#' RETICULATE_MAX_CACHE_AGE=30
+#' ```
+#'
+#' The `reticulate.max_cache_age` R option takes precedence. Configure it in
+#' `.Rprofile` with:
 #'
 #' ```r
 #' options(reticulate.max_cache_age = as.difftime(30, units = "days"))
@@ -1150,10 +1158,12 @@ maybe_clear_reticulate_uv_cache <- function() {
   if (!file.exists(uv))
     return()
 
-  max_age <- getOption(
-    "reticulate.max_cache_age",
-    as.difftime(120, units = "days")
-  )
+  max_age <- getOption("reticulate.max_cache_age")
+  if (is.null(max_age)) {
+    max_age <- Sys.getenv("RETICULATE_MAX_CACHE_AGE", unset = "120")
+    max_age <- suppressWarnings(as.numeric(max_age))
+    max_age <- as.difftime(max_age, units = "days")
+  }
   if (is.na(max_age))
     return()
   if (!inherits(max_age, "difftime"))

--- a/man/py_require.Rd
+++ b/man/py_require.Rd
@@ -165,7 +165,14 @@ unlink(tools::R_user_dir("reticulate", "cache"), recursive = TRUE)
 }\if{html}{\out{</div>}}
 
 Reticulate also clears its managed cache automatically on an interval,
-defaulting to every 120 days. Configure this interval in \code{.Rprofile} with:
+defaulting to every 120 days. Set \code{RETICULATE_MAX_CACHE_AGE} to a number of
+days in \code{.Renviron}:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{RETICULATE_MAX_CACHE_AGE=30
+}\if{html}{\out{</div>}}
+
+The \code{reticulate.max_cache_age} R option takes precedence. Configure it in
+\code{.Rprofile} with:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{options(reticulate.max_cache_age = as.difftime(30, units = "days"))
 }\if{html}{\out{</div>}}

--- a/man/py_require.Rd
+++ b/man/py_require.Rd
@@ -165,14 +165,15 @@ unlink(tools::R_user_dir("reticulate", "cache"), recursive = TRUE)
 }\if{html}{\out{</div>}}
 
 Reticulate also clears its managed cache automatically on an interval,
-defaulting to every 120 days. Set \code{RETICULATE_MAX_CACHE_AGE} to a number of
-days in \code{.Renviron}:
+defaulting to every 120 days. Set \code{RETICULATE_MAX_CACHE_AGE_DAYS} to a
+possibly fractional number of days in \code{.Renviron}:
 
-\if{html}{\out{<div class="sourceCode">}}\preformatted{RETICULATE_MAX_CACHE_AGE=30
+\if{html}{\out{<div class="sourceCode">}}\preformatted{RETICULATE_MAX_CACHE_AGE_DAYS=30
 }\if{html}{\out{</div>}}
 
-The \code{reticulate.max_cache_age} R option takes precedence. Configure it in
-\code{.Rprofile} with:
+The environment variable takes precedence over the
+\code{reticulate.max_cache_age} R option. Configure the option in \code{.Rprofile}
+with:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{options(reticulate.max_cache_age = as.difftime(30, units = "days"))
 }\if{html}{\out{</div>}}

--- a/tests/testthat/test-cache-age.R
+++ b/tests/testthat/test-cache-age.R
@@ -1,14 +1,17 @@
-test_that("RETICULATE_MAX_CACHE_AGE configures automatic cache clearing", {
+test_that("RETICULATE_MAX_CACHE_AGE_DAYS takes precedence over the R option", {
   skip_if(getRversion() <= "4.0")
 
   cache_root <- withr::local_tempdir()
   withr::local_envvar(c(
     R_USER_CACHE_DIR = cache_root,
-    RETICULATE_MAX_CACHE_AGE = "0",
+    RETICULATE_MAX_CACHE_AGE_DAYS = "0",
     RETICULATE_PYTHON = file.path(cache_root, "missing-python"),
     UV_OFFLINE = NA
   ))
-  withr::local_options(reticulate.uv_binary = NULL)
+  withr::local_options(
+    reticulate.uv_binary = NULL,
+    reticulate.max_cache_age = as.difftime(30, units = "days")
+  )
 
   cache_dir <- tools::R_user_dir("reticulate", "cache")
   uv <- file.path(

--- a/tests/testthat/test-cache-age.R
+++ b/tests/testthat/test-cache-age.R
@@ -6,6 +6,7 @@ test_that("RETICULATE_MAX_CACHE_AGE_DAYS takes precedence over the R option", {
     R_USER_CACHE_DIR = cache_root,
     RETICULATE_MAX_CACHE_AGE_DAYS = "0",
     RETICULATE_PYTHON = file.path(cache_root, "missing-python"),
+    RETICULATE_UV = NA,
     UV_OFFLINE = NA
   ))
   withr::local_options(

--- a/tests/testthat/test-cache-age.R
+++ b/tests/testthat/test-cache-age.R
@@ -1,0 +1,31 @@
+test_that("RETICULATE_MAX_CACHE_AGE configures automatic cache clearing", {
+  skip_if(getRversion() <= "4.0")
+
+  cache_root <- withr::local_tempdir()
+  withr::local_envvar(c(
+    R_USER_CACHE_DIR = cache_root,
+    RETICULATE_MAX_CACHE_AGE = "0",
+    RETICULATE_PYTHON = file.path(cache_root, "missing-python"),
+    UV_OFFLINE = NA
+  ))
+  withr::local_options(reticulate.uv_binary = NULL)
+
+  cache_dir <- tools::R_user_dir("reticulate", "cache")
+  uv <- file.path(
+    cache_dir,
+    "uv",
+    "bin",
+    if (.Platform$OS.type == "windows") "uv.exe" else "uv"
+  )
+  dir.create(dirname(uv), recursive = TRUE)
+  marker <- file.path(cache_dir, "uv", "marker")
+  stopifnot(file.create(uv), file.create(marker))
+
+  expect_message(
+    virtualenv_starter(all = TRUE),
+    "Clearing reticulate's uv cache",
+    fixed = TRUE,
+    all = FALSE
+  )
+  expect_false(file.exists(marker))
+})


### PR DESCRIPTION
Closes #1905.

CRAN requested an environment-variable counterpart to
`reticulate.max_cache_age`.

This adds `RETICULATE_MAX_CACHE_AGE_DAYS`, interpreted as a possibly fractional
number of days. It takes precedence over the R option, while the default remains
120 days.

The change updates `?py_require` and NEWS and adds a regression covering
environment-variable precedence and cache clearing.
