### PR TITLE
Convert R abort restarts to Python exceptions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # reticulate (development version)
 
+- Reticulate now converts base R's built-in `abort` restart to a Python
+  exception when Python calls R, instead of jumping to R's top level.
+
 - Fixed `py_to_r()` conversion of pandas data frames and series containing
   Arrow-backed string columns (#1910).
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -142,9 +142,6 @@ call_r_function <- function(fn, args, named_args) {
     abort = function(cnd = NULL, ...) {
       if (!inherits(cnd, "condition"))
         cnd <- simpleError("R evaluation aborted")
-      else if (!inherits(cnd, "error"))
-        # Use the existing R-error-to-Python converter.
-        class(cnd) <- c("error", class(cnd))
 
       list(NULL, cnd)
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -137,6 +137,16 @@ call_r_function <- function(fn, args, named_args) {
 
     raise_py_exception = function(e) {
       list(NULL, e)
+    },
+
+    abort = function(cnd = NULL, ...) {
+      if (!inherits(cnd, "condition"))
+        cnd <- simpleError("R evaluation aborted")
+      else if (!inherits(cnd, "error"))
+        # Use the existing R-error-to-Python converter.
+        class(cnd) <- c("error", class(cnd))
+
+      list(NULL, cnd)
     }
   ) # end withRestarts()
 }

--- a/tests/testthat/test-python-exceptions.R
+++ b/tests/testthat/test-python-exceptions.R
@@ -156,12 +156,6 @@ test_that("R abort restarts become Python exceptions", {
     invokeRestart("abort", cnd)
   }
 
-  abort_with_plain_condition <- function() {
-    cnd <- simpleCondition("cancelled by condition")
-    cnd$metadata <- "preserved"
-    invokeRestart("abort", cnd)
-  }
-
   ordinary_error <- function() {
     stop("ordinary R error")
   }
@@ -196,21 +190,6 @@ survived_second_abort = True
 
   expect_true(py$survived_second_abort)
   expect_identical(py$condition_exception$trace, abort_state$trace)
-
-  py_run_string("
-try:
-    r.abort_with_plain_condition()
-except RuntimeError as exc:
-    plain_condition_exception = exc
-else:
-    raise AssertionError('expected an exception')
-
-assert str(plain_condition_exception) == 'cancelled by condition'
-")
-
-  expect_identical(py$plain_condition_exception$metadata, "preserved")
-  expect_contains(py$plain_condition_exception$r_class, "simpleCondition")
-  expect_false(py_has_attr(py$plain_condition_exception, "trace"))
 
   py_run_string("
 try:

--- a/tests/testthat/test-python-exceptions.R
+++ b/tests/testthat/test-python-exceptions.R
@@ -140,6 +140,93 @@ def catch_clear_errstatus_then_raise_new_exception(fn):
 })
 
 
+test_that("R abort restarts become Python exceptions", {
+  skip_if_no_python()
+
+  abort_state <- new.env(parent = emptyenv())
+
+  abort_without_condition <- function() {
+    invokeRestart("abort")
+  }
+
+  abort_with_condition <- function() {
+    cnd <- simpleError("cancelled from R")
+    cnd$trace <- rlang::trace_back()
+    abort_state$trace <- cnd$trace
+    invokeRestart("abort", cnd)
+  }
+
+  abort_with_plain_condition <- function() {
+    cnd <- simpleCondition("cancelled by condition")
+    cnd$metadata <- "preserved"
+    invokeRestart("abort", cnd)
+  }
+
+  ordinary_error <- function() {
+    stop("ordinary R error")
+  }
+
+  py_run_string("
+try:
+    r.abort_without_condition()
+except RuntimeError as exc:
+    abort_exception = exc
+else:
+    raise AssertionError('expected an exception')
+
+assert str(abort_exception) == 'R evaluation aborted'
+survived_first_abort = True
+")
+
+  expect_true(py$survived_first_abort)
+  expect_false(py_has_attr(py$abort_exception, "trace"))
+
+  py_run_string("
+try:
+    r.abort_with_condition()
+except RuntimeError as exc:
+    condition_exception = exc
+else:
+    raise AssertionError('expected an exception')
+
+assert str(condition_exception) == 'cancelled from R'
+assert r.identity(42) == 42
+survived_second_abort = True
+")
+
+  expect_true(py$survived_second_abort)
+  expect_identical(py$condition_exception$trace, abort_state$trace)
+
+  py_run_string("
+try:
+    r.abort_with_plain_condition()
+except RuntimeError as exc:
+    plain_condition_exception = exc
+else:
+    raise AssertionError('expected an exception')
+
+assert str(plain_condition_exception) == 'cancelled by condition'
+")
+
+  expect_identical(py$plain_condition_exception$metadata, "preserved")
+  expect_contains(py$plain_condition_exception$r_class, "simpleCondition")
+  expect_false(py_has_attr(py$plain_condition_exception, "trace"))
+
+  py_run_string("
+try:
+    r.ordinary_error()
+except RuntimeError as exc:
+    ordinary_exception = exc
+else:
+    raise AssertionError('expected an exception')
+
+assert str(ordinary_exception) == 'ordinary R error'
+")
+
+  expect_s3_class(py$ordinary_exception$trace, "rlang_trace")
+})
+
+
 test_that("confirm rlang/purrr can catch the exception", {
   skip_if_no_python()
 


### PR DESCRIPTION
Python calls through reticulate's `r` bridge now convert base R's built-in `abort` restart into a catchable Python `RuntimeError`. Without a nearer restart, `invokeRestart("abort")` selected R's top-level restart and jumped past reticulate's existing error handlers.

Internally, `call_r_function()` now installs an `abort` restart alongside `raise_py_exception` and returns the existing `(NULL, condition)` result. Supplied error conditions preserve their messages and existing R traces. Aborts without a condition use `R evaluation aborted` and do not synthesize an R trace. Other condition payloads remain safely contained by the existing `RuntimeError` fallback without changing their R classes. This adds no exported API.

The regression covers aborts with and without a supplied error condition, trace preservation, continued Python and R bridge use, and the existing `stop()` traceback behavior.

## Testing

- `devtools::test(filter = "python-exceptions", stop_on_failure = TRUE)` (197 passed)
- `devtools::test(stop_on_failure = TRUE)` (939 passed, 12 skipped)
- `devtools::check(error_on = "warning")` (0 errors, 0 warnings, 0 notes)
