### PR TITLE
Fix Clang nonnull warning in module name lookup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # reticulate (development version)
 
+- Fixed a `-Wnonnull` compiler warning from Clang 21 when building reticulate
+  (#1917).
+
 - Fixed `py_to_r()` conversion of pandas data frames and series containing
   Arrow-backed string columns (#1910).
 

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -647,7 +647,7 @@ std::string get_module_name(PyObject* classPtr) {
       }
       if (PyErr_Occurred()) PyErr_Print();
       REprintf("as_r_class: failed to convert __module__ bytes object to string\n");
-      return NULL;
+      return "";
     }
 
     // Fallback, if type(class) != type (i.e., it's a metaclass),


### PR DESCRIPTION
## Summary

Clang 21 warns when `get_module_name()` returns `NULL` from a function that returns `std::string`. Return an empty string instead, matching the existing fallback for unresolved module names and avoiding construction from a null pointer.

## User-facing changes

- Package builds no longer emit this `-Wnonnull` warning.
- Python object class naming remains unchanged.

## Internal changes

- Use the existing empty-module fallback in the bytes-valued `__module__` error path.
- Document the compiler warning fix in `NEWS.md`.
