### PR TITLE
Restore Python output streams after fork

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # reticulate (development version)
 
+- Reticulate now restores Python's original output streams in child processes
+  created by `os.fork()` when output remapping is enabled.
+
 - Fixed a `-Wnonnull` compiler warning from Clang 21 when building reticulate
   (#1917).
 

--- a/R/output.R
+++ b/R/output.R
@@ -20,6 +20,11 @@ remap_output_streams <- function() {
 set_output_streams <- function(tty) {
   stream_context <- output_stream_context(tty)
   stream_context$`__enter__`()
+
+  os <- import("os")
+  # Native extensions that bypass CPython's fork hooks are unsupported.
+  if (py_has_attr(os, "register_at_fork"))
+    os$register_at_fork(after_in_child = stream_context$`__exit__`)
 }
 
 set_knitr_python_stdout_hook <- function() {

--- a/R/output.R
+++ b/R/output.R
@@ -22,9 +22,13 @@ set_output_streams <- function(tty) {
   stream_context$`__enter__`()
 
   os <- import("os")
+  # The first context owns the original streams restored after a fork.
   # Native extensions that bypass CPython's fork hooks are unsupported.
-  if (py_has_attr(os, "register_at_fork"))
+  if (py_has_attr(os, "register_at_fork") &&
+      !isTRUE(.globals$output_stream_fork_hook_registered)) {
     os$register_at_fork(after_in_child = stream_context$`__exit__`)
+    .globals$output_stream_fork_hook_registered <- TRUE
+  }
 }
 
 set_knitr_python_stdout_hook <- function() {

--- a/inst/python/rpytools/output.py
+++ b/inst/python/rpytools/output.py
@@ -149,5 +149,7 @@ class RemapOutputStreams:
         _remap_output_streams(self.r_stdout, self.r_stderr, self.tty)
 
     def __exit__(self, *args):
-        sys.stdout = self._stdout
-        sys.stderr = self._stderr
+        if isinstance(sys.stdout, OutputRemap):
+            sys.stdout = self._stdout
+        if isinstance(sys.stderr, OutputRemap):
+            sys.stderr = self._stderr

--- a/tests/testthat/test-python-output.R
+++ b/tests/testthat/test-python-output.R
@@ -25,6 +25,57 @@ test_that("Python stderr stream can be captured", {
   expect_equal(capture_test_output(type = "stderr") , "err\n")
 })
 
+test_that("forked children restore fd-backed Python output streams", {
+  skip_on_os("windows")
+  skip_if_no_python()
+
+  os <- import("os")
+  skip_if(!py_has_attr(os, "register_at_fork"))
+
+  p <- callr::r_bg(
+    function() {
+      library(reticulate)
+
+      py_run_string("
+import os
+import sys
+
+inherited_stdout = sys.stdout
+inherited_stderr = sys.stderr
+pid = os.fork()
+
+if pid == 0:
+    if sys.stdout is inherited_stdout or sys.stderr is inherited_stderr:
+        os._exit(1)
+
+    sys.stdout.write('fork child stdout\\n')
+    sys.stderr.write('fork child stderr\\n')
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0)
+
+_, status = os.waitpid(pid, 0)
+if status != 0:
+    raise RuntimeError('forked child inherited remapped output streams')
+if sys.stdout is not inherited_stdout or sys.stderr is not inherited_stderr:
+    raise RuntimeError('parent output streams were restored')
+")
+
+      TRUE
+    },
+    env = c(
+      RETICULATE_PYTHON = py_exe(),
+      RETICULATE_REMAP_OUTPUT_STREAMS = "1"
+    )
+  )
+
+  p$wait()
+  expect_identical(p$get_exit_status(), 0L)
+  expect_true(p$get_result())
+  expect_match(p$read_all_output(), "fork child stdout", fixed = TRUE)
+  expect_match(p$read_all_error(), "fork child stderr", fixed = TRUE)
+})
+
 test_that("Python loggers work with py_capture_output", {
 
   skip_if(py_version() < "3.2")

--- a/tests/testthat/test-python-output.R
+++ b/tests/testthat/test-python-output.R
@@ -59,6 +59,44 @@ if status != 0:
     raise RuntimeError('forked child inherited remapped output streams')
 if sys.stdout is not inherited_stdout or sys.stderr is not inherited_stderr:
     raise RuntimeError('parent output streams were restored')
+
+class StreamProxy:
+    def __init__(self, stream):
+        self.stream = stream
+
+    def write(self, message):
+        return self.stream.write(message)
+
+    def flush(self):
+        return self.stream.flush()
+
+custom_stdout = StreamProxy(sys.__stdout__)
+custom_stderr = StreamProxy(sys.__stderr__)
+sys.stdout = custom_stdout
+sys.stderr = custom_stderr
+pid = os.fork()
+
+if pid == 0:
+    if sys.stdout is not custom_stdout or sys.stderr is not custom_stderr:
+        os._exit(1)
+
+    sys.stdout.write('custom fork child stdout\\n')
+    sys.stderr.write('custom fork child stderr\\n')
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0)
+
+_, status = os.waitpid(pid, 0)
+parent_streams_preserved = (
+    sys.stdout is custom_stdout and sys.stderr is custom_stderr
+)
+sys.stdout = inherited_stdout
+sys.stderr = inherited_stderr
+
+if status != 0:
+    raise RuntimeError('forked child did not preserve custom output streams')
+if not parent_streams_preserved:
+    raise RuntimeError('parent custom output streams were replaced')
 ")
 
       TRUE
@@ -72,8 +110,12 @@ if sys.stdout is not inherited_stdout or sys.stderr is not inherited_stderr:
   p$wait()
   expect_identical(p$get_exit_status(), 0L)
   expect_true(p$get_result())
-  expect_match(p$read_all_output(), "fork child stdout", fixed = TRUE)
-  expect_match(p$read_all_error(), "fork child stderr", fixed = TRUE)
+  stdout <- p$read_all_output()
+  stderr <- p$read_all_error()
+  expect_match(stdout, "fork child stdout", fixed = TRUE)
+  expect_match(stderr, "fork child stderr", fixed = TRUE)
+  expect_match(stdout, "custom fork child stdout", fixed = TRUE)
+  expect_match(stderr, "custom fork child stderr", fixed = TRUE)
 })
 
 test_that("Python loggers work with py_capture_output", {

--- a/tests/testthat/test-python-output.R
+++ b/tests/testthat/test-python-output.R
@@ -44,6 +44,7 @@ inherited_stdout = sys.stdout
 inherited_stderr = sys.stderr
 pid = os.fork()
 
+# os.fork() returns 0 in the child and the child's PID in the parent.
 if pid == 0:
     if sys.stdout is inherited_stdout or sys.stderr is inherited_stderr:
         os._exit(1)
@@ -76,6 +77,7 @@ sys.stdout = custom_stdout
 sys.stderr = custom_stderr
 pid = os.fork()
 
+# os.fork() returns 0 in the child and the child's PID in the parent.
 if pid == 0:
     if sys.stdout is not custom_stdout or sys.stderr is not custom_stderr:
         os._exit(1)


### PR DESCRIPTION
## Summary

When Python output remapping is enabled, a child created by `os.fork()` inherits callbacks into the copied R runtime. Restore the original fd-backed Python streams through CPython's child-fork hook so the child writes to its inherited operating-system streams while the parent remains remapped.

## User-facing changes

- Forked Python children no longer use inherited reticulate output callbacks.
- Replaced non-reticulate streams remain unchanged in the child.
- Temporary and nested output-capture contexts keep their existing behavior.

## Internal changes

- Register the first process-lifetime output context's bound exit method once.
- Restore a stream only when its current value is a reticulate `OutputRemap`.
- Cover child and parent stream identity, raw stdout and stderr, and later custom streams in a fresh background R process.

Native extensions that call `fork()` without CPython's `PyOS` fork hooks remain unsupported.
