### PR TITLE
Accept R date objects for exclude_newer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # reticulate (development version)
 
+- The `exclude_newer` arguments to `py_require()` and `uv_run_tool()` now
+  accept `Date` and `POSIXt` objects. Date-times are converted to UTC RFC 3339
+  timestamps.
+
 - `py_require()` now applies late package additions atomically. Failed
   package-originated additions warn without changing the declared requirements.
   Its printed summary now shows successful requirement requests in chronological

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,7 @@
 # reticulate (development version)
 
 - The `exclude_newer` arguments to `py_require()` and `uv_run_tool()` now
-  accept `Date` and `POSIXt` objects. Date-times are converted to whole-second
-  UTC RFC 3339 timestamps.
+  accept `Date` and `POSIXt` objects.
 
 - `py_require()` now applies late package additions atomically. Failed
   package-originated additions warn without changing the declared requirements.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,8 @@
 # reticulate (development version)
 
 - The `exclude_newer` arguments to `py_require()` and `uv_run_tool()` now
-  accept `Date` and `POSIXt` objects. Date-times are converted to UTC RFC 3339
-  timestamps.
+  accept `Date` and `POSIXt` objects. Date-times are converted to whole-second
+  UTC RFC 3339 timestamps.
 
 - `py_require()` now applies late package additions atomically. Failed
   package-originated additions warn without changing the declared requirements.

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -163,7 +163,7 @@
 #'   timestamp strings (e.g., `"2006-12-02T02:07:43Z"`), local-date strings
 #'   (e.g., `"2006-12-02"`) or `Date` objects, and `POSIXt` objects. Local dates
 #'   use your system's configured time zone; `POSIXt` values are converted to
-#'   UTC. Once
+#'   UTC at whole-second precision. Once
 #'   `exclude_newer` is set, `action = "add"` cannot change it. Use
 #'   `action = "set"` to replace it. To clear it, use `action = "remove"` with
 #'   the same value, `NA`, or `""`.

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -161,9 +161,8 @@
 #'   versions, helping guard against Python package updates that break a
 #'   workflow. Accepts RFC 3339
 #'   timestamp strings (e.g., `"2006-12-02T02:07:43Z"`), local-date strings
-#'   (e.g., `"2006-12-02"`) or `Date` objects, and `POSIXt` objects. Local dates
-#'   use your system's configured time zone; `POSIXt` values are converted to
-#'   UTC at whole-second precision. Once
+#'   (e.g., `"2006-12-02"`), `Date` objects, and `POSIXt` objects. Local dates
+#'   use your system's configured time zone. Once
 #'   `exclude_newer` is set, `action = "add"` cannot change it. Use
 #'   `action = "set"` to replace it. To clear it, use `action = "remove"` with
 #'   the same value, `NA`, or `""`.

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -159,11 +159,14 @@
 #' @param exclude_newer Limit package versions to those published before a
 #'   specified date. This offers a lightweight alternative to freezing package
 #'   versions, helping guard against Python package updates that break a
-#'   workflow. Accepts strings formatted as RFC 3339 timestamps (e.g.,
-#'   `"2006-12-02T02:07:43Z"`) and local dates in the same format (e.g.,
-#'   `"2006-12-02"`) in your system's configured time zone. Once `exclude_newer`
-#'   is set, `action = "add"` cannot change it. Use `action = "set"` to replace
-#'   it. To clear it, use `action = "remove"` with the same value, `NA`, or `""`.
+#'   workflow. Accepts RFC 3339
+#'   timestamp strings (e.g., `"2006-12-02T02:07:43Z"`), local-date strings
+#'   (e.g., `"2006-12-02"`) or `Date` objects, and `POSIXt` objects. Local dates
+#'   use your system's configured time zone; `POSIXt` values are converted to
+#'   UTC. Once
+#'   `exclude_newer` is set, `action = "add"` cannot change it. Use
+#'   `action = "set"` to replace it. To clear it, use `action = "remove"` with
+#'   the same value, `NA`, or `""`.
 #'
 #' @returns `py_require()` is primarily called for its side effect of modifying
 #'   the manifest of "Python requirements" for the current R session  that
@@ -198,6 +201,7 @@ py_require <- function(packages = NULL,
   if (exclude_newer_supplied) {
     if (length(exclude_newer) != 1L)
       stop("`exclude_newer` must be a single value")
+    exclude_newer <- format_exclude_newer(exclude_newer)
     if (is.na(exclude_newer) || identical(exclude_newer, ""))
       exclude_newer <- NULL
   }

--- a/R/py_require.R
+++ b/R/py_require.R
@@ -189,10 +189,9 @@ py_require <- function(packages = NULL,
   }
 
   if (!is.null(python_version)) {
-    python_version <- trimws(unlist(
-      strsplit(python_version, ",", fixed = TRUE),
-      use.names = FALSE
-    ))
+    python_version <- trimws(unname(unlist(
+      strsplit(python_version, ",", fixed = TRUE)
+    )))
   }
 
   exclude_newer_supplied <- !is.null(exclude_newer)

--- a/R/uv.R
+++ b/R/uv.R
@@ -175,6 +175,9 @@ uv_install_managed <- function(uv, installer) {
 
 
 format_exclude_newer <- function(x) {
+  if (is.null(x))
+    return()
+
   if (inherits(x, "Date"))
     return(format(x, "%Y-%m-%d"))
 

--- a/R/uv.R
+++ b/R/uv.R
@@ -314,9 +314,8 @@ builtin_module_names <- c('abc', 'aifc', 'antigravity', 'argparse', 'ast', 'asyn
 #'   versions, helping guard against Python package updates that break a
 #'   workflow. Accepts RFC 3339
 #'   timestamp strings (e.g., `"2006-12-02T02:07:43Z"`), local-date strings
-#'   (e.g., `"2006-12-02"`) or `Date` objects, and `POSIXt` objects. Local dates
-#'   use your system's configured time zone; `POSIXt` values are converted to
-#'   UTC at whole-second precision.
+#'   (e.g., `"2006-12-02"`), `Date` objects, and `POSIXt` objects. Local dates
+#'   use your system's configured time zone.
 #' @inheritDotParams base::system2 -command
 #'
 #' @details

--- a/R/uv.R
+++ b/R/uv.R
@@ -173,10 +173,40 @@ uv_install_managed <- function(uv, installer) {
   stop(paste(c(msg, details), collapse = "\n"), call. = FALSE)
 }
 
+
+format_exclude_newer <- function(x) {
+  if (inherits(x, "Date"))
+    return(format(x, "%Y-%m-%d"))
+
+  if (!inherits(x, "POSIXt"))
+    return(x)
+
+  time <- as.numeric(as.POSIXct(x))
+  seconds <- floor(time)
+  microseconds <- as.integer(round((time - seconds) * 1e6))
+  carry <- !is.na(microseconds) & microseconds == 1e6L
+  seconds[carry] <- seconds[carry] + 1
+  microseconds[carry] <- 0L
+
+  timestamp <- format(
+    as.POSIXct(seconds, origin = "1970-01-01", tz = "UTC"),
+    "%Y-%m-%dT%H:%M:%S",
+    tz = "UTC"
+  )
+  fraction <- sub("0+$", "", sprintf(".%06d", microseconds))
+  fraction[!is.na(microseconds) & microseconds == 0L] <- ""
+
+  out <- paste0(timestamp, fraction, "Z")
+  out[is.na(time)] <- NA_character_
+  out
+}
+
+
 uv_get_or_create_env <- function(packages = py_reqs_get()$packages,
                                  python_version = py_reqs_python_version(),
                                  exclude_newer = py_reqs_get()$exclude_newer) {
 
+  exclude_newer <- format_exclude_newer(exclude_newer)
   uv <- uv_binary() %||% return()
 
   resolved_python_version <-
@@ -291,12 +321,14 @@ builtin_module_names <- c('abc', 'aifc', 'antigravity', 'argparse', 'ast', 'asyn
 #'   specify version constraints like `"ruff>=0.3.0"`.
 #' @param python_version A Python version string, or character vector of Python
 #'   version constraints.
-#' @param exclude_newer String. Limit package versions to those published before
-#'   a specified date. This offers a lightweight alternative to freezing package
+#' @param exclude_newer Limit package versions to those published before a
+#'   specified date. This offers a lightweight alternative to freezing package
 #'   versions, helping guard against Python package updates that break a
-#'   workflow. Accepts strings formatted as RFC 3339 timestamps (e.g.,
-#'   `"2006-12-02T02:07:43Z"`) and local dates in the same format (e.g.,
-#'   `"2006-12-02"`) in your system's configured time zone.
+#'   workflow. Accepts RFC 3339
+#'   timestamp strings (e.g., `"2006-12-02T02:07:43Z"`), local-date strings
+#'   (e.g., `"2006-12-02"`) or `Date` objects, and `POSIXt` objects. Local dates
+#'   use your system's configured time zone; `POSIXt` values are converted to
+#'   UTC.
 #' @inheritDotParams base::system2 -command
 #'
 #' @details
@@ -323,6 +355,7 @@ uv_run_tool <- function(tool,
                         with = NULL,
                         python_version = NULL,
                         exclude_newer = NULL) {
+  exclude_newer <- format_exclude_newer(exclude_newer)
   uv <- uv_binary()
 
   key <- python_version %||% "default"

--- a/R/uv.R
+++ b/R/uv.R
@@ -181,24 +181,12 @@ format_exclude_newer <- function(x) {
   if (!inherits(x, "POSIXt"))
     return(x)
 
-  time <- as.numeric(as.POSIXct(x))
-  seconds <- floor(time)
-  microseconds <- as.integer(round((time - seconds) * 1e6))
-  carry <- !is.na(microseconds) & microseconds == 1e6L
-  seconds[carry] <- seconds[carry] + 1
-  microseconds[carry] <- 0L
-
-  timestamp <- format(
-    as.POSIXct(seconds, origin = "1970-01-01", tz = "UTC"),
-    "%Y-%m-%dT%H:%M:%S",
+  # Convert POSIXlt to an instant before changing its time zone.
+  strftime(
+    as.POSIXct(x),
+    "%Y-%m-%dT%H:%M:%SZ",
     tz = "UTC"
   )
-  fraction <- sub("0+$", "", sprintf(".%06d", microseconds))
-  fraction[!is.na(microseconds) & microseconds == 0L] <- ""
-
-  out <- paste0(timestamp, fraction, "Z")
-  out[is.na(time)] <- NA_character_
-  out
 }
 
 
@@ -328,7 +316,7 @@ builtin_module_names <- c('abc', 'aifc', 'antigravity', 'argparse', 'ast', 'asyn
 #'   timestamp strings (e.g., `"2006-12-02T02:07:43Z"`), local-date strings
 #'   (e.g., `"2006-12-02"`) or `Date` objects, and `POSIXt` objects. Local dates
 #'   use your system's configured time zone; `POSIXt` values are converted to
-#'   UTC.
+#'   UTC at whole-second precision.
 #' @inheritDotParams base::system2 -command
 #'
 #' @details

--- a/man/py_require.Rd
+++ b/man/py_require.Rd
@@ -30,7 +30,7 @@ workflow. Accepts RFC 3339
 timestamp strings (e.g., \code{"2006-12-02T02:07:43Z"}), local-date strings
 (e.g., \code{"2006-12-02"}) or \code{Date} objects, and \code{POSIXt} objects. Local dates
 use your system's configured time zone; \code{POSIXt} values are converted to
-UTC. Once
+UTC at whole-second precision. Once
 \code{exclude_newer} is set, \code{action = "add"} cannot change it. Use
 \code{action = "set"} to replace it. To clear it, use \code{action = "remove"} with
 the same value, \code{NA}, or \code{""}.}

--- a/man/py_require.Rd
+++ b/man/py_require.Rd
@@ -28,9 +28,8 @@ specified date. This offers a lightweight alternative to freezing package
 versions, helping guard against Python package updates that break a
 workflow. Accepts RFC 3339
 timestamp strings (e.g., \code{"2006-12-02T02:07:43Z"}), local-date strings
-(e.g., \code{"2006-12-02"}) or \code{Date} objects, and \code{POSIXt} objects. Local dates
-use your system's configured time zone; \code{POSIXt} values are converted to
-UTC at whole-second precision. Once
+(e.g., \code{"2006-12-02"}), \code{Date} objects, and \code{POSIXt} objects. Local dates
+use your system's configured time zone. Once
 \code{exclude_newer} is set, \code{action = "add"} cannot change it. Use
 \code{action = "set"} to replace it. To clear it, use \code{action = "remove"} with
 the same value, \code{NA}, or \code{""}.}

--- a/man/py_require.Rd
+++ b/man/py_require.Rd
@@ -26,11 +26,14 @@ from local files or a git repository is also supported (see details).}
 \item{exclude_newer}{Limit package versions to those published before a
 specified date. This offers a lightweight alternative to freezing package
 versions, helping guard against Python package updates that break a
-workflow. Accepts strings formatted as RFC 3339 timestamps (e.g.,
-\code{"2006-12-02T02:07:43Z"}) and local dates in the same format (e.g.,
-\code{"2006-12-02"}) in your system's configured time zone. Once \code{exclude_newer}
-is set, \code{action = "add"} cannot change it. Use \code{action = "set"} to replace
-it. To clear it, use \code{action = "remove"} with the same value, \code{NA}, or \code{""}.}
+workflow. Accepts RFC 3339
+timestamp strings (e.g., \code{"2006-12-02T02:07:43Z"}), local-date strings
+(e.g., \code{"2006-12-02"}) or \code{Date} objects, and \code{POSIXt} objects. Local dates
+use your system's configured time zone; \code{POSIXt} values are converted to
+UTC. Once
+\code{exclude_newer} is set, \code{action = "add"} cannot change it. Use
+\code{action = "set"} to replace it. To clear it, use \code{action = "remove"} with
+the same value, \code{NA}, or \code{""}.}
 
 \item{action}{Determines how \code{py_require()} processes the provided
 requirements. Options are:

--- a/man/uv_run_tool.Rd
+++ b/man/uv_run_tool.Rd
@@ -60,12 +60,14 @@ specify version constraints like \code{"ruff>=0.3.0"}.}
 \item{python_version}{A Python version string, or character vector of Python
 version constraints.}
 
-\item{exclude_newer}{String. Limit package versions to those published before
-a specified date. This offers a lightweight alternative to freezing package
+\item{exclude_newer}{Limit package versions to those published before a
+specified date. This offers a lightweight alternative to freezing package
 versions, helping guard against Python package updates that break a
-workflow. Accepts strings formatted as RFC 3339 timestamps (e.g.,
-\code{"2006-12-02T02:07:43Z"}) and local dates in the same format (e.g.,
-\code{"2006-12-02"}) in your system's configured time zone.}
+workflow. Accepts RFC 3339
+timestamp strings (e.g., \code{"2006-12-02T02:07:43Z"}), local-date strings
+(e.g., \code{"2006-12-02"}) or \code{Date} objects, and \code{POSIXt} objects. Local dates
+use your system's configured time zone; \code{POSIXt} values are converted to
+UTC.}
 }
 \value{
 Return value of \code{\link[=system2]{system2()}}

--- a/man/uv_run_tool.Rd
+++ b/man/uv_run_tool.Rd
@@ -67,7 +67,7 @@ workflow. Accepts RFC 3339
 timestamp strings (e.g., \code{"2006-12-02T02:07:43Z"}), local-date strings
 (e.g., \code{"2006-12-02"}) or \code{Date} objects, and \code{POSIXt} objects. Local dates
 use your system's configured time zone; \code{POSIXt} values are converted to
-UTC.}
+UTC at whole-second precision.}
 }
 \value{
 Return value of \code{\link[=system2]{system2()}}

--- a/man/uv_run_tool.Rd
+++ b/man/uv_run_tool.Rd
@@ -65,9 +65,8 @@ specified date. This offers a lightweight alternative to freezing package
 versions, helping guard against Python package updates that break a
 workflow. Accepts RFC 3339
 timestamp strings (e.g., \code{"2006-12-02T02:07:43Z"}), local-date strings
-(e.g., \code{"2006-12-02"}) or \code{Date} objects, and \code{POSIXt} objects. Local dates
-use your system's configured time zone; \code{POSIXt} values are converted to
-UTC at whole-second precision.}
+(e.g., \code{"2006-12-02"}), \code{Date} objects, and \code{POSIXt} objects. Local dates
+use your system's configured time zone.}
 }
 \value{
 Return value of \code{\link[=system2]{system2()}}

--- a/tests/testthat/test-exclude-newer.R
+++ b/tests/testthat/test-exclude-newer.R
@@ -1,0 +1,91 @@
+test_that("py_require() accepts R date and date-time cutoffs", {
+  session <- r_session(echo = FALSE, {
+    library(reticulate)
+
+    py_require(exclude_newer = as.Date("2006-12-02"))
+    stopifnot(identical(py_require()$exclude_newer, "2006-12-02"))
+
+    datetime <- as.POSIXct(
+      "2006-12-02 02:07:43",
+      tz = "America/New_York"
+    ) + 0.125
+    for (cutoff in list(datetime, as.POSIXlt(datetime))) {
+      py_require(exclude_newer = cutoff, action = "set")
+      stopifnot(identical(
+        py_require()$exclude_newer,
+        "2006-12-02T07:07:43.125Z"
+      ))
+    }
+  })
+
+  expect_null(attr(session, "status", exact = TRUE), info = paste(session, collapse = "\n"))
+})
+
+
+test_that("uv_run_tool() accepts R date and date-time cutoffs", {
+  datetime <- as.POSIXct(
+    "2006-12-02 02:07:43",
+    tz = "America/New_York"
+  ) + 0.125
+  cutoffs <- list(
+    as.Date("2006-12-02"),
+    datetime,
+    as.POSIXlt(datetime),
+    as.POSIXct("2006-12-02 02:07:59", tz = "UTC") + 0.9999996
+  )
+  args <- list()
+  testthat::with_mocked_bindings(
+    for (cutoff in cutoffs) {
+      uv_run_tool(
+        "example",
+        python_version = "exclude-newer-test",
+        exclude_newer = cutoff
+      )
+    },
+    uv_binary = function(...) "uv",
+    resolve_python_version = function(...) "3.11",
+    uv_exec = function(command, ...) {
+      args[[length(args) + 1L]] <<- command
+      0L
+    },
+    .package = "reticulate"
+  )
+
+  exclude_newer <- vapply(args, function(x) {
+    x[[match("--exclude-newer", x) + 1L]]
+  }, character(1))
+  expect_identical(
+    exclude_newer,
+    c(
+      "2006-12-02",
+      rep("2006-12-02T07:07:43.125Z", 2L),
+      "2006-12-02T02:08:00Z"
+    )
+  )
+})
+
+
+test_that("uv_get_or_create_env() accepts R date cutoffs", {
+  args <- NULL
+  testthat::with_mocked_bindings(
+    reticulate:::uv_get_or_create_env(
+      packages = NULL,
+      python_version = "3.11",
+      exclude_newer = as.Date("2006-12-02")
+    ),
+    uv_binary = function(...) "uv",
+    resolve_python_version = function(...) "3.11",
+    maybe_shQuote = identity,
+    uv_exec = function(command, ...) {
+      args <<- command
+      writeLines("/tmp/python", command[[length(command)]])
+      0L
+    },
+    .package = "reticulate"
+  )
+
+  expect_identical(
+    args[[match("--exclude-newer", args) + 1L]],
+    "2006-12-02"
+  )
+})

--- a/tests/testthat/test-exclude-newer.R
+++ b/tests/testthat/test-exclude-newer.R
@@ -13,7 +13,7 @@ test_that("py_require() accepts R date and date-time cutoffs", {
       py_require(exclude_newer = cutoff, action = "set")
       stopifnot(identical(
         py_require()$exclude_newer,
-        "2006-12-02T07:07:43.125Z"
+        "2006-12-02T07:07:43Z"
       ))
     }
   })
@@ -30,8 +30,7 @@ test_that("uv_run_tool() accepts R date and date-time cutoffs", {
   cutoffs <- list(
     as.Date("2006-12-02"),
     datetime,
-    as.POSIXlt(datetime),
-    as.POSIXct("2006-12-02 02:07:59", tz = "UTC") + 0.9999996
+    as.POSIXlt(datetime)
   )
   args <- list()
   testthat::with_mocked_bindings(
@@ -58,8 +57,7 @@ test_that("uv_run_tool() accepts R date and date-time cutoffs", {
     exclude_newer,
     c(
       "2006-12-02",
-      rep("2006-12-02T07:07:43.125Z", 2L),
-      "2006-12-02T02:08:00Z"
+      rep("2006-12-02T07:07:43Z", 2L)
     )
   )
 })


### PR DESCRIPTION
## Summary

Allow `exclude_newer` to accept R date and date-time objects directly, so callers do not need to convert them into uv-compatible strings first.

## User-facing changes

- `py_require()` and `uv_run_tool()` now accept `Date`, `POSIXct`, and `POSIXlt` values for `exclude_newer`.
- Character inputs keep their existing behavior.
- Direct callers of `uv_get_or_create_env()` can use the same input types.

## Internal changes

- Centralizes `exclude_newer` formatting so manifests, diagnostics, and uv arguments use the same canonical representation.
- Simplifies Python version constraint normalization by using `unname(unlist(...))` to make the intent explicit.
