### PR TITLE
Retain expired uv cache when the installer is unavailable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,10 @@
 - `RETICULATE_MAX_CACHE_AGE_DAYS` can now configure the maximum age, in days,
   of reticulate's managed `uv` cache before it is cleared (#1905).
 
+- Before automatic managed `uv` cache cleanup, reticulate now downloads the
+  `uv` installer and reuses it if a replacement is needed. If the download
+  fails, reticulate retains the expired cache (#1876).
+
 - Fixed managed `uv` bootstrapping on Windows when R inherits a PowerShell 7
   `PSModulePath`, such as from GitHub Actions `pwsh` steps.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,9 +15,8 @@
 - `RETICULATE_MAX_CACHE_AGE_DAYS` can now configure the maximum age, in days,
   of reticulate's managed `uv` cache before it is cleared (#1905).
 
-- Before automatic managed `uv` cache cleanup, reticulate now downloads the
-  `uv` installer and reuses it if a replacement is needed. If the download
-  fails, reticulate retains the expired cache (#1876).
+- Reticulate now checks that it can download the `uv` installer before clearing
+  an expired managed cache (#1876).
 
 - Fixed managed `uv` bootstrapping on Windows when R inherits a PowerShell 7
   `PSModulePath`, such as from GitHub Actions `pwsh` steps.

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -589,9 +589,13 @@ py_reqs_get <- function(x = NULL) {
 
 # uv ---------------------------------------------------------------------------
 
-uv_installer_url <- function() {
+download_uv_installer <- function(path) {
   file_ext <- if (is_windows()) ".ps1" else ".sh"
-  paste0("https://astral.sh/uv/install", file_ext)
+  download.file(
+    paste0("https://astral.sh/uv/install", file_ext),
+    path,
+    quiet = TRUE
+  )
 }
 
 uv_binary <- function(bootstrap_install = TRUE) {
@@ -696,7 +700,7 @@ uv_binary <- function(bootstrap_install = TRUE) {
       install_uv <- tempfile("install-uv-", fileext = file_ext)
       on.exit(unlink(install_uv), add = TRUE)
       message("Downloading uv...", appendLF = FALSE)
-      download.file(uv_installer_url(), install_uv, quiet = TRUE)
+      download_uv_installer(install_uv)
       if (!file.exists(install_uv)) {
         return(NULL)
         # stop("Unable to download Python dependencies. Please install `uv` manually.")
@@ -1209,7 +1213,7 @@ maybe_clear_reticulate_uv_cache <- function() {
     file_ext <- if (is_windows()) ".ps1" else ".sh"
     installer <- tempfile("install-uv-", fileext = file_ext)
     status <- suppressWarnings(try(
-      download.file(uv_installer_url(), installer, quiet = TRUE),
+      download_uv_installer(installer),
       silent = TRUE
     ))
     if (!identical(status, 0L) || !file.exists(installer)) {

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -132,6 +132,10 @@
 #' options(reticulate.max_cache_age = as.difftime(30, units = "days"))
 #' ```
 #'
+#' Before cleanup, reticulate downloads the `uv` installer and reuses it if a
+#' replacement is needed. If the download fails, reticulate retains the expired
+#' cache and defers cleanup.
+#'
 #' @param packages A character vector of Python packages to be available during
 #'   the session. These can be simple package names like `"jax"` or names with
 #'   version constraints like `"jax[cpu]>=0.5"`. Pip style syntax for installing
@@ -585,8 +589,14 @@ py_reqs_get <- function(x = NULL) {
 
 # uv ---------------------------------------------------------------------------
 
+uv_installer_url <- function() {
+  file_ext <- if (is_windows()) ".ps1" else ".sh"
+  paste0("https://astral.sh/uv/install", file_ext)
+}
+
 uv_binary <- function(bootstrap_install = TRUE) {
   min_uv_version <- numeric_version("0.6.3")
+  install_uv <- NULL
   is_usable_uv <- function(uv) {
     if (is.null(uv) || is.na(uv) || uv == "" || !file.exists(uv)) {
       return(FALSE)
@@ -604,7 +614,8 @@ uv_binary <- function(bootstrap_install = TRUE) {
     if (!is.na(uv)) {
       if (uv == "managed") {
         on.exit(
-          if(is_usable_uv(uv)) Sys.setenv(RETICULATE_UV = uv),
+          if (bootstrap_install && is_usable_uv(uv))
+            Sys.setenv(RETICULATE_UV = uv),
           add = TRUE
         )
         break
@@ -622,8 +633,14 @@ uv_binary <- function(bootstrap_install = TRUE) {
     # observed to be 0.2s for just `uv --version`.
     # This is an approach to avoid paying that cost on each invocation, mostly
     # motivated by uv_run_tool()
-    on.exit(if(is_usable_uv(uv)) options(reticulate.uv_binary = uv), add = TRUE)
-    maybe_clear_reticulate_uv_cache()
+    on.exit(
+      if ((bootstrap_install ||
+           !isTRUE(attr(uv, "reticulate-managed", exact = TRUE))) &&
+          is_usable_uv(uv)) {
+        options(reticulate.uv_binary = uv)
+      },
+      add = TRUE
+    )
 
     uv <- as.character(Sys.which("uv"))
     if (is_usable_uv(uv)) {
@@ -640,6 +657,12 @@ uv_binary <- function(bootstrap_install = TRUE) {
 
   uv <- reticulate_cache_dir("uv", "bin", if (is_windows()) "uv.exe" else "uv")
   attr(uv, "reticulate-managed") <- TRUE
+
+  if (bootstrap_install) {
+    install_uv <- maybe_clear_reticulate_uv_cache()
+    if (!is.null(install_uv))
+      on.exit(unlink(install_uv), add = TRUE)
+  }
 
   if (is_usable_uv(uv)) {
     return(uv)
@@ -668,16 +691,18 @@ uv_binary <- function(bootstrap_install = TRUE) {
     unlink(dirname(dirname(uv)), recursive = TRUE, force = TRUE)
 
     dir.create(dirname(uv), showWarnings = FALSE, recursive = TRUE)
-    file_ext <- if (is_windows()) ".ps1" else ".sh"
-    url <- paste0("https://astral.sh/uv/install", file_ext)
-    install_uv <- tempfile("install-uv-", fileext = file_ext)
-    message("Downloading uv...", appendLF = FALSE)
-    download.file(url, install_uv, quiet = TRUE)
-    if (!file.exists(install_uv)) {
-      return(NULL)
-      # stop("Unable to download Python dependencies. Please install `uv` manually.")
+    if (is.null(install_uv)) {
+      file_ext <- if (is_windows()) ".ps1" else ".sh"
+      install_uv <- tempfile("install-uv-", fileext = file_ext)
+      on.exit(unlink(install_uv), add = TRUE)
+      message("Downloading uv...", appendLF = FALSE)
+      download.file(uv_installer_url(), install_uv, quiet = TRUE)
+      if (!file.exists(install_uv)) {
+        return(NULL)
+        # stop("Unable to download Python dependencies. Please install `uv` manually.")
+      }
+      message("Done!")
     }
-    message("Done!")
     if (debug_uv <- Sys.getenv("_RETICULATE_DEBUG_UV_") == "1")
       system2 <- system2t
 
@@ -1181,6 +1206,21 @@ maybe_clear_reticulate_uv_cache <- function() {
     if (Sys.getenv("UV_OFFLINE") == "1")
       return()
 
+    file_ext <- if (is_windows()) ".ps1" else ".sh"
+    installer <- tempfile("install-uv-", fileext = file_ext)
+    status <- suppressWarnings(try(
+      download.file(uv_installer_url(), installer, quiet = TRUE),
+      silent = TRUE
+    ))
+    if (!identical(status, 0L) || !file.exists(installer)) {
+      unlink(installer)
+      message(
+        "Retaining reticulate's uv cache because access to the uv ",
+        "installer could not be verified."
+      )
+      return()
+    }
+
     cache_dir <- reticulate_cache_dir("uv")
     # best-effort; avoid surfacing errors
     message("Clearing reticulate's uv cache...", appendLF = FALSE)
@@ -1196,5 +1236,6 @@ maybe_clear_reticulate_uv_cache <- function() {
       error = warning
     )
     message("Done!")
+    installer
   }
 }

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -589,13 +589,22 @@ py_reqs_get <- function(x = NULL) {
 
 # uv ---------------------------------------------------------------------------
 
-download_uv_installer <- function(path) {
+download_uv_installer <- function() {
   file_ext <- if (is_windows()) ".ps1" else ".sh"
-  download.file(
+  installer <- tempfile("install-uv-", fileext = file_ext)
+  downloaded <- FALSE
+  on.exit(if (!downloaded) unlink(installer), add = TRUE)
+
+  status <- download.file(
     paste0("https://astral.sh/uv/install", file_ext),
-    path,
+    installer,
     quiet = TRUE
   )
+  if (!identical(status, 0L) || !file.exists(installer))
+    return()
+
+  downloaded <- TRUE
+  installer
 }
 
 uv_binary <- function(bootstrap_install = TRUE) {
@@ -696,15 +705,13 @@ uv_binary <- function(bootstrap_install = TRUE) {
 
     dir.create(dirname(uv), showWarnings = FALSE, recursive = TRUE)
     if (is.null(install_uv)) {
-      file_ext <- if (is_windows()) ".ps1" else ".sh"
-      install_uv <- tempfile("install-uv-", fileext = file_ext)
-      on.exit(unlink(install_uv), add = TRUE)
       message("Downloading uv...", appendLF = FALSE)
-      download_uv_installer(install_uv)
-      if (!file.exists(install_uv)) {
+      install_uv <- download_uv_installer()
+      if (is.null(install_uv)) {
         return(NULL)
         # stop("Unable to download Python dependencies. Please install `uv` manually.")
       }
+      on.exit(unlink(install_uv), add = TRUE)
       message("Done!")
     }
     if (debug_uv <- Sys.getenv("_RETICULATE_DEBUG_UV_") == "1")
@@ -1210,14 +1217,11 @@ maybe_clear_reticulate_uv_cache <- function() {
     if (Sys.getenv("UV_OFFLINE") == "1")
       return()
 
-    file_ext <- if (is_windows()) ".ps1" else ".sh"
-    installer <- tempfile("install-uv-", fileext = file_ext)
-    status <- suppressWarnings(try(
-      download_uv_installer(installer),
+    installer <- suppressWarnings(try(
+      download_uv_installer(),
       silent = TRUE
     ))
-    if (!identical(status, 0L) || !file.exists(installer)) {
-      unlink(installer)
+    if (inherits(installer, "try-error") || is.null(installer)) {
       message(
         "Retaining reticulate's uv cache because access to the uv ",
         "installer could not be verified."

--- a/R/virtualenv.R
+++ b/R/virtualenv.R
@@ -681,7 +681,7 @@ virtualenv_starter <- function(version = NULL, all = FALSE) {
   # We skip reticulate-managed uv installs because reticulate deletes their Pythons when it clears its cache.
   uv <- uv_binary(bootstrap_install = FALSE)
   is_user_uv <-
-    !is.null(uv) && !isTRUE(attr(uv_binary(FALSE), "reticulate-managed", TRUE))
+    !is.null(uv) && !isTRUE(attr(uv, "reticulate-managed", TRUE))
   if (is_user_uv) {
     find_starters(suppressWarnings(uv_exec(c(
       "python dir --managed-python",

--- a/man/py_require.Rd
+++ b/man/py_require.Rd
@@ -177,5 +177,9 @@ with:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{options(reticulate.max_cache_age = as.difftime(30, units = "days"))
 }\if{html}{\out{</div>}}
+
+Before cleanup, reticulate downloads the \code{uv} installer and reuses it if a
+replacement is needed. If the download fails, reticulate retains the expired
+cache and defers cleanup.
 }
 }

--- a/tests/testthat/test-cache-age.R
+++ b/tests/testthat/test-cache-age.R
@@ -1,18 +1,26 @@
-test_that("RETICULATE_MAX_CACHE_AGE_DAYS takes precedence over the R option", {
-  skip_if(getRversion() <= "4.0")
+local_expired_uv_cache <- function(max_cache_age = NULL,
+                                   reticulate_uv = NA_character_) {
+  local_envir <- parent.frame()
+  cache_root <- withr::local_tempdir(.local_envir = local_envir)
+  home <- withr::local_tempdir(.local_envir = local_envir)
+  bin_dir <- withr::local_tempdir(.local_envir = local_envir)
 
-  cache_root <- withr::local_tempdir()
   withr::local_envvar(c(
     R_USER_CACHE_DIR = cache_root,
     RETICULATE_MAX_CACHE_AGE_DAYS = "0",
     RETICULATE_PYTHON = file.path(cache_root, "missing-python"),
-    RETICULATE_UV = NA,
-    UV_OFFLINE = NA
-  ))
-  withr::local_options(
-    reticulate.uv_binary = NULL,
-    reticulate.max_cache_age = as.difftime(30, units = "days")
-  )
+    RETICULATE_UV = reticulate_uv,
+    UV_OFFLINE = NA,
+    UV_PYTHON_PREFERENCE = "only-managed",
+    HOME = home,
+    USERPROFILE = home,
+    PATH = bin_dir
+  ), .local_envir = local_envir)
+
+  options <- list(reticulate.uv_binary = NULL)
+  if (!is.null(max_cache_age))
+    options$reticulate.max_cache_age <- max_cache_age
+  withr::local_options(options, .local_envir = local_envir)
 
   cache_dir <- tools::R_user_dir("reticulate", "cache")
   uv <- file.path(
@@ -25,11 +33,175 @@ test_that("RETICULATE_MAX_CACHE_AGE_DAYS takes precedence over the R option", {
   marker <- file.path(cache_dir, "uv", "marker")
   stopifnot(file.create(uv), file.create(marker))
 
-  expect_message(
-    virtualenv_starter(all = TRUE),
-    "Clearing reticulate's uv cache",
-    fixed = TRUE,
-    all = FALSE
+  state <- new.env(parent = emptyenv())
+  state$bin_dir <- bin_dir
+  state$downloads <- 0L
+  state$installer <- NULL
+  state$marker <- marker
+  state$uv <- uv
+  state
+}
+
+mock_installer_download <- function(state, succeeds = TRUE) {
+  force(state)
+  force(succeeds)
+  function(url, destfile, ...) {
+    state$downloads <- state$downloads + 1L
+    state$installer <- destfile
+    writeLines("installer", destfile)
+    if (!succeeds)
+      stop("offline", call. = FALSE)
+    0L
+  }
+}
+
+same_file_path <- function(x, y) {
+  identical(
+    normalizePath(x, winslash = "/", mustWork = FALSE),
+    normalizePath(y, winslash = "/", mustWork = FALSE)
   )
-  expect_false(file.exists(marker))
+}
+
+mock_uv_system2 <- function(state, python_version, install = FALSE) {
+  force(state)
+  force(python_version)
+  force(install)
+  version_parts <- strsplit(python_version, ".", fixed = TRUE)[[1L]]
+  stopifnot(length(version_parts) == 3L)
+  python_list <- paste0(
+    '[{"version":"', python_version, '",',
+    '"version_parts":{"major":', version_parts[[1L]],
+    ',"minor":', version_parts[[2L]],
+    ',"patch":', version_parts[[3L]], '},',
+    '"path":null,"symlink":null,',
+    '"url":"https://example.invalid/python",',
+    '"variant":"default","implementation":"cpython"}]'
+  )
+  function(command, args = character(), ...) {
+    command <- as.character(command)
+    if (same_file_path(command, state$uv)) {
+      if (identical(args, "--version"))
+        return("uv 999.0.0")
+      if (any(grepl("python list", args, fixed = TRUE)))
+        return(python_list)
+      return(0L)
+    }
+
+    is_installer <- !is.null(state$installer) &&
+      if (.Platform$OS.type == "windows") {
+        identical(tolower(basename(command)), "powershell.exe") &&
+          utils::shortPathName(state$installer) %in% args
+      } else {
+        same_file_path(command, state$installer)
+      }
+    if (is_installer && install) {
+      dir.create(dirname(state$uv), recursive = TRUE, showWarnings = FALSE)
+      stopifnot(file.create(state$uv))
+      return(0L)
+    }
+
+    stop("unexpected system2 call: ", command, call. = FALSE)
+  }
+}
+
+test_that("RETICULATE_MAX_CACHE_AGE_DAYS takes precedence over the R option", {
+  skip_if(getRversion() <= "4.0")
+
+  state <- local_expired_uv_cache(as.difftime(30, units = "days"))
+  result <- testthat::with_mocked_bindings(
+    testthat::with_mocked_bindings(
+      expect_message(
+        uv_run_tool("example", python_version = "3.12.999"),
+        "Clearing reticulate's uv cache",
+        fixed = TRUE,
+        all = FALSE
+      ),
+      system2 = mock_uv_system2(state, "3.12.999", install = TRUE),
+      .package = "base"
+    ),
+    download.file = mock_installer_download(state),
+    .package = "reticulate"
+  )
+
+  expect_equal(result, 0L)
+  expect_equal(state$downloads, 1L)
+  expect_false(file.exists(state$installer))
+  expect_false(file.exists(state$marker))
+})
+
+test_that("expired uv cache is retained when the uv installer is unavailable", {
+  skip_if(getRversion() <= "4.0")
+
+  state <- local_expired_uv_cache()
+  result <- testthat::with_mocked_bindings(
+    testthat::with_mocked_bindings(
+      expect_message(
+        uv_run_tool("example", python_version = "3.12.998"),
+        "Retaining reticulate's uv cache",
+        fixed = TRUE,
+        all = FALSE
+      ),
+      system2 = mock_uv_system2(state, "3.12.998"),
+      .package = "base"
+    ),
+    download.file = mock_installer_download(state, succeeds = FALSE),
+    .package = "reticulate"
+  )
+
+  expect_equal(result, 0L)
+  expect_equal(state$downloads, 1L)
+  expect_false(file.exists(state$installer))
+  expect_true(file.exists(state$uv))
+  expect_true(file.exists(state$marker))
+})
+
+test_that("uv availability probes do not clear the expired cache", {
+  skip_if(getRversion() <= "4.0")
+
+  for (reticulate_uv in list(NA_character_, "managed")) {
+    local({
+      python_version <- if (is.na(reticulate_uv)) "3.12.997" else "3.12.996"
+      state <- local_expired_uv_cache(reticulate_uv = reticulate_uv)
+      system2 <- base::system2
+      uv_version_checks <- 0L
+
+      result <- testthat::with_mocked_bindings(
+        {
+          testthat::with_mocked_bindings(
+            virtualenv_starter(all = TRUE),
+            system2 = function(command, args = character(), ...) {
+              if (same_file_path(as.character(command), state$uv) &&
+                  identical(args, "--version")) {
+                uv_version_checks <<- uv_version_checks + 1L
+                return("uv 999.0.0")
+              }
+              system2(command, args, ...)
+            },
+            .package = "base"
+          )
+
+          expect_equal(state$downloads, 0L)
+          expect_equal(uv_version_checks, 1L)
+          expect_true(file.exists(state$marker))
+
+          testthat::with_mocked_bindings(
+            uv_run_tool("example", python_version = python_version),
+            system2 = mock_uv_system2(
+              state,
+              python_version,
+              install = TRUE
+            ),
+            .package = "base"
+          )
+        },
+        download.file = mock_installer_download(state),
+        .package = "reticulate"
+      )
+
+      expect_equal(result, 0L)
+      expect_equal(state$downloads, 1L)
+      expect_false(file.exists(state$installer))
+      expect_false(file.exists(state$marker))
+    })
+  }
 })

--- a/tests/testthat/test-cache-age.R
+++ b/tests/testthat/test-cache-age.R
@@ -1,5 +1,6 @@
-local_expired_uv_cache <- function(max_cache_age = NULL,
-                                   reticulate_uv = NA_character_) {
+local_uv_cache <- function(max_cache_age = NULL,
+                           reticulate_uv = NA_character_,
+                           installed = TRUE) {
   local_envir <- parent.frame()
   cache_root <- withr::local_tempdir(.local_envir = local_envir)
   home <- withr::local_tempdir(.local_envir = local_envir)
@@ -29,14 +30,17 @@ local_expired_uv_cache <- function(max_cache_age = NULL,
     "bin",
     if (.Platform$OS.type == "windows") "uv.exe" else "uv"
   )
-  dir.create(dirname(uv), recursive = TRUE)
   marker <- file.path(cache_dir, "uv", "marker")
-  stopifnot(file.create(uv), file.create(marker))
+  if (installed) {
+    dir.create(dirname(uv), recursive = TRUE)
+    stopifnot(file.create(uv), file.create(marker))
+  }
 
   state <- new.env(parent = emptyenv())
   state$bin_dir <- bin_dir
   state$downloads <- 0L
   state$installer <- NULL
+  state$installer_runs <- 0L
   state$marker <- marker
   state$uv <- uv
   state
@@ -95,6 +99,7 @@ mock_uv_system2 <- function(state, python_version, install = FALSE) {
         same_file_path(command, state$installer)
       }
     if (is_installer && install) {
+      state$installer_runs <- state$installer_runs + 1L
       dir.create(dirname(state$uv), recursive = TRUE, showWarnings = FALSE)
       stopifnot(file.create(state$uv))
       return(0L)
@@ -107,7 +112,7 @@ mock_uv_system2 <- function(state, python_version, install = FALSE) {
 test_that("RETICULATE_MAX_CACHE_AGE_DAYS takes precedence over the R option", {
   skip_if(getRversion() <= "4.0")
 
-  state <- local_expired_uv_cache(as.difftime(30, units = "days"))
+  state <- local_uv_cache(as.difftime(30, units = "days"))
   result <- testthat::with_mocked_bindings(
     testthat::with_mocked_bindings(
       expect_message(
@@ -125,14 +130,36 @@ test_that("RETICULATE_MAX_CACHE_AGE_DAYS takes precedence over the R option", {
 
   expect_equal(result, 0L)
   expect_equal(state$downloads, 1L)
+  expect_equal(state$installer_runs, 1L)
   expect_false(file.exists(state$installer))
   expect_false(file.exists(state$marker))
+})
+
+test_that("missing uv is bootstrapped from the downloaded installer", {
+  skip_if(getRversion() <= "4.0")
+
+  state <- local_uv_cache(installed = FALSE)
+  result <- testthat::with_mocked_bindings(
+    testthat::with_mocked_bindings(
+      uv_run_tool("example", python_version = "3.12.995"),
+      system2 = mock_uv_system2(state, "3.12.995", install = TRUE),
+      .package = "base"
+    ),
+    download.file = mock_installer_download(state),
+    .package = "reticulate"
+  )
+
+  expect_equal(result, 0L)
+  expect_equal(state$downloads, 1L)
+  expect_equal(state$installer_runs, 1L)
+  expect_true(file.exists(state$uv))
+  expect_false(file.exists(state$installer))
 })
 
 test_that("expired uv cache is retained when the uv installer is unavailable", {
   skip_if(getRversion() <= "4.0")
 
-  state <- local_expired_uv_cache()
+  state <- local_uv_cache()
   result <- testthat::with_mocked_bindings(
     testthat::with_mocked_bindings(
       expect_message(
@@ -161,7 +188,7 @@ test_that("uv availability probes do not clear the expired cache", {
   for (reticulate_uv in list(NA_character_, "managed")) {
     local({
       python_version <- if (is.na(reticulate_uv)) "3.12.997" else "3.12.996"
-      state <- local_expired_uv_cache(reticulate_uv = reticulate_uv)
+      state <- local_uv_cache(reticulate_uv = reticulate_uv)
       system2 <- base::system2
       uv_version_checks <- 0L
 
@@ -200,6 +227,7 @@ test_that("uv availability probes do not clear the expired cache", {
 
       expect_equal(result, 0L)
       expect_equal(state$downloads, 1L)
+      expect_equal(state$installer_runs, 1L)
       expect_false(file.exists(state$installer))
       expect_false(file.exists(state$marker))
     })

--- a/tests/testthat/test-cache-age.R
+++ b/tests/testthat/test-cache-age.R
@@ -1,27 +1,27 @@
-local_uv_cache <- function(max_cache_age = NULL,
-                           reticulate_uv = NA_character_,
-                           installed = TRUE) {
-  local_envir <- parent.frame()
-  cache_root <- withr::local_tempdir(.local_envir = local_envir)
-  home <- withr::local_tempdir(.local_envir = local_envir)
-  bin_dir <- withr::local_tempdir(.local_envir = local_envir)
+test_that("expired uv cache is retained when the installer is unavailable", {
+  skip_if(getRversion() <= "4.0")
 
+  system_uv <- Sys.which("uv")
+  skip_if(!nzchar(system_uv), "uv is not installed")
+  version <- suppressWarnings(numeric_version(
+    sub("uv ([0-9.]+).*", "\\1", system2(system_uv, "--version", stdout = TRUE)),
+    strict = FALSE
+  ))
+  skip_if(anyNA(version) || version < "0.6.3", "uv is too old")
+
+  cache_root <- withr::local_tempdir()
   withr::local_envvar(c(
     R_USER_CACHE_DIR = cache_root,
-    RETICULATE_MAX_CACHE_AGE_DAYS = "0",
-    RETICULATE_PYTHON = file.path(cache_root, "missing-python"),
-    RETICULATE_UV = reticulate_uv,
+    RETICULATE_MAX_CACHE_AGE_DAYS = "-1",
+    RETICULATE_UV = "managed",
     UV_OFFLINE = NA,
-    UV_PYTHON_PREFERENCE = "only-managed",
-    HOME = home,
-    USERPROFILE = home,
-    PATH = bin_dir
-  ), .local_envir = local_envir)
-
-  options <- list(reticulate.uv_binary = NULL)
-  if (!is.null(max_cache_age))
-    options$reticulate.max_cache_age <- max_cache_age
-  withr::local_options(options, .local_envir = local_envir)
+    UV_PYTHON_PREFERENCE = "only-managed"
+  ))
+  withr::local_options(
+    download.file.method = "invalid",
+    reticulate.max_cache_age = as.difftime(30, units = "days"),
+    reticulate.uv_binary = NULL
+  )
 
   cache_dir <- tools::R_user_dir("reticulate", "cache")
   uv <- file.path(
@@ -31,205 +31,19 @@ local_uv_cache <- function(max_cache_age = NULL,
     if (.Platform$OS.type == "windows") "uv.exe" else "uv"
   )
   marker <- file.path(cache_dir, "uv", "marker")
-  if (installed) {
-    dir.create(dirname(uv), recursive = TRUE)
-    stopifnot(file.create(uv), file.create(marker))
-  }
+  dir.create(dirname(uv), recursive = TRUE)
+  stopifnot(file.copy(system_uv, uv), file.create(marker))
 
-  state <- new.env(parent = emptyenv())
-  state$bin_dir <- bin_dir
-  state$downloads <- 0L
-  state$installer <- NULL
-  state$installer_runs <- 0L
-  state$marker <- marker
-  state$uv <- uv
-  state
-}
-
-mock_installer_download <- function(state, succeeds = TRUE) {
-  force(state)
-  force(succeeds)
-  function(url, destfile, ...) {
-    state$downloads <- state$downloads + 1L
-    state$installer <- destfile
-    writeLines("installer", destfile)
-    if (!succeeds)
-      stop("offline", call. = FALSE)
-    0L
-  }
-}
-
-same_file_path <- function(x, y) {
-  identical(
-    normalizePath(x, winslash = "/", mustWork = FALSE),
-    normalizePath(y, winslash = "/", mustWork = FALSE)
-  )
-}
-
-mock_uv_system2 <- function(state, python_version, install = FALSE) {
-  force(state)
-  force(python_version)
-  force(install)
-  version_parts <- strsplit(python_version, ".", fixed = TRUE)[[1L]]
-  stopifnot(length(version_parts) == 3L)
-  python_list <- paste0(
-    '[{"version":"', python_version, '",',
-    '"version_parts":{"major":', version_parts[[1L]],
-    ',"minor":', version_parts[[2L]],
-    ',"patch":', version_parts[[3L]], '},',
-    '"path":null,"symlink":null,',
-    '"url":"https://example.invalid/python",',
-    '"variant":"default","implementation":"cpython"}]'
-  )
-  function(command, args = character(), ...) {
-    command <- as.character(command)
-    if (same_file_path(command, state$uv)) {
-      if (identical(args, "--version"))
-        return("uv 999.0.0")
-      if (any(grepl("python list", args, fixed = TRUE)))
-        return(python_list)
-      return(0L)
-    }
-
-    is_installer <- !is.null(state$installer) &&
-      if (.Platform$OS.type == "windows") {
-        identical(tolower(basename(command)), "powershell.exe") &&
-          utils::shortPathName(state$installer) %in% args
-      } else {
-        same_file_path(command, state$installer)
-      }
-    if (is_installer && install) {
-      state$installer_runs <- state$installer_runs + 1L
-      dir.create(dirname(state$uv), recursive = TRUE, showWarnings = FALSE)
-      stopifnot(file.create(state$uv))
-      return(0L)
-    }
-
-    stop("unexpected system2 call: ", command, call. = FALSE)
-  }
-}
-
-test_that("RETICULATE_MAX_CACHE_AGE_DAYS takes precedence over the R option", {
-  skip_if(getRversion() <= "4.0")
-
-  state <- local_uv_cache(as.difftime(30, units = "days"))
-  result <- testthat::with_mocked_bindings(
-    testthat::with_mocked_bindings(
-      expect_message(
-        uv_run_tool("example", python_version = "3.12.999"),
-        "Clearing reticulate's uv cache",
-        fixed = TRUE,
-        all = FALSE
-      ),
-      system2 = mock_uv_system2(state, "3.12.999", install = TRUE),
-      .package = "base"
+  expect_error(
+    expect_message(
+      uv_run_tool("example", python_version = ">999"),
+      "Retaining reticulate's uv cache",
+      fixed = TRUE,
+      all = FALSE
     ),
-    download.file = mock_installer_download(state),
-    .package = "reticulate"
+    "could not be satisfied",
+    fixed = TRUE
   )
-
-  expect_equal(result, 0L)
-  expect_equal(state$downloads, 1L)
-  expect_equal(state$installer_runs, 1L)
-  expect_false(file.exists(state$installer))
-  expect_false(file.exists(state$marker))
-})
-
-test_that("missing uv is bootstrapped from the downloaded installer", {
-  skip_if(getRversion() <= "4.0")
-
-  state <- local_uv_cache(installed = FALSE)
-  result <- testthat::with_mocked_bindings(
-    testthat::with_mocked_bindings(
-      uv_run_tool("example", python_version = "3.12.995"),
-      system2 = mock_uv_system2(state, "3.12.995", install = TRUE),
-      .package = "base"
-    ),
-    download.file = mock_installer_download(state),
-    .package = "reticulate"
-  )
-
-  expect_equal(result, 0L)
-  expect_equal(state$downloads, 1L)
-  expect_equal(state$installer_runs, 1L)
-  expect_true(file.exists(state$uv))
-  expect_false(file.exists(state$installer))
-})
-
-test_that("expired uv cache is retained when the uv installer is unavailable", {
-  skip_if(getRversion() <= "4.0")
-
-  state <- local_uv_cache()
-  result <- testthat::with_mocked_bindings(
-    testthat::with_mocked_bindings(
-      expect_message(
-        uv_run_tool("example", python_version = "3.12.998"),
-        "Retaining reticulate's uv cache",
-        fixed = TRUE,
-        all = FALSE
-      ),
-      system2 = mock_uv_system2(state, "3.12.998"),
-      .package = "base"
-    ),
-    download.file = mock_installer_download(state, succeeds = FALSE),
-    .package = "reticulate"
-  )
-
-  expect_equal(result, 0L)
-  expect_equal(state$downloads, 1L)
-  expect_false(file.exists(state$installer))
-  expect_true(file.exists(state$uv))
-  expect_true(file.exists(state$marker))
-})
-
-test_that("uv availability probes do not clear the expired cache", {
-  skip_if(getRversion() <= "4.0")
-
-  for (reticulate_uv in list(NA_character_, "managed")) {
-    local({
-      python_version <- if (is.na(reticulate_uv)) "3.12.997" else "3.12.996"
-      state <- local_uv_cache(reticulate_uv = reticulate_uv)
-      system2 <- base::system2
-      uv_version_checks <- 0L
-
-      result <- testthat::with_mocked_bindings(
-        {
-          testthat::with_mocked_bindings(
-            virtualenv_starter(all = TRUE),
-            system2 = function(command, args = character(), ...) {
-              if (same_file_path(as.character(command), state$uv) &&
-                  identical(args, "--version")) {
-                uv_version_checks <<- uv_version_checks + 1L
-                return("uv 999.0.0")
-              }
-              system2(command, args, ...)
-            },
-            .package = "base"
-          )
-
-          expect_equal(state$downloads, 0L)
-          expect_equal(uv_version_checks, 1L)
-          expect_true(file.exists(state$marker))
-
-          testthat::with_mocked_bindings(
-            uv_run_tool("example", python_version = python_version),
-            system2 = mock_uv_system2(
-              state,
-              python_version,
-              install = TRUE
-            ),
-            .package = "base"
-          )
-        },
-        download.file = mock_installer_download(state),
-        .package = "reticulate"
-      )
-
-      expect_equal(result, 0L)
-      expect_equal(state$downloads, 1L)
-      expect_equal(state$installer_runs, 1L)
-      expect_false(file.exists(state$installer))
-      expect_false(file.exists(state$marker))
-    })
-  }
+  expect_true(file.exists(uv))
+  expect_true(file.exists(marker))
 })


### PR DESCRIPTION
## Summary

Reticulate currently clears an expired managed `uv` cache before it knows whether it can bootstrap `uv` again. If the installer is unavailable, this removes a working cache without creating a replacement.

This change downloads the platform installer before automatic cleanup. A failed download defers cleanup and retains the cache. A successful download is reused when reticulate replaces its managed `uv`, avoiding a second request.

## User-facing changes

- Retains an expired managed `uv` cache when the installer download fails.
- Avoids network access and cache deletion during non-installing availability probes.
- Continues to honor `RETICULATE_MAX_CACHE_AGE_DAYS` and `reticulate.max_cache_age` when a managed bootstrap can proceed.

## Internal changes

- Centralizes installer tempfile creation, download validation, and failed-download cleanup.
- Passes a successful installer download through cache cleanup into the existing managed `uv` installation path.
- Prevents probe-only calls from caching a managed `uv` path and bypassing cleanup on later use.
- Reuses the resolved `uv` value in `virtualenv_starter()` so discovery performs one version check.
- Adds a compact public regression for retaining the cache when the installer download fails.

Related to #1876.
