### PR TITLE
List Tomasz Kalinowski as an author

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: Interface to 'Python'
 Version: 1.46.0.9000
 Authors@R: c(
-  person("Tomasz", "Kalinowski", role = c("ctb", "cre"),
+  person("Tomasz", "Kalinowski", role = c("aut", "cre"),
          email = "tomasz@posit.co"),
   person("Kevin", "Ushey", role = c("aut"),
          email = "kevin@posit.co"),

--- a/man/reticulate.Rd
+++ b/man/reticulate.Rd
@@ -22,10 +22,11 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Tomasz Kalinowski \email{tomasz@posit.co} [contributor]
+\strong{Maintainer}: Tomasz Kalinowski \email{tomasz@posit.co}
 
 Authors:
 \itemize{
+  \item Tomasz Kalinowski \email{tomasz@posit.co}
   \item Kevin Ushey \email{kevin@posit.co}
   \item JJ Allaire \email{jj@posit.co}
   \item Yuan Tang \email{terrytangyuan@gmail.com} (\href{https://orcid.org/0000-0001-5243-233X}{ORCID}) [copyright holder]


### PR DESCRIPTION
I've maintained and developed reticulate since 2022. 
This updates my `Authors@R` role from contributor (`ctb`) to author (`aut`).
