### PR TITLE
Preserve explicit integer row names in pandas conversion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # reticulate (development version)
 
+- `r_to_py()` now preserves explicit integer row names as the index when
+  converting an R data frame to a pandas data frame (#1924).
+
 - The `exclude_newer` arguments to `py_require()` and `uv_run_tool()` now
   accept `Date` and `POSIXt` objects.
 

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -280,7 +280,9 @@ r_to_py.data.frame <- function(x, convert = FALSE) {
 
   # copy over row names if they exist
   rni <- .row_names_info(x, type = 0L)
-  if (is.character(rni)) {
+  if (.row_names_info(x, type = 1L) > 0L) {
+    if (length(rni) == 2L && is.na(rni[[1L]]))
+      rni <- seq_len(rni[[2L]])
     if (length(rni) == 1)
       rni <- as.list(rni)
     pdf$index <- rni

--- a/tests/testthat/test-python-pandas.R
+++ b/tests/testthat/test-python-pandas.R
@@ -148,6 +148,21 @@ test_that("single-row data.frames with rownames can be converted", {
 
 })
 
+test_that("explicit integer row names become the pandas index, #1924", {
+  skip_if_no_pandas()
+
+  for (row_names in list(c(1L, 2L, 4L), 1:3, 4L)) {
+    df <- data.frame(x = seq_along(row_names))
+    attr(df, "row.names") <- row_names
+
+    index <- r_to_py(df)$index$tolist()
+    expect_identical(py_to_r(index), row_names)
+  }
+
+  index <- r_to_py(data.frame(x = 1:3))$index$tolist()
+  expect_identical(py_to_r(index), 0:2)
+})
+
 test_that("Time zones are respected if available", {
   skip_if_no_pandas()
 


### PR DESCRIPTION
Closes #1924.

`r_to_py.data.frame()` previously copied row names only when their internal representation was character. Explicit integer row names were skipped, causing pandas to replace them with a default `RangeIndex`.

This change uses R's row-name metadata to distinguish explicit row names from automatic ones. It expands compact integer row-name sequences before assigning the pandas index, while automatic R row names continue to use pandas' default zero-based index.

Tests cover gapped, sequential, and single integer row names.

## Testing

- `devtools::test(filter = "python-pandas")`
- `devtools::test()`